### PR TITLE
fix: Avatar mismatch during agent creation

### DIFF
--- a/app/api/sessions/create/route.ts
+++ b/app/api/sessions/create/route.ts
@@ -49,7 +49,7 @@ async function httpPost(url: string, body: any, timeout: number = 10000): Promis
 
 export async function POST(request: Request) {
   try {
-    const { name, workingDirectory, agentId, hostId, label } = await request.json()
+    const { name, workingDirectory, agentId, hostId, label, avatar } = await request.json()
 
     if (!name || typeof name !== 'string') {
       return NextResponse.json({ error: 'Session name is required' }, { status: 400 })
@@ -74,7 +74,7 @@ export async function POST(request: Request) {
         const remoteUrl = `${targetHost.url}/api/sessions/create`
         console.log(`[Sessions] Creating session "${name}" on remote host ${targetHost.name} at ${remoteUrl}`)
 
-        const data = await httpPost(remoteUrl, { name, workingDirectory, agentId, label })
+        const data = await httpPost(remoteUrl, { name, workingDirectory, agentId, label, avatar })
 
         console.log(`[Sessions] Successfully created session "${name}" on ${targetHost.name}`)
         return NextResponse.json(data)
@@ -159,6 +159,7 @@ export async function POST(request: Request) {
         registeredAgent = createAgent({
           name: agentName,
           label,  // Persona name like "NatalIA"
+          avatar, // Avatar URL from the creation modal
           program: 'claude-code',
           taskDescription: `Agent for ${agentName}`,
           tags,

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -593,14 +593,14 @@ export default function AgentList({
     }
   }
 
-  const handleCreateAgent = async (name: string, workingDirectory?: string, hostId?: string, label?: string): Promise<boolean> => {
+  const handleCreateAgent = async (name: string, workingDirectory?: string, hostId?: string, label?: string, avatar?: string): Promise<boolean> => {
     setActionLoading(true)
 
     try {
       const response = await fetch('/api/sessions/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, workingDirectory, hostId, label }),
+        body: JSON.stringify({ name, workingDirectory, hostId, label, avatar }),
       })
 
       if (!response.ok) {
@@ -1463,7 +1463,7 @@ function CreateAgentModal({
   loading,
 }: {
   onClose: () => void
-  onCreate: (name: string, workingDirectory?: string, hostId?: string, label?: string) => Promise<boolean>
+  onCreate: (name: string, workingDirectory?: string, hostId?: string, label?: string, avatar?: string) => Promise<boolean>
   onComplete: () => void
   loading: boolean
 }) {
@@ -1594,9 +1594,11 @@ function CreateAgentModal({
     e.preventDefault()
     if (name.trim()) {
       setIsCreating(true)
-      // Generate persona name (like "NatalIA") and pass it to be saved
+      // Generate persona name (like "NatalIA") and avatar URL to be saved
+      // These must match what's shown in the preview animation
       const personaName = getRandomAlias(name.trim())
-      const success = await onCreate(name.trim(), workingDirectory.trim() || undefined, undefined, personaName)
+      const avatarUrl = getPreviewAvatarUrl(name.trim())
+      const success = await onCreate(name.trim(), workingDirectory.trim() || undefined, undefined, personaName, avatarUrl)
       if (success) {
         setCreationSuccess(true)
         // Animation continues, user will click "Let's Go!" to close

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-23T06:49:24.216Z",
+  "generatedAt": "2026-01-23T07:31:42.697Z",
   "documentCount": 136,
   "documents": [
     {


### PR DESCRIPTION
## Summary

Fixes bug where the avatar shown during agent creation was different from the avatar saved to the agent.

## Root Cause

- Modal preview used `getPreviewAvatarUrl(name)` which hashes the **agent name**
- Registry used `generateUniqueAvatarUrl(id)` which hashes the **agent UUID**
- Different hash inputs = different avatars!

## Fix

Pass the avatar URL generated in the modal through to the registry:
- Add `avatar` parameter to `handleCreateAgent()`
- Include `avatar` in API request body
- Forward `avatar` to `createAgent()` call

Now the preview avatar during creation matches the saved avatar.

## Test plan
- [ ] Create a new agent
- [ ] Verify avatar shown during animation matches avatar in agent list
- [ ] Verify persona name (label) matches between animation and agent list

🤖 Generated with [Claude Code](https://claude.ai/code)