### PR TITLE
fix: Case-insensitive agent name matching in orphan detection

### DIFF
--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-23T07:31:42.697Z",
+  "generatedAt": "2026-01-23T07:45:16.619Z",
   "documentCount": 136,
   "documents": [
     {


### PR DESCRIPTION
## Summary

Fixes bug where creating an agent resulted in TWO agents appearing in the list.

## Root Cause

Creating agent "PAs-Lola" resulted in:
- `pas-lola` (lowercase) from API with avatar/label  
- `PAs-Lola` (original case) from orphan detection WITHOUT avatar

The orphan detection compared:
- `sessionsByAgentName` keys: preserved tmux case (`"PAs-Lola"`)
- `processedAgentNames` set: normalized lowercase from registry (`"pas-lola"`)

Since Set comparison is case-sensitive, they didn't match → orphan created.

## Fix

Normalize all agent names to lowercase when:
- Building `sessionsByAgentName` map
- Adding to `processedAgentNames` set
- Creating orphan agents in `createOrphanAgent()`

## Test plan
- [ ] Create agent with mixed case name (e.g., "Test-Agent")
- [ ] Verify only ONE agent appears in the list
- [ ] Verify avatar and label are preserved

🤖 Generated with [Claude Code](https://claude.ai/code)