### PR TITLE
docs: Add prominent pre-PR checklist to enforce version bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,20 @@ This script updates ALL version references across the codebase:
 
 **DO NOT manually edit version numbers in individual files.** Always use the script to ensure consistency.
 
+## Pre-PR Checklist (MANDATORY)
+
+**⚠️ STOP! Before creating ANY Pull Request to main, complete this checklist:**
+
+```
+□ 1. BUMP VERSION: ./scripts/bump-version.sh patch
+□ 2. BUILD PASSES: yarn build
+□ 3. COMMIT version bump with your changes
+```
+
+**This is NON-NEGOTIABLE.** Every PR to main MUST include a version bump. No exceptions.
+
+---
+
 ## Release & Marketing Workflow
 
 ### Pull Request Protocol
@@ -61,7 +75,7 @@ This script updates ALL version references across the codebase:
 **IMPORTANT:** Every time you create a Pull Request to main, also draft an X (Twitter) post to announce the release.
 
 **PR Creation Checklist:**
-1. **BUMP VERSION FIRST** - Run `./scripts/bump-version.sh patch` (or minor/major) BEFORE creating the PR. This is mandatory for every PR to main.
+1. ✅ **VERSION BUMPED** (see Pre-PR Checklist above - this should already be done)
 2. Create PR with comprehensive description (summary, features, bug fixes, breaking changes)
 3. Draft X post highlighting key features and improvements
 4. Include release notes or link to PR in the post


### PR DESCRIPTION
## Summary
- Add highly visible "Pre-PR Checklist (MANDATORY)" section to CLAUDE.md
- Makes version bump requirement impossible to miss before creating PRs

## Changes
```
□ 1. BUMP VERSION: ./scripts/bump-version.sh patch
□ 2. BUILD PASSES: yarn build  
□ 3. COMMIT version bump with your changes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)