### PR TITLE
fix: Add migration support for legacy 'local' host ID

### DIFF
--- a/.aimaestro/hosts.example.json
+++ b/.aimaestro/hosts.example.json
@@ -1,12 +1,12 @@
 {
   "hosts": [
     {
-      "id": "local",
-      "name": "Local Machine",
-      "url": "http://localhost:23000",
+      "id": "YOUR-HOSTNAME-HERE",
+      "name": "This Machine",
+      "url": "http://YOUR-IP-OR-HOSTNAME:23000",
       "type": "local",
       "enabled": true,
-      "description": "This machine (local tmux sessions)"
+      "description": "This machine - replace YOUR-HOSTNAME-HERE with your actual hostname (run: hostname)"
     },
     {
       "id": "mac-mini",


### PR DESCRIPTION
## Summary

Adds migration support for existing users who have `\"id\": \"local\"` in their hosts.json file.

## Problem

Existing installations have hosts.json with:
```json
{
  "id": "local",
  "url": "http://localhost:23000"
}
```

The mesh network infrastructure requires actual hostnames as host IDs for proper cross-host communication.

## Solution

### Install Script Migration
- Detects existing hosts.json with `"id": "local"`
- Prompts user to migrate (with backup)
- Uses jq for safe JSON migration
- Updates both ID and URL to actual hostname/IP

### Shell Helpers Backwards Compatibility  
- `get_host_url("local")` returns self host URL
- `is_self_host("local")` returns true
- `list_hosts()` filters out legacy "local" entries

### Example File Update
- Updated hosts.example.json to use placeholder instead of "local"

## Test plan

- [x] Tested migration with legacy hosts.json
- [x] Verified remote hosts are preserved
- [x] Verified backup is created
- [x] Tested backwards compatibility functions

🤖 Generated with [Claude Code](https://claude.ai/code)