### PR TITLE
fix: Use POSIX character class for bash regex (Issue #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.18.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.18.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.18.11
+**Current Version:** v0.18.12
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.18.11",
+      "softwareVersion": "0.18.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.18.11",
+      "softwareVersion": "0.18.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -439,7 +439,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.18.11</span>
+                        <span>v0.18.12</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/messaging_scripts/reply-aimaestro-message.sh
+++ b/messaging_scripts/reply-aimaestro-message.sh
@@ -75,7 +75,7 @@ SLACK_CONTEXT=$(echo "$RESPONSE" | jq '.content.slack // null')
 
 # Build reply subject (add "Re: " prefix if not already present)
 REPLY_SUBJECT="$ORIG_SUBJECT"
-if [[ ! "$REPLY_SUBJECT" =~ ^Re:\ ]]; then
+if [[ ! "$REPLY_SUBJECT" =~ ^Re:[[:space:]] ]]; then
   REPLY_SUBJECT="Re: $ORIG_SUBJECT"
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.18.11",
+  "version": "0.18.12",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.18.11"
+VERSION="0.18.12"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.18.11",
+  "version": "0.18.12",
   "releaseDate": "2026-01-24",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
Fixed bash syntax error in `reply-aimaestro-message.sh` when running on bash 5.2+ (Ubuntu).

## Problem
The regex pattern `^Re:\ ` with an escaped space causes a syntax error:
```
syntax error in conditional expression: unexpected token `;'
syntax error near `;'
```

## Solution
Changed line 78 from:
```bash
if [[ ! "$REPLY_SUBJECT" =~ ^Re:\ ]]; then
```
To:
```bash
if [[ ! "$REPLY_SUBJECT" =~ ^Re:[[:space:]] ]]; then
```

The POSIX character class `[[:space:]]` is more portable and works correctly across different bash versions.

## Test Plan
- [x] Verified syntax is valid bash
- [ ] Test reply-aimaestro-message.sh on Ubuntu with bash 5.2+

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)