### PR TITLE
feat: Add Claude Code hooks to main installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -555,6 +555,7 @@ if [ -n "$INSTALL_DIR" ] && [ "$SKIP_TOOLS" != true ]; then
     echo "  🧠 Memory       - Search conversation history for context"
     echo "  🔗 Graph        - Query code relationships and dependencies"
     echo "  📚 Docs         - Search auto-generated documentation"
+    echo "  🪝 Hooks        - Claude Code integration for Chat interface"
     echo ""
     if command -v claude &> /dev/null; then
         echo "  Claude Code skills will be installed for natural language access."
@@ -595,6 +596,13 @@ if [ -n "$INSTALL_DIR" ] && [ "$SKIP_TOOLS" != true ]; then
             echo ""
             print_step "Installing doc tools..."
             ./install-doc-tools.sh
+        fi
+
+        # Install Claude Code hooks
+        if [ -f "scripts/claude-hooks/install-hooks.sh" ]; then
+            echo ""
+            print_step "Installing Claude Code hooks..."
+            ./scripts/claude-hooks/install-hooks.sh
         fi
 
         print_success "All agent tools installed"


### PR DESCRIPTION
## Summary
- Add Claude Code hooks installation to the main `install.sh` script
- Hooks are now installed alongside messaging, memory, graph, and doc tools in Step 4
- Enables Chat interface integration with Claude Code sessions

## Test plan
- [ ] Run `./install.sh` and verify hooks installation step appears
- [ ] Confirm hooks are installed to `~/.claude/settings.json`
- [ ] Verify Chat interface shows Claude status after hook installation

🤖 Generated with [Claude Code](https://claude.ai/code)