### PR TITLE
feat: Add hibernate/wake functionality for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ secrets/
 # But allow .env.example files
 !agent-container/.env.example
 
+# Business planning (internal strategy, not open source)
+business_plan/
+
 # Terraform
 *.tfstate
 *.tfstate.*

--- a/app/api/agents/[id]/hibernate/route.ts
+++ b/app/api/agents/[id]/hibernate/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import { getAgent, updateAgent, loadAgents, saveAgents } from '@/lib/agent-registry'
+import { unpersistSession } from '@/lib/session-persistence'
+
+const execAsync = promisify(exec)
+
+/**
+ * Check if a tmux session exists
+ */
+async function tmuxSessionExists(sessionName: string): Promise<boolean> {
+  try {
+    await execAsync(`tmux has-session -t "${sessionName}" 2>/dev/null`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * POST /api/agents/[id]/hibernate
+ *
+ * Hibernate an agent by:
+ * 1. Gracefully stopping Claude Code (send Ctrl+C, then exit)
+ * 2. Killing the tmux session
+ * 3. Updating agent status to 'offline' and session status to 'stopped'
+ *
+ * The agent's configuration (working directory, etc.) is preserved so it can be woken up later.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+
+    // Get the agent
+    const agent = getAgent(id)
+    if (!agent) {
+      return NextResponse.json(
+        { error: 'Agent not found' },
+        { status: 404 }
+      )
+    }
+
+    const sessionName = agent.tools.session?.tmuxSessionName
+    if (!sessionName) {
+      return NextResponse.json(
+        { error: 'Agent has no linked session to hibernate' },
+        { status: 400 }
+      )
+    }
+
+    // Check if session exists
+    const exists = await tmuxSessionExists(sessionName)
+    if (!exists) {
+      // Session doesn't exist, just update the status
+      const agents = loadAgents()
+      const index = agents.findIndex(a => a.id === id)
+      if (index !== -1) {
+        if (agents[index].tools.session) {
+          agents[index].tools.session.status = 'stopped'
+        }
+        agents[index].status = 'offline'
+        agents[index].lastActive = new Date().toISOString()
+        saveAgents(agents)
+      }
+
+      return NextResponse.json({
+        success: true,
+        agentId: id,
+        sessionName,
+        hibernated: true,
+        message: 'Session was already terminated, agent status updated'
+      })
+    }
+
+    // Try to gracefully stop Claude Code first
+    try {
+      // Send Ctrl+C to interrupt any running command
+      await execAsync(`tmux send-keys -t "${sessionName}" C-c`)
+      await new Promise(resolve => setTimeout(resolve, 500))
+
+      // Send 'exit' to close Claude Code gracefully
+      await execAsync(`tmux send-keys -t "${sessionName}" "exit" Enter`)
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    } catch (e) {
+      // Ignore errors in graceful shutdown, we'll force kill anyway
+      console.log(`[Hibernate] Graceful shutdown attempt failed for ${sessionName}, will force kill`)
+    }
+
+    // Kill the tmux session
+    try {
+      await execAsync(`tmux kill-session -t "${sessionName}"`)
+    } catch (e) {
+      // Session might have already closed from the exit command
+      console.log(`[Hibernate] Session ${sessionName} may have already closed`)
+    }
+
+    // Remove from session persistence
+    unpersistSession(sessionName)
+
+    // Update agent status in registry
+    const agents = loadAgents()
+    const index = agents.findIndex(a => a.id === id)
+    if (index !== -1) {
+      if (agents[index].tools.session) {
+        agents[index].tools.session.status = 'stopped'
+        agents[index].tools.session.lastActive = new Date().toISOString()
+      }
+      agents[index].status = 'offline'
+      agents[index].lastActive = new Date().toISOString()
+      saveAgents(agents)
+    }
+
+    console.log(`[Hibernate] Agent ${agent.alias} (${id}) hibernated successfully`)
+
+    return NextResponse.json({
+      success: true,
+      agentId: id,
+      alias: agent.alias,
+      sessionName,
+      hibernated: true,
+      message: `Agent "${agent.alias}" has been hibernated. Use wake to restart.`
+    })
+
+  } catch (error) {
+    console.error('[Hibernate] Error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to hibernate agent' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/agents/[id]/wake/route.ts
+++ b/app/api/agents/[id]/wake/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import { getAgent, loadAgents, saveAgents } from '@/lib/agent-registry'
+import { persistSession } from '@/lib/session-persistence'
+
+const execAsync = promisify(exec)
+
+/**
+ * Check if a tmux session exists
+ */
+async function tmuxSessionExists(sessionName: string): Promise<boolean> {
+  try {
+    await execAsync(`tmux has-session -t "${sessionName}" 2>/dev/null`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * POST /api/agents/[id]/wake
+ *
+ * Wake a hibernated agent by:
+ * 1. Creating a new tmux session with the stored working directory
+ * 2. Starting Claude Code (or configured program) in the session
+ * 3. Updating agent status to 'active' and session status to 'running'
+ *
+ * Optional body parameters:
+ * - startProgram: boolean - Whether to start Claude Code automatically (default: true)
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+
+    // Parse optional body
+    let startProgram = true
+    try {
+      const body = await request.json()
+      if (body.startProgram === false) {
+        startProgram = false
+      }
+    } catch {
+      // No body or invalid JSON, use defaults
+    }
+
+    // Get the agent
+    const agent = getAgent(id)
+    if (!agent) {
+      return NextResponse.json(
+        { error: 'Agent not found' },
+        { status: 404 }
+      )
+    }
+
+    // Get session configuration
+    const sessionConfig = agent.tools.session
+    if (!sessionConfig) {
+      return NextResponse.json(
+        { error: 'Agent has no session configuration. Create a session first.' },
+        { status: 400 }
+      )
+    }
+
+    const sessionName = sessionConfig.tmuxSessionName
+    const workingDirectory = sessionConfig.workingDirectory ||
+                            agent.preferences?.defaultWorkingDirectory ||
+                            process.cwd()
+
+    // Check if session already exists
+    const exists = await tmuxSessionExists(sessionName)
+    if (exists) {
+      // Session already running, just update status
+      const agents = loadAgents()
+      const index = agents.findIndex(a => a.id === id)
+      if (index !== -1) {
+        if (agents[index].tools.session) {
+          agents[index].tools.session.status = 'running'
+        }
+        agents[index].status = 'active'
+        agents[index].lastActive = new Date().toISOString()
+        saveAgents(agents)
+      }
+
+      return NextResponse.json({
+        success: true,
+        agentId: id,
+        alias: agent.alias,
+        sessionName,
+        woken: true,
+        alreadyRunning: true,
+        message: `Agent "${agent.alias}" session was already running`
+      })
+    }
+
+    // Create new tmux session
+    try {
+      await execAsync(`tmux new-session -d -s "${sessionName}" -c "${workingDirectory}"`)
+    } catch (error) {
+      console.error(`[Wake] Failed to create tmux session:`, error)
+      return NextResponse.json(
+        { error: 'Failed to create tmux session' },
+        { status: 500 }
+      )
+    }
+
+    // Persist session metadata
+    persistSession({
+      id: sessionName,
+      name: sessionName,
+      workingDirectory,
+      createdAt: new Date().toISOString(),
+      agentId: id
+    })
+
+    // Start the AI program if requested
+    if (startProgram) {
+      // Determine which program to start based on agent.program
+      const program = agent.program?.toLowerCase() || 'claude code'
+
+      let startCommand = ''
+      if (program.includes('claude') || program.includes('claude code')) {
+        startCommand = 'claude'
+      } else if (program.includes('aider')) {
+        startCommand = 'aider'
+      } else if (program.includes('cursor')) {
+        startCommand = 'cursor'
+      } else {
+        // Default to claude for unknown programs
+        startCommand = 'claude'
+      }
+
+      // Small delay to let the session initialize
+      await new Promise(resolve => setTimeout(resolve, 300))
+
+      // Send the command to start the program
+      try {
+        await execAsync(`tmux send-keys -t "${sessionName}" "${startCommand}" Enter`)
+      } catch (error) {
+        console.error(`[Wake] Failed to start program:`, error)
+        // Don't fail the whole operation, session is still created
+      }
+    }
+
+    // Update agent status in registry
+    const agents = loadAgents()
+    const index = agents.findIndex(a => a.id === id)
+    if (index !== -1) {
+      if (agents[index].tools.session) {
+        agents[index].tools.session.status = 'running'
+        agents[index].tools.session.lastActive = new Date().toISOString()
+      }
+      agents[index].status = 'active'
+      agents[index].lastActive = new Date().toISOString()
+      saveAgents(agents)
+    }
+
+    console.log(`[Wake] Agent ${agent.alias} (${id}) woken up successfully`)
+
+    return NextResponse.json({
+      success: true,
+      agentId: id,
+      alias: agent.alias,
+      sessionName,
+      workingDirectory,
+      woken: true,
+      programStarted: startProgram,
+      message: `Agent "${agent.alias}" has been woken up and is ready to use.`
+    })
+
+  } catch (error) {
+    console.error('[Wake] Error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to wake agent' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add hibernate endpoint (`POST /api/agents/[id]/hibernate`) that gracefully stops an agent's tmux session while preserving state
- Add wake endpoint (`POST /api/agents/[id]/wake`) that restores a hibernated agent's tmux session
- Add UI controls (moon/sun icons) to hibernate/wake agents directly from the sidebar

## Test Plan
- [ ] Hibernate an active agent and verify tmux session closes
- [ ] Wake a hibernated agent and verify tmux session restores
- [ ] Verify working directory is preserved after hibernate/wake cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)