### PR TITLE
fix: Disable Next.js fetch caching in health proxy endpoint

### DIFF
--- a/app/api/hosts/health/route.ts
+++ b/app/api/hosts/health/route.ts
@@ -87,7 +87,8 @@ async function makeHealthCheckRequest(
         'User-Agent': 'AI-Maestro-Health-Check',
         'Accept': 'application/json'
       },
-      signal: AbortSignal.timeout(timeout)
+      signal: AbortSignal.timeout(timeout),
+      cache: 'no-store'  // Disable Next.js fetch caching
     })
 
     if (response.ok || response.status < 500) {
@@ -133,7 +134,8 @@ async function fetchVersionInfo(
         'User-Agent': 'AI-Maestro-Health-Check',
         'Accept': 'application/json'
       },
-      signal: AbortSignal.timeout(timeout)
+      signal: AbortSignal.timeout(timeout),
+      cache: 'no-store'  // Disable Next.js fetch caching
     })
 
     if (response.ok) {

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-25T19:04:56.146Z",
+  "generatedAt": "2026-01-25T21:46:27.353Z",
   "documentCount": 136,
   "documents": [
     {


### PR DESCRIPTION
## Summary
- Fixed stale version data in host health checks caused by Next.js fetch caching
- Added `cache: 'no-store'` to health proxy fetch calls
- Improved Refresh button UX to show all hosts checking simultaneously

## Test plan
- [ ] Go to Settings → Host Management
- [ ] Click Refresh button
- [ ] Verify all hosts show correct versions (not cached old versions)

🤖 Generated with [Claude Code](https://claude.ai/code)