### PR TITLE
feat: Real-time agent activity status (Waiting/Active/Idle)

### DIFF
--- a/app/api/sessions/activity/route.ts
+++ b/app/api/sessions/activity/route.ts
@@ -1,21 +1,111 @@
 import { NextResponse } from 'next/server'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as crypto from 'crypto'
+import * as os from 'os'
+import { loadAgents } from '@/lib/agent-registry'
+
+// Disable caching - this endpoint reads from global state that changes frequently
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 // This will be populated by server.mjs via global state
 declare global {
   var sessionActivity: Map<string, number> | undefined
 }
 
+// Hash working directory to find state file (same as in hook and chat route)
+function hashCwd(cwd: string): string {
+  return crypto.createHash('md5').update(cwd || '').digest('hex').substring(0, 16)
+}
+
+// Read hook state for a given working directory
+function getHookState(workingDir: string): { status: string; notificationType?: string } | null {
+  if (!workingDir) return null
+
+  const stateDir = path.join(os.homedir(), '.aimaestro', 'chat-state')
+  const cwdHash = hashCwd(workingDir)
+  const stateFile = path.join(stateDir, `${cwdHash}.json`)
+
+  try {
+    if (fs.existsSync(stateFile)) {
+      const content = fs.readFileSync(stateFile, 'utf-8')
+      const state = JSON.parse(content)
+
+      // Check if state is fresh enough (within 60 seconds for non-waiting states)
+      const isWaitingState = state.status === 'waiting_for_input' || state.status === 'permission_request'
+      if (!isWaitingState) {
+        const stateAge = Date.now() - new Date(state.updatedAt).getTime()
+        if (stateAge > 60000) {
+          return null
+        }
+      }
+
+      return {
+        status: state.status,
+        notificationType: state.notificationType
+      }
+    }
+  } catch (err) {
+    // Ignore errors reading state files
+  }
+
+  return null
+}
+
+export type SessionActivityStatus = 'active' | 'idle' | 'waiting'
+
+interface SessionActivityInfo {
+  lastActivity: string
+  status: SessionActivityStatus
+  hookStatus?: string
+  notificationType?: string
+}
+
 export async function GET() {
   try {
     const activityMap = global.sessionActivity || new Map()
-    const activity: Record<string, { lastActivity: string; status: 'active' | 'idle' }> = {}
+    const activity: Record<string, SessionActivityInfo> = {}
+
+    // Get all agents to map sessions to working directories
+    const agents = loadAgents()
+    const sessionToWorkingDir = new Map<string, string>()
+
+    for (const agent of agents) {
+      const sessionName = agent.name || agent.alias
+      const workingDir = agent.workingDirectory ||
+                         agent.sessions?.[0]?.workingDirectory ||
+                         agent.preferences?.defaultWorkingDirectory
+
+      if (sessionName && workingDir) {
+        sessionToWorkingDir.set(sessionName, workingDir)
+      }
+    }
 
     const now = Date.now()
     activityMap.forEach((timestamp, sessionName) => {
       const secondsSinceActivity = (now - timestamp) / 1000
+      const terminalIdle = secondsSinceActivity > 3
+
+      // Check hook state for this session
+      const workingDir = sessionToWorkingDir.get(sessionName)
+      const hookState = workingDir ? getHookState(workingDir) : null
+
+      // Determine status:
+      // - 'waiting' if hook says waiting_for_input or permission_request
+      // - 'active' if terminal had recent output (Claude is working)
+      // - 'idle' if no recent activity and not waiting
+      let status: SessionActivityStatus = terminalIdle ? 'idle' : 'active'
+
+      if (hookState && (hookState.status === 'waiting_for_input' || hookState.status === 'permission_request')) {
+        status = 'waiting'
+      }
+
       activity[sessionName] = {
         lastActivity: new Date(timestamp).toISOString(),
-        status: secondsSinceActivity > 3 ? 'idle' : 'active'
+        status,
+        hookStatus: hookState?.status,
+        notificationType: hookState?.notificationType
       }
     })
 

--- a/app/api/sessions/activity/update/route.ts
+++ b/app/api/sessions/activity/update/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Disable caching
+export const dynamic = 'force-dynamic'
+
+declare global {
+  var broadcastStatusUpdate: ((sessionName: string, status: string, hookStatus?: string, notificationType?: string) => void) | undefined
+}
+
+/**
+ * POST /api/sessions/activity/update
+ * Called by Claude Code hook to broadcast status updates in real-time
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { sessionName, status, hookStatus, notificationType } = body
+
+    if (!sessionName) {
+      return NextResponse.json(
+        { success: false, error: 'sessionName is required' },
+        { status: 400 }
+      )
+    }
+
+    // Broadcast to all WebSocket subscribers
+    if (global.broadcastStatusUpdate) {
+      global.broadcastStatusUpdate(sessionName, status, hookStatus, notificationType)
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('[Activity Update API] Error:', error)
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/hooks/useSessionActivity.ts
+++ b/hooks/useSessionActivity.ts
@@ -1,0 +1,181 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+export type SessionActivityStatus = 'active' | 'idle' | 'waiting'
+
+export interface SessionActivityInfo {
+  lastActivity: string
+  status: SessionActivityStatus
+  hookStatus?: string
+  notificationType?: string
+}
+
+export type SessionActivityMap = Record<string, SessionActivityInfo>
+
+/**
+ * Hook to track session activity status via WebSocket for real-time updates.
+ *
+ * Status meanings:
+ * - 'active': Terminal had recent output (Claude is working/processing)
+ * - 'idle': No recent terminal activity and not waiting for input
+ * - 'waiting': Claude is waiting for user input (detected via hooks)
+ *
+ * This is separate from online/offline/hibernated status which is about whether
+ * the tmux session exists. Activity status only applies to online sessions.
+ */
+export function useSessionActivity() {
+  const [activity, setActivity] = useState<SessionActivityMap>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+  const [connected, setConnected] = useState(false)
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const connect = useCallback(() => {
+    // Clean up existing connection
+    if (wsRef.current) {
+      wsRef.current.close()
+    }
+
+    try {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const ws = new WebSocket(`${protocol}//${window.location.host}/status`)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        console.log('[useSessionActivity] WebSocket connected')
+        setConnected(true)
+        setError(null)
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data)
+
+          if (data.type === 'initial_status') {
+            // Initial status from server
+            setActivity(data.activity || {})
+            setLoading(false)
+          } else if (data.type === 'status_update') {
+            // Real-time status update
+            setActivity(prev => ({
+              ...prev,
+              [data.sessionName]: {
+                lastActivity: data.timestamp,
+                status: data.status,
+                hookStatus: data.hookStatus,
+                notificationType: data.notificationType
+              }
+            }))
+          }
+        } catch (err) {
+          console.error('[useSessionActivity] Failed to parse message:', err)
+        }
+      }
+
+      ws.onclose = () => {
+        console.log('[useSessionActivity] WebSocket disconnected')
+        setConnected(false)
+
+        // Reconnect after 2 seconds
+        reconnectTimeoutRef.current = setTimeout(() => {
+          console.log('[useSessionActivity] Reconnecting...')
+          connect()
+        }, 2000)
+      }
+
+      ws.onerror = (err) => {
+        console.error('[useSessionActivity] WebSocket error:', err)
+        setError(new Error('WebSocket connection failed'))
+      }
+    } catch (err) {
+      console.error('[useSessionActivity] Failed to create WebSocket:', err)
+      setError(err instanceof Error ? err : new Error('Unknown error'))
+      setLoading(false)
+    }
+  }, [])
+
+  // Fallback: Poll API if WebSocket fails
+  const fetchActivity = useCallback(async () => {
+    try {
+      const response = await fetch('/api/sessions/activity')
+      if (response.ok) {
+        const data = await response.json()
+        setActivity(data.activity || {})
+        setLoading(false)
+      }
+    } catch (err) {
+      console.error('[useSessionActivity] Poll failed:', err)
+    }
+  }, [])
+
+  // Connect on mount and poll as fallback
+  useEffect(() => {
+    // Initial fetch immediately
+    fetchActivity()
+
+    // Try WebSocket connection
+    connect()
+
+    // Poll every 2s as fallback (WebSocket updates will override if connected)
+    const pollInterval = setInterval(fetchActivity, 2000)
+
+    return () => {
+      clearInterval(pollInterval)
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current)
+      }
+      if (wsRef.current) {
+        wsRef.current.close()
+      }
+    }
+  }, [connect, fetchActivity])
+
+  /**
+   * Get activity status for a specific session
+   * @param sessionName The tmux session name
+   * @returns Activity info or null if not found
+   */
+  const getSessionActivity = useCallback(
+    (sessionName: string): SessionActivityInfo | null => {
+      return activity[sessionName] || null
+    },
+    [activity]
+  )
+
+  /**
+   * Check if a session is currently waiting for user input
+   * @param sessionName The tmux session name
+   */
+  const isSessionWaiting = useCallback(
+    (sessionName: string): boolean => {
+      const info = activity[sessionName]
+      return info?.status === 'waiting'
+    },
+    [activity]
+  )
+
+  /**
+   * Check if a session is currently active (processing)
+   * @param sessionName The tmux session name
+   */
+  const isSessionActive = useCallback(
+    (sessionName: string): boolean => {
+      const info = activity[sessionName]
+      return info?.status === 'active'
+    },
+    [activity]
+  )
+
+  return {
+    activity,
+    loading,
+    error,
+    connected,
+    getSessionActivity,
+    isSessionWaiting,
+    isSessionActive,
+    reconnect: connect,
+  }
+}

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -212,6 +212,25 @@ export function updateAgent(id: string, updates: UpdateAgentRequest): Agent | nu
     if (existing) {
       throw new Error(`Agent with name "${newName}" already exists`)
     }
+
+    // Also rename the tmux session if it exists
+    if (currentName) {
+      try {
+        const { execSync } = require('child_process')
+        // Check if tmux session exists
+        try {
+          execSync(`tmux has-session -t "${currentName}" 2>/dev/null`)
+          // Session exists, rename it
+          execSync(`tmux rename-session -t "${currentName}" "${newName}"`)
+          console.log(`[Agent Registry] Renamed tmux session: ${currentName} -> ${newName}`)
+        } catch {
+          // Session doesn't exist, that's fine
+        }
+      } catch (err) {
+        console.error(`[Agent Registry] Failed to rename tmux session:`, err)
+        // Don't fail the agent update if tmux rename fails
+      }
+    }
   }
 
   // Normalize tags if being updated


### PR DESCRIPTION
## Summary
- Add real-time activity status indicators to sidebar showing agent state:
  - **Waiting** (amber, pulsing) - agent waiting for user input
  - **Active** (green, pulsing) - agent processing
  - **Idle** (green, solid) - agent ready for new task
- Implement WebSocket-based status updates with polling fallback
- Fix agent rename to also rename tmux session

## Changes
- `app/api/sessions/activity/route.ts` - Enhanced to read hook state files for waiting detection
- `app/api/sessions/activity/update/route.ts` - New endpoint for hook to broadcast status
- `hooks/useSessionActivity.ts` - New hook for real-time status via WebSocket + polling fallback
- `components/AgentList.tsx` - Updated status indicator with Waiting/Active/Idle states
- `components/MobileHostsList.tsx` - Same status updates for mobile view
- `server.mjs` - Added `/status` WebSocket endpoint for real-time broadcasts
- `scripts/claude-hooks/ai-maestro-hook.cjs` - Hook now broadcasts status changes via API
- `lib/agent-registry.ts` - Agent rename now also renames tmux session

## Test plan
- [ ] Verify status indicators show correctly in sidebar
- [ ] Test WebSocket connection for instant updates
- [ ] Verify polling fallback works if WebSocket fails
- [ ] Test agent rename also renames tmux session
- [ ] Confirm mobile view shows correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)