### PR TITLE
fix: Handle uninitialized database in getMemoryStats gracefully

### DIFF
--- a/lib/cozo-db.ts
+++ b/lib/cozo-db.ts
@@ -137,6 +137,13 @@ export class AgentDatabase {
   }
 
   /**
+   * Check if database is initialized
+   */
+  isInitialized(): boolean {
+    return this.db !== null
+  }
+
+  /**
    * Execute a CozoDB query (Datalog or special commands)
    * @param query - CozoDB query string
    * @returns Query result
@@ -208,6 +215,17 @@ export class AgentDatabase {
     oldestMessage: number | null
     newestMessage: number | null
   }> {
+    // Return defaults if database is not initialized (avoid log spam)
+    if (!this.isInitialized()) {
+      return {
+        totalMessages: 0,
+        totalConversations: 0,
+        totalVectors: 0,
+        oldestMessage: null,
+        newestMessage: null
+      }
+    }
+
     try {
       // Count total messages
       const msgCountResult = await this.run(`?[count(msg_id)] := *messages{msg_id}`)
@@ -233,9 +251,8 @@ export class AgentDatabase {
         oldestMessage,
         newestMessage
       }
-    } catch (error) {
-      // Tables might not exist yet
-      console.error(`[CozoDB] Failed to get memory stats:`, error)
+    } catch {
+      // Tables might not exist yet - return defaults silently
       return {
         totalMessages: 0,
         totalConversations: 0,


### PR DESCRIPTION
## Summary
- Add `isInitialized()` method to CozoDB class to check database state
- Return default values silently in `getMemoryStats()` when database not initialized
- Remove error logging for expected uninitialized state

## Problem
The `/api/agents/[id]/subconscious` endpoint was being polled by the frontend for agents whose CozoDB database wasn't initialized. This caused:
- Repeated `[CozoDB] Failed to get memory stats: Error: Database not initialized` errors
- Log spam that filled up disk space
- Process instability leading to 222+ PM2 restarts

## Solution
Check if database is initialized before running queries, and return defaults silently instead of throwing/logging errors.

## Test plan
- [x] Build passes
- [x] Service runs without error spam
- [x] Subconscious API returns valid response for uninitialized agents

🤖 Generated with [Claude Code](https://claude.ai/code)