### PR TITLE
fix: Add retry logic for remote WebSocket connections

### DIFF
--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -122,7 +122,7 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
     } catch {}
   }, [])
 
-  const { isConnected, sendMessage, connectionError, errorHint } = useWebSocket({
+  const { isConnected, sendMessage, connectionError, errorHint, connectionMessage } = useWebSocket({
     sessionId: session.id,
     hostId: session.hostId,  // Pass host ID for remote session routing
     autoConnect: isVisible,  // Only auto-connect when visible
@@ -604,6 +604,15 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
           )}
         </div>
       </div>
+      )}
+
+      {/* Connection Status (retry messages for remote connections) */}
+      {connectionMessage && !connectionError && (
+        <div className="px-4 py-2 bg-yellow-900/20 border-b border-yellow-800">
+          <p className="text-sm text-yellow-400">
+            🔄 {connectionMessage}
+          </p>
+        </div>
       )}
 
       {/* Connection Error */}

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-18T02:13:45.951Z",
+  "generatedAt": "2026-01-20T05:16:14.374Z",
   "documentCount": 136,
   "documents": [
     {


### PR DESCRIPTION
## Summary
- Add exponential backoff retry (5 attempts) for flaky network connections to remote hosts
- Send status messages to client during connection retries
- Use close code 4000 for permanent failures (client won't retry after max attempts)
- Display connection status in TerminalView UI

## Changes
- **server.mjs**: Add retry logic with exponential backoff [500, 1000, 2000, 3000, 5000]ms
- **hooks/useWebSocket.ts**: Handle status messages and permanent failure code 4000
- **components/TerminalView.tsx**: Display connection status messages during retries

## Test plan
- [ ] Test remote connection with stable network
- [ ] Test remote connection with flaky network (should retry up to 5 times)
- [ ] Verify status messages appear in UI during retries
- [ ] Verify client doesn't infinitely retry after permanent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)