### PR TITLE
docs: Add Slack integration release notes

### DIFF
--- a/docs/RELEASE-NOTES-0.18.8-SLACK.md
+++ b/docs/RELEASE-NOTES-0.18.8-SLACK.md
@@ -1,0 +1,146 @@
+# Release Notes: Slack Integration for Agent Messaging
+
+**Version:** 0.18.8 - 0.18.9
+**Date:** 2026-01-23
+**RFC Author:** Lola
+**Implementation:** Claude Opus 4.5
+
+---
+
+## Summary
+
+Implemented Slack bridge support for the agent messaging system based on Lola's RFC. Agents can now receive messages from Slack and reply directly to Slack threads.
+
+---
+
+## What's New
+
+### 1. New `reply-aimaestro-message.sh` Script
+
+A new script for replying to messages. When replying to a Slack-bridged message, the reply automatically includes the Slack context so the bridge can post it to the original thread.
+
+```bash
+# Reply to any message
+reply-aimaestro-message.sh <message-id> "Your reply here" [priority]
+
+# Example
+reply-aimaestro-message.sh msg-1234567890-abc "I'll look into that API issue"
+```
+
+### 2. Slack Context Display in `read-aimaestro-message.sh`
+
+When reading a message that came from Slack, you'll now see:
+
+```
+═══════════════════════════════════════════════════════════════
+📧 Message: Question from #engineering
+═══════════════════════════════════════════════════════════════
+
+From:     slack-bridge
+To:       backend-api
+Date:     2025-01-23 14:30:00
+Priority: 🔵 normal
+Type:     request
+
+───────────────────────────────────────────────────────────────
+
+Can you help with the API design for the new user service?
+
+───────────────────────────────────────────────────────────────
+📱 VIA SLACK:
+
+   Channel:  CS5SXB7C6
+   Thread:   1769217994.223089
+   User:     US37DSBS8
+
+═══════════════════════════════════════════════════════════════
+✅ Message marked as read
+
+💡 To reply (will post to Slack thread):
+   reply-aimaestro-message.sh msg-1234... "Your reply here"
+═══════════════════════════════════════════════════════════════
+```
+
+### 3. Slack Indicators in `check-aimaestro-messages.sh`
+
+Messages from Slack now show a 📱 indicator in the inbox list:
+
+```
+[msg-1234...] 🔵 📱 From: slack-bridge | 2025-01-23 14:30
+    Subject: Question from #engineering
+    Preview: Can you help with the API design? [via Slack]
+```
+
+### 4. API Changes
+
+Added `viaSlack?: boolean` field to `MessageSummary` interface. This is populated when `content.slack` exists in the message.
+
+---
+
+## How It Works
+
+### Receiving from Slack
+
+1. Slack bridge service monitors for messages directed to agents
+2. Bridge converts message to AI Maestro format with `content.slack` attached:
+   ```json
+   {
+     "content": {
+       "type": "request",
+       "message": "Can you help with...",
+       "slack": {
+         "channel": "CS5SXB7C6",
+         "thread_ts": "1769217994.223089",
+         "user": "US37DSBS8"
+       }
+     }
+   }
+   ```
+3. Message appears in agent's inbox with 📱 indicator
+
+### Replying to Slack
+
+1. Agent uses `reply-aimaestro-message.sh <msg-id> "reply"`
+2. Script fetches original message and extracts `content.slack`
+3. Reply is sent with Slack context preserved
+4. Slack bridge picks up the reply and posts to the original thread
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `messaging_scripts/reply-aimaestro-message.sh` | **NEW** - Reply script with Slack support |
+| `messaging_scripts/read-aimaestro-message.sh` | Added VIA SLACK section + reply hint |
+| `messaging_scripts/check-aimaestro-messages.sh` | Added 📱 indicator + [via Slack] tag |
+| `lib/messageQueue.ts` | Added `viaSlack` field to MessageSummary |
+| `skills/agent-messaging/SKILL.md` | Full documentation for Slack integration |
+| `install-messaging.sh` | Added reply script to verification |
+
+---
+
+## Testing
+
+To test (requires Slack bridge to be running):
+
+1. Send a message from Slack to an agent
+2. Check inbox: `check-aimaestro-messages.sh` → should show 📱
+3. Read message: `read-aimaestro-message.sh <id>` → should show VIA SLACK section
+4. Reply: `reply-aimaestro-message.sh <id> "test reply"` → should post to Slack thread
+
+For testing without Slack bridge, manually create a message with `content.slack` field.
+
+---
+
+## Next Steps for Lola
+
+The agent-side implementation is complete. The Slack bridge needs to:
+
+1. **Send messages** with `content.slack` containing `channel`, `thread_ts`, `user`
+2. **Watch for replies** where `content.slack` exists and post to the thread
+3. **Handle the `inReplyTo` field** to maintain conversation threading
+
+---
+
+🤖 *Implemented with Claude Code*


### PR DESCRIPTION
## Summary
- Add release notes for Slack messaging integration (v0.18.8-0.18.9)
- Documents what was implemented and what the Slack bridge needs to do

For Lola to understand the agent-side implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)