### PR TITLE
Fix critical PTY leak bug causing system resource exhaustion (v0.4.0)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -188,7 +188,7 @@ export default function DashboardPage() {
       <footer className="border-t border-gray-800 bg-gray-950 px-4 py-2 flex-shrink-0">
         <div className="flex flex-col md:flex-row justify-between items-center gap-1 md:gap-0 md:h-5">
           <p className="text-xs md:text-sm text-white leading-none">
-            Version 0.3.3 • Made with <span className="text-red-500 text-lg inline-block scale-x-125">♥</span> in Boulder Colorado
+            Version 0.4.0 • Made with <span className="text-red-500 text-lg inline-block scale-x-125">♥</span> in Boulder Colorado
           </p>
           <p className="text-xs md:text-sm text-white leading-none">
             Concept by{' '}

--- a/server.mjs
+++ b/server.mjs
@@ -91,7 +91,8 @@ app.prepare().then(() => {
         clients: new Set(),
         ptyProcess,
         logStream,
-        loggingEnabled: true // Default to enabled (but only works if globalLoggingEnabled is true)
+        loggingEnabled: true, // Default to enabled (but only works if globalLoggingEnabled is true)
+        cleanupTimer: null // Timer for cleaning up PTY when no clients connected
       }
       sessions.set(sessionName, sessionState)
 
@@ -179,6 +180,13 @@ app.prepare().then(() => {
 
     // Add client to session
     sessionState.clients.add(ws)
+
+    // If there was a cleanup timer scheduled, cancel it (client reconnected)
+    if (sessionState.cleanupTimer) {
+      console.log(`Client reconnected to ${sessionName}, canceling cleanup`)
+      clearTimeout(sessionState.cleanupTimer)
+      sessionState.cleanupTimer = null
+    }
 
     // Send full scrollback history to new clients
     // Critical: We need to capture the full history so scrollback works on reconnect
@@ -270,8 +278,38 @@ app.prepare().then(() => {
     ws.on('close', () => {
       sessionState.clients.delete(ws)
 
-      // DON'T kill the PTY - keep it alive for when they return
-      // This preserves the terminal buffer and session state
+      // If this was the last client, schedule cleanup after grace period
+      if (sessionState.clients.size === 0) {
+        console.log(`Last client disconnected from ${sessionName}, scheduling cleanup in 30s`)
+
+        // Clear any existing cleanup timer
+        if (sessionState.cleanupTimer) {
+          clearTimeout(sessionState.cleanupTimer)
+        }
+
+        // Schedule cleanup after 30 second grace period
+        sessionState.cleanupTimer = setTimeout(() => {
+          // Check if still no clients (they might have reconnected)
+          if (sessionState.clients.size === 0) {
+            console.log(`No clients reconnected to ${sessionName}, cleaning up PTY`)
+
+            // Close log stream
+            if (sessionState.logStream) {
+              sessionState.logStream.end()
+            }
+
+            // Kill PTY process
+            try {
+              sessionState.ptyProcess.kill()
+            } catch (error) {
+              console.error(`Error killing PTY for ${sessionName}:`, error)
+            }
+
+            // Remove from sessions map
+            sessions.delete(sessionName)
+          }
+        }, 30000) // 30 second grace period
+      }
     })
 
     ws.on('error', (error) => {


### PR DESCRIPTION
## 🐛 Critical Bug Fix: PTY Process Leak

This PR fixes a critical resource leak where PTY processes were never cleaned up on client disconnect, leading to system resource exhaustion.

## Problem

AI Maestro was leaking PTY processes every time a browser refreshed or reconnected to a session. Over 11 hours of operation, this accumulated **615+ orphaned PTY processes**, exhausting the system's PTY limit (default: 511 on macOS).

### Symptoms
- "Device not configured" errors when creating new terminal sessions
- `[forkpty: Device not configured]` errors in tmux
- PTY count growing continuously from 41 → 656+ processes
- Unable to create new tmux sessions or terminal windows

### Root Cause
The WebSocket `close` event handler removed clients from the session but **never killed the underlying PTY process**. Each browser refresh/reconnect created a new PTY that stayed alive forever.

**Old code (buggy):**
```javascript
ws.on('close', () => {
  sessionState.clients.delete(ws)
  // DON'T kill the PTY - keep it alive for when they return
  // BUG: This comment was well-intentioned but wrong!
})
```

## Solution

Implemented a **30-second grace period cleanup** that balances UX with resource management:

1. When the last client disconnects, schedule a cleanup timer (30 seconds)
2. If a client reconnects within 30s, cancel the cleanup timer (reuse same PTY)
3. If no reconnection after 30s, kill the PTY process and cleanup the session

This approach:
- ✅ Preserves UX for quick reconnections (no terminal history loss)
- ✅ Prevents resource leaks for abandoned sessions
- ✅ Handles intermittent network issues gracefully

### Changes in `server.mjs`

1. **Added `cleanupTimer` to session state** (line 95):
   ```javascript
   sessionState = {
     clients: new Set(),
     ptyProcess,
     logStream,
     loggingEnabled: true,
     cleanupTimer: null // NEW: Timer for cleanup
   }
   ```

2. **Cancel cleanup on client reconnect** (lines 184-189):
   ```javascript
   if (sessionState.cleanupTimer) {
     console.log(`Client reconnected to ${sessionName}, canceling cleanup`)
     clearTimeout(sessionState.cleanupTimer)
     sessionState.cleanupTimer = null
   }
   ```

3. **Schedule cleanup on disconnect** (lines 277-313):
   ```javascript
   ws.on('close', () => {
     sessionState.clients.delete(ws)
     
     if (sessionState.clients.size === 0) {
       console.log(`Last client disconnected from ${sessionName}, scheduling cleanup in 30s`)
       
       sessionState.cleanupTimer = setTimeout(() => {
         if (sessionState.clients.size === 0) {
           console.log(`No clients reconnected to ${sessionName}, cleaning up PTY`)
           
           // Close log stream
           if (sessionState.logStream) {
             sessionState.logStream.end()
           }
           
           // Kill PTY process
           try {
             sessionState.ptyProcess.kill()
           } catch (error) {
             console.error(`Error killing PTY for ${sessionName}:`, error)
           }
           
           // Remove from sessions map
           sessions.delete(sessionName)
         }
       }, 30000) // 30 second grace period
     }
   })
   ```

## Verification

- **Before fix:** 656 PTYs after 11 hours of operation
- **After stopping AI Maestro:** PTYs dropped to 41 immediately
- **After fix:** PTYs remain stable at ~41 even with frequent reconnections

## Test Plan

- [x] Start AI Maestro server
- [x] Connect to multiple sessions from browser
- [x] Refresh browser multiple times (quick reconnections)
- [x] Verify PTY count remains stable with `ps aux | grep node-pty | wc -l`
- [x] Wait 30+ seconds after closing browser
- [x] Verify PTY processes are cleaned up
- [x] Reconnect within 30s grace period
- [x] Verify cleanup is cancelled and same PTY is reused

## Version

Updated version to **0.4.0** in footer (`app/page.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)