### PR TITLE
fix: Strip .local suffix from hostname for cross-platform consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.4
+**Current Version:** v0.19.5
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.19.4",
+      "softwareVersion": "0.19.5",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.4",
+      "softwareVersion": "0.19.5",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -440,7 +440,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.4</span>
+                        <span>v0.19.5</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/host-sync.ts
+++ b/lib/host-sync.ts
@@ -97,7 +97,8 @@ export function getPublicUrl(host?: Host): string {
 
   // NEVER return localhost - use hostname as last resort
   // localhost is useless in a mesh network
-  const hostname = os.hostname().toLowerCase()
+  // Strip .local suffix (macOS Bonjour/mDNS) for cross-platform consistency
+  const hostname = os.hostname().toLowerCase().replace(/\.local$/, '')
   return `http://${hostname}:${port}`
 }
 

--- a/lib/hosts-config-server.mjs
+++ b/lib/hosts-config-server.mjs
@@ -18,9 +18,10 @@ const HOSTS_CONFIG_PATH = path.join(os.homedir(), '.aimaestro', 'hosts.json')
 /**
  * Get this machine's hostname - the canonical host ID
  * Always returns lowercase for case-insensitive consistency
+ * Strips .local suffix (macOS Bonjour/mDNS) for cross-platform consistency
  */
 export function getSelfHostId() {
-  return os.hostname().toLowerCase()
+  return os.hostname().toLowerCase().replace(/\.local$/, '')
 }
 
 /**

--- a/lib/hosts-config.ts
+++ b/lib/hosts-config.ts
@@ -85,9 +85,10 @@ async function withLock<T>(fn: () => T | Promise<T>): Promise<T> {
 /**
  * Get this machine's hostname - the canonical host ID
  * Always returns lowercase for case-insensitive consistency
+ * Strips .local suffix (macOS Bonjour/mDNS) for cross-platform consistency
  */
 export function getSelfHostId(): string {
-  return os.hostname().toLowerCase()
+  return os.hostname().toLowerCase().replace(/\.local$/, '')
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.4"
+VERSION="0.19.5"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.19.4",
-  "releaseDate": "2026-01-24",
+  "version": "0.19.5",
+  "releaseDate": "2026-01-25",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- Strips `.local` suffix from hostname returned by `os.hostname()` for cross-platform mesh network consistency
- macOS returns hostname with `.local` suffix (Bonjour/mDNS), Linux returns plain hostname
- This caused mesh network identity mismatches (e.g., "mac-mini.local" vs "mac-mini")

## Changes
- `lib/hosts-config-server.mjs`: `getSelfHostId()` now strips `.local` suffix
- `lib/hosts-config.ts`: `getSelfHostId()` now strips `.local` suffix  
- `lib/host-sync.ts`: Uses consistent hostname without `.local` suffix

## Test plan
- [ ] Verify `getSelfHostId()` returns hostname without `.local` suffix on macOS
- [ ] Verify cross-host agent messaging works between macOS and Linux hosts
- [ ] Verify host appears correctly in mesh network with consistent ID

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)