### PR TITLE
chore: Update version to 0.8.0 in documentation

### DIFF
--- a/docs/NETWORK-ACCESS.md
+++ b/docs/NETWORK-ACCESS.md
@@ -510,4 +510,4 @@ ping mac-mini.local
 ---
 
 **Last Updated:** 2025-11-05
-**AI Maestro Version:** 0.7.1
+**AI Maestro Version:** 0.8.0

--- a/docs/REMOTE-SESSIONS-ARCHITECTURE.md
+++ b/docs/REMOTE-SESSIONS-ARCHITECTURE.md
@@ -817,5 +817,5 @@ The Manager/Worker pattern is the **recommended approach** for remote sessions b
 ---
 
 **Last Updated:** 2025-11-05
-**AI Maestro Version:** 0.7.1
+**AI Maestro Version:** 0.8.0
 **Status:** Design Document - Implementation Pending

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. Zero-configuration terminal multiplexer for autonomous AI agents.",
-      "softwareVersion": "0.5.0",
+      "softwareVersion": "0.8.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -343,7 +343,7 @@
                     <a href="#quick-start" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg no-underline font-semibold transition-all duration-200 bg-white text-primary border-2 border-primary hover:bg-primary hover:text-white text-lg">Learn More</a>
                 </div>
                 <div class="flex flex-wrap gap-2 justify-center">
-                    <img src="https://img.shields.io/badge/version-0.5.0-blue" alt="Version">
+                    <img src="https://img.shields.io/badge/version-0.8.0-blue" alt="Version">
                     <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)%20%7C%20Linux-lightgrey" alt="Platform">
                     <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
                 </div>


### PR DESCRIPTION
## Summary
Updates version numbers in documentation files to match v0.8.0 release.

## Changes
- **docs/index.html**: Updated version badge and schema.org metadata from 0.5.0 to 0.8.0
- **docs/REMOTE-SESSIONS-ARCHITECTURE.md**: Updated version footer to 0.8.0
- **docs/NETWORK-ACCESS.md**: Updated version footer to 0.8.0

## Context
This PR contains the version documentation updates that were made after PR #20 was merged. These updates ensure all documentation reflects the current v0.8.0 release.

## Related
- Part of v0.8.0 release
- Follows PR #20 (onboarding flow implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>