### PR TITLE
fix: Mesh network configuration and case-insensitive host/agent names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.17.28-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.17.29-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/app/api/hosts/identity/route.ts
+++ b/app/api/hosts/identity/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getSelfHost } from '@/lib/hosts-config'
-import { getPublicUrl } from '@/lib/host-sync'
 import { HostIdentityResponse } from '@/types/host-sync'
-import os from 'os'
 
 // Get package version
 const packageJson = require('@/package.json')
@@ -15,48 +13,22 @@ const packageJson = require('@/package.json')
  *
  * Uses centralized getPublicUrl() for consistent URL detection.
  */
-export async function GET(request: Request): Promise<NextResponse<HostIdentityResponse>> {
+export async function GET(): Promise<NextResponse<HostIdentityResponse>> {
   const selfHost = getSelfHost()
 
-  // Use centralized URL detection
-  const publicUrl = getPublicUrl(selfHost)
+  // ALWAYS use the configured URL from hosts.json
+  // NEVER use localhost - it's useless in a mesh network
+  // The URL in hosts.json should already be a reachable IP (set by getDefaultSelfHost)
+  const url = selfHost.url
 
   // Detect if running on Tailscale (IPs start with 100.)
-  let tailscale = false
-  try {
-    const networkInterfaces = os.networkInterfaces()
-    for (const interfaces of Object.values(networkInterfaces)) {
-      if (!interfaces) continue
-      for (const iface of interfaces) {
-        if (iface.family === 'IPv4' && !iface.internal && iface.address.startsWith('100.')) {
-          tailscale = true
-          break
-        }
-      }
-      if (tailscale) break
-    }
-  } catch {
-    // Ignore network interface errors
-  }
-
-  // Check if URL contains Tailscale IP pattern
-  if (!tailscale && publicUrl.includes('100.')) {
-    tailscale = true
-  }
-
-  // Get host identity from headers if provided (for external URL detection)
-  let finalUrl = publicUrl
-  const forwardedHost = request.headers.get('x-forwarded-host')
-  const forwardedProto = request.headers.get('x-forwarded-proto')
-  if (forwardedHost) {
-    finalUrl = `${forwardedProto || 'http'}://${forwardedHost}`
-  }
+  const tailscale = selfHost.tailscale || url.includes('100.')
 
   return NextResponse.json({
     host: {
       id: selfHost.id,
       name: selfHost.name,
-      url: finalUrl,
+      url,
       description: selfHost.description,
       version: packageJson.version || '0.0.0',
       tailscale,

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-20T05:24:47.610Z",
+  "generatedAt": "2026-01-21T16:56:17.918Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.17.28
+**Current Version:** v0.17.29
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.17.28",
+      "softwareVersion": "0.17.29",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.17.28",
+      "softwareVersion": "0.17.29",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -439,7 +439,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.17.28</span>
+                        <span>v0.17.29</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -155,7 +155,8 @@ export function createAgent(request: CreateAgentRequest): Agent {
   const agents = loadAgents()
 
   // Support both new 'name' and deprecated 'alias'
-  const agentName = request.name || request.alias
+  // Normalize to lowercase for case-insensitive consistency
+  const agentName = (request.name || request.alias)?.toLowerCase()
   if (!agentName) {
     throw new Error('Agent name is required')
   }
@@ -258,7 +259,8 @@ export function updateAgent(id: string, updates: UpdateAgentRequest): Agent | nu
   }
 
   // Support both new 'name' and deprecated 'alias'
-  const newName = updates.name || updates.alias
+  // Normalize to lowercase for case-insensitive consistency
+  const newName = (updates.name || updates.alias)?.toLowerCase()
   const currentName = agents[index].name || agents[index].alias
   const agentHostId = agents[index].hostId || getSelfHostId()
 
@@ -701,17 +703,20 @@ export function renameAgent(agentId: string, newName: string): boolean {
   // Get agent's host for per-host uniqueness check
   const agentHostId = agents[index].hostId || getSelfHostId()
 
+  // Normalize to lowercase for case-insensitive consistency
+  const normalizedNewName = newName.toLowerCase()
+
   // Check if new name already exists ON THIS HOST
-  const existing = getAgentByName(newName, agentHostId)
+  const existing = getAgentByName(normalizedNewName, agentHostId)
   if (existing && existing.id !== agentId) {
-    console.error(`[Agent Registry] Cannot rename: agent "${newName}" already exists on host "${agentHostId}"`)
+    console.error(`[Agent Registry] Cannot rename: agent "${normalizedNewName}" already exists on host "${agentHostId}"`)
     return false
   }
 
   const oldName = agents[index].name || agents[index].alias
-  console.log(`[Agent Registry] Renaming agent from "${oldName}" to "${newName}"`)
+  console.log(`[Agent Registry] Renaming agent from "${oldName}" to "${normalizedNewName}"`)
 
-  agents[index].name = newName
+  agents[index].name = normalizedNewName
   // Clear deprecated alias
   delete agents[index].alias
   agents[index].lastActive = new Date().toISOString()

--- a/lib/host-sync.ts
+++ b/lib/host-sync.ts
@@ -19,7 +19,7 @@ import {
   PeerExchangeRequest,
   PeerExchangeResponse,
 } from '@/types/host-sync'
-import { getHosts, getSelfHost, addHost, addHostAsync, getHostById, clearHostsCache } from './hosts-config'
+import { getHosts, getSelfHost, addHost, addHostAsync, getHostById, clearHostsCache, getSelfAliases } from './hosts-config'
 import os from 'os'
 
 // Track processed propagation IDs to prevent infinite loops
@@ -296,12 +296,16 @@ async function registerWithPeer(
   error?: string
 }> {
   try {
+    // Include all aliases for duplicate detection on remote host
+    const aliases = getSelfAliases()
+
     const request: PeerRegistrationRequest = {
       host: {
         id: localHost.id,
         name: localHost.name,
         url: getPublicUrl(localHost),
         description: localHost.description,
+        aliases,
       },
       source: {
         initiator: localHost.id,

--- a/lib/hosts-config-server.mjs
+++ b/lib/hosts-config-server.mjs
@@ -12,35 +12,144 @@ import path from 'path'
 import os from 'os'
 
 const HOSTS_ENV_VAR = 'AIMAESTRO_HOSTS'
-const HOSTS_CONFIG_PATH = path.join(process.cwd(), '.aimaestro', 'hosts.json')
+// Use user's home directory for hosts.json - shared across all projects
+const HOSTS_CONFIG_PATH = path.join(os.homedir(), '.aimaestro', 'hosts.json')
 
 /**
  * Get this machine's hostname - the canonical host ID
+ * Always returns lowercase for case-insensitive consistency
  */
 export function getSelfHostId() {
-  return os.hostname()
+  return os.hostname().toLowerCase()
+}
+
+/**
+ * Get all local IP addresses for this machine
+ * Returns IPs from all network interfaces (excluding loopback)
+ */
+export function getLocalIPs() {
+  const interfaces = os.networkInterfaces()
+  const ips = []
+
+  for (const [name, addrs] of Object.entries(interfaces)) {
+    if (!addrs) continue
+    for (const addr of addrs) {
+      // Skip loopback and internal addresses
+      if (addr.internal) continue
+      // Only IPv4 for now (more compatible)
+      if (addr.family === 'IPv4') {
+        ips.push({
+          ip: addr.address,
+          family: addr.family,
+          internal: addr.internal,
+          interface: name,
+        })
+      }
+    }
+  }
+
+  return ips
+}
+
+/**
+ * Get the preferred IP address for external communication
+ * Priority: Tailscale (100.x) > LAN (10.x, 192.168.x) > other
+ * NEVER returns localhost or 127.0.0.1
+ */
+export function getPreferredIP() {
+  const ips = getLocalIPs()
+
+  // Priority 1: Tailscale IPs (100.x.x.x range used by Tailscale)
+  const tailscaleIP = ips.find(i => i.ip.startsWith('100.'))
+  if (tailscaleIP) return tailscaleIP.ip
+
+  // Priority 2: Private LAN IPs
+  const lanIP = ips.find(i =>
+    i.ip.startsWith('10.') ||
+    i.ip.startsWith('192.168.') ||
+    /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(i.ip)
+  )
+  if (lanIP) return lanIP.ip
+
+  // Priority 3: Any other non-internal IP
+  if (ips.length > 0) return ips[0].ip
+
+  // Fallback: null (caller should handle this)
+  return null
+}
+
+/**
+ * Get all aliases for this host (all IPs, hostname, etc.)
+ * Used for duplicate detection in mesh network
+ * All aliases are lowercase for case-insensitive consistency
+ */
+export function getSelfAliases() {
+  const hostname = getSelfHostId() // Already lowercase
+  const ips = getLocalIPs().map(i => i.ip)
+
+  // Include hostname variations and all IPs (all lowercase)
+  const aliases = new Set([
+    hostname,
+    ...ips,
+    // Also include URL forms for matching
+    ...ips.map(ip => `http://${ip}:23000`),
+  ])
+
+  return Array.from(aliases)
 }
 
 /**
  * Check if a hostId refers to this machine
+ * Checks against hostname and all known IPs/aliases
  */
 export function isSelf(hostId) {
   if (!hostId) return false
+
   const selfId = getSelfHostId()
-  // Case-insensitive comparison, also handle legacy 'local' value
-  return hostId.toLowerCase() === selfId.toLowerCase() ||
-         hostId === 'local'  // DEPRECATED: backward compat
+  const hostIdLower = hostId.toLowerCase()
+
+  // Direct hostname match
+  if (hostIdLower === selfId.toLowerCase()) return true
+
+  // Legacy 'local' value (DEPRECATED)
+  if (hostId === 'local') return true
+
+  // Check against all our IPs
+  const selfIPs = getLocalIPs().map(i => i.ip.toLowerCase())
+  if (selfIPs.includes(hostIdLower)) return true
+
+  // Check if it's a URL pointing to one of our IPs
+  try {
+    const url = new URL(hostId)
+    const urlHost = url.hostname.toLowerCase()
+    if (urlHost === selfId.toLowerCase() || selfIPs.includes(urlHost)) return true
+  } catch {
+    // Not a URL, that's fine
+  }
+
+  return false
 }
 
 /**
  * Get the default host configuration for this machine
+ * Uses actual IP address, NEVER localhost
  */
 function getDefaultSelfHost() {
   const hostname = getSelfHostId()
+  const preferredIP = getPreferredIP()
+  const aliases = getSelfAliases()
+
+  // Use actual IP for URL, fallback to hostname if no IP found
+  // NEVER use localhost - it's useless in a mesh network
+  const url = preferredIP
+    ? `http://${preferredIP}:23000`
+    : `http://${hostname}:23000`
+
   return {
-    id: hostname,  // NOT 'local' - use actual hostname
+    id: hostname,
     name: hostname,
-    url: 'http://localhost:23000',
+    url,
+    aliases,
     enabled: true,
     description: 'This machine',
   }
@@ -49,19 +158,27 @@ function getDefaultSelfHost() {
 let cachedHosts = null
 
 /**
- * Migrate legacy host config (convert id:'local' to hostname)
+ * Migrate and normalize host config
+ * - Convert id:'local' to hostname
+ * - Normalize host ID to lowercase
  */
 function migrateHost(host) {
+  const selfId = getSelfHostId() // Already lowercase
+
   // Migrate id:'local' to actual hostname
   if (host.id === 'local') {
-    const selfId = getSelfHostId()
     return {
       ...host,
       id: selfId,
       name: host.name || selfId,
     }
   }
-  return host
+
+  // Normalize host ID to lowercase for case-insensitive consistency
+  return {
+    ...host,
+    id: host.id.toLowerCase(),
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.17.28",
+  "version": "0.17.29",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.17.28"
+VERSION="0.17.29"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/types/host-sync.ts
+++ b/types/host-sync.ts
@@ -15,6 +15,8 @@ export interface HostIdentity {
   name: string
   url: string
   description?: string
+  /** All known IPs, hostnames, URLs for duplicate detection */
+  aliases?: string[]
 }
 
 /**

--- a/types/host.ts
+++ b/types/host.ts
@@ -18,8 +18,15 @@ export interface Host {
   /** Human-readable display name */
   name: string
 
-  /** Base URL for the AI Maestro API (e.g., "http://localhost:23000") */
+  /** Base URL for the AI Maestro API (e.g., "http://10.0.0.5:23000") */
   url: string
+
+  /**
+   * All known ways to reach this host (IPs, hostnames, URLs)
+   * Used for duplicate detection and fallback connections
+   * Examples: ['10.0.0.5', '100.104.178.57', 'macbook-pro.local', 'http://10.0.0.5:23000']
+   */
+  aliases?: string[]
 
   /** Whether this host is enabled */
   enabled?: boolean

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.17.28",
+  "version": "0.17.29",
   "releaseDate": "2026-01-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- **Canonical hosts.json location**: Moved to `~/.aimaestro/hosts.json` (shared across all projects)
- **No more localhost in mesh**: Auto-detect IPs with priority: Tailscale (100.x) > LAN (10.x, 192.168.x) > other
- **Duplicate detection**: Store all host aliases (IPs, hostnames, URLs) for robust peer registration
- **Case-insensitive names**: Host IDs and agent names normalized to lowercase to avoid "nightmare" issues

## Key Changes

### Hosts Configuration
- `getSelfHostId()` returns lowercase hostname
- `getLocalIPs()` detects all network interfaces
- `getPreferredIP()` prioritizes Tailscale > LAN > other
- `getSelfAliases()` collects all known identifiers
- `findHostByAnyIdentifier()` for duplicate detection
- `migrateHost()` normalizes IDs to lowercase

### Agent Registry
- Agent names normalized to lowercase on create/update/rename
- Per-host uniqueness check uses lowercase comparison

### Identity Endpoint
- Always returns configured URL from hosts.json
- Never derives URL from request (fixes localhost issue)

### Peer Registration
- Checks all incoming identifiers (URL, aliases, IPs) against existing hosts
- Prevents duplicate entries from different IP addresses

## Test plan

- [ ] Verify `curl localhost:23000/api/hosts/identity` returns Tailscale IP, not localhost
- [ ] Verify host ID is lowercase in identity response
- [ ] Create agent with mixed-case name, verify stored as lowercase
- [ ] Add peer host, verify duplicate detection works with different IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)