### PR TITLE
chore: bump version to 0.17.28

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,12 +61,13 @@ This script updates ALL version references across the codebase:
 **IMPORTANT:** Every time you create a Pull Request to main, also draft an X (Twitter) post to announce the release.
 
 **PR Creation Checklist:**
-1. Create PR with comprehensive description (summary, features, bug fixes, breaking changes)
-2. Draft X post highlighting key features and improvements
-3. Include release notes or link to PR in the post
-4. Use relevant hashtags: #AIcoding #DevTools #OpenSource
-5. Consider adding screenshots/GIFs for visual features
-6. Post during peak hours (9-11am or 1-3pm EST)
+1. **BUMP VERSION FIRST** - Run `./scripts/bump-version.sh patch` (or minor/major) BEFORE creating the PR. This is mandatory for every PR to main.
+2. Create PR with comprehensive description (summary, features, bug fixes, breaking changes)
+3. Draft X post highlighting key features and improvements
+4. Include release notes or link to PR in the post
+5. Use relevant hashtags: #AIcoding #DevTools #OpenSource
+6. Consider adding screenshots/GIFs for visual features
+7. Post during peak hours (9-11am or 1-3pm EST)
 
 **X Post Template:**
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.17.27-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.17.28-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-20T05:16:14.374Z",
+  "generatedAt": "2026-01-20T05:24:47.610Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.17.27
+**Current Version:** v0.17.28
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.17.27",
+      "softwareVersion": "0.17.28",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.17.27",
+      "softwareVersion": "0.17.28",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -439,7 +439,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.17.27</span>
+                        <span>v0.17.28</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.17.27",
+  "version": "0.17.28",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.17.27"
+VERSION="0.17.28"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.17.27",
-  "releaseDate": "2026-01-17",
+  "version": "0.17.28",
+  "releaseDate": "2026-01-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.17.28
- Add explicit version bump requirement to PR checklist in CLAUDE.md

## Changes in this release
- Add retry logic for remote WebSocket connections (exponential backoff)
- Display connection status in UI during retries
- Use close code 4000 for permanent failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)