### PR TITLE
fix: Add isSelf flag to hosts API for correct version display

### DIFF
--- a/app/api/hosts/route.ts
+++ b/app/api/hosts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { getHosts, saveHosts, addHost, updateHost, deleteHost } from '@/lib/hosts-config'
+import { getHosts, saveHosts, addHost, updateHost, deleteHost, isSelf } from '@/lib/hosts-config'
 import { addHostWithSync } from '@/lib/host-sync'
 import type { Host } from '@/types/host'
 
@@ -11,11 +11,17 @@ export const dynamic = 'force-dynamic'
  *
  * Returns the list of configured hosts (local and remote).
  * Used by the UI to display host information and for session creation.
+ * Adds `isSelf` flag to identify which host is this machine.
  */
 export async function GET() {
   try {
     const hosts = getHosts()
-    return NextResponse.json({ hosts })
+    // Add isSelf flag to each host so UI can identify the local machine
+    const hostsWithSelf = hosts.map(host => ({
+      ...host,
+      isSelf: isSelf(host.id),
+    }))
+    return NextResponse.json({ hosts: hostsWithSelf })
   } catch (error) {
     console.error('[Hosts API] Failed to fetch hosts:', error)
     return NextResponse.json({ error: 'Failed to fetch hosts', hosts: [] }, { status: 500 })

--- a/components/settings/HostsSection.tsx
+++ b/components/settings/HostsSection.tsx
@@ -61,8 +61,8 @@ export default function HostsSection() {
     if (hosts.length > 0) {
       hosts.forEach(host => {
         if (host.enabled) {
-          if (host.type === 'local') {
-            // For local host, fetch version and sessions directly
+          if (host.isSelf) {
+            // For this machine, fetch version and sessions directly (no proxy needed)
             Promise.all([
               fetch('/api/config').then(res => res.json()),
               fetch('/api/sessions').then(res => res.json())

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-21T19:28:17.461Z",
+  "generatedAt": "2026-01-21T20:22:36.707Z",
   "documentCount": 136,
   "documents": [
     {

--- a/types/host.ts
+++ b/types/host.ts
@@ -53,9 +53,12 @@ export interface Host {
   lastSyncError?: string
 
   // DEPRECATED: type field is no longer meaningful
-  // In a mesh network, all hosts are equal. Use isSelf(host.id) for self-detection.
+  // In a mesh network, all hosts are equal. Use isSelf for self-detection.
   // Kept for backward compatibility during migration - will be removed.
   type?: 'local' | 'remote'
+
+  /** Whether this host is the current machine (set by API, not stored) */
+  isSelf?: boolean
 }
 
 export interface HostsConfig {


### PR DESCRIPTION
## Summary
- Fixes host version display in settings showing wrong version for local machine
- Added `isSelf` flag to `/api/hosts` response to identify the current machine
- Updated `HostsSection.tsx` to use `host.isSelf` instead of deprecated `host.type === 'local'`
- Added `isSelf?: boolean` to Host type definition

## Problem
The settings page was showing incorrect version numbers for the local host because:
1. The code checked `host.type === 'local'` but the `type` field is deprecated
2. The API wasn't returning the `isSelf` flag to identify which host is the current machine

## Solution
- `/api/hosts/route.ts` now adds `isSelf: isSelf(host.id)` to each host
- `HostsSection.tsx` uses `host.isSelf` to determine when to fetch version directly vs via proxy

## Test plan
- [ ] Verify local host shows correct version in settings
- [ ] Verify remote hosts show their correct versions
- [ ] Verify version updates are reflected after bumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)