### PR TITLE
fix: Installer scripts now properly configure PATH for shell scripts

### DIFF
--- a/install-doc-tools.sh
+++ b/install-doc-tools.sh
@@ -130,6 +130,21 @@ else
     echo "  Warning: SKILL.md not found, skipping"
 fi
 
+# Verify jq is available
+echo ""
+if command -v jq &> /dev/null; then
+    echo "✅ jq is installed"
+else
+    echo "⚠️  jq is not installed (required for docs scripts)"
+    echo "   Install with: brew install jq (macOS) or apt install jq (Linux)"
+fi
+
+# Setup PATH
+echo ""
+echo "Configuring PATH..."
+source "$SCRIPT_DIR/scripts/shell-helpers/common.sh"
+setup_local_bin_path
+
 echo ""
 echo "Installation complete!"
 echo ""
@@ -141,3 +156,11 @@ echo "  docs-index.sh                 - Index documentation"
 echo "  docs-index-delta.sh           - Delta index (changed files only)"
 echo "  docs-list.sh                  - List indexed documents"
 echo "  docs-get.sh <doc-id>          - Get specific document"
+echo ""
+
+# Verify installation
+if command -v docs-search.sh &> /dev/null; then
+    echo "✅ Scripts are accessible in PATH"
+else
+    echo "⚠️  Restart terminal or run: source ~/.bashrc (or ~/.zshrc)"
+fi

--- a/install-graph-tools.sh
+++ b/install-graph-tools.sh
@@ -42,29 +42,31 @@ echo "Installing graph-query skill to $SKILL_DIR..."
 cp "$SCRIPT_DIR/skills/graph-query/SKILL.md" "$SKILL_DIR/SKILL.md"
 echo "  Installed: SKILL.md"
 
-# Check if ~/.local/bin is in PATH
-echo ""
-if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    echo "NOTE: $INSTALL_DIR is not in your PATH."
-    echo ""
-    echo "Add this to your ~/.bashrc or ~/.zshrc:"
-    echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
-    echo ""
-else
-    echo "PATH already includes $INSTALL_DIR"
-fi
-
 # Verify jq is available
 echo ""
 if command -v jq &> /dev/null; then
-    echo "jq is installed."
+    echo "✅ jq is installed"
 else
-    echo "WARNING: jq is not installed. Graph scripts require jq."
-    echo "Install with: brew install jq"
+    echo "⚠️  jq is not installed (required for graph scripts)"
+    echo "   Install with: brew install jq (macOS) or apt install jq (Linux)"
 fi
+
+# Setup PATH
+echo ""
+echo "Configuring PATH..."
+source "$SCRIPT_DIR/scripts/shell-helpers/common.sh"
+setup_local_bin_path
 
 echo ""
 echo "Installation complete!"
+
+# Verify installation
+echo ""
+if command -v graph-describe.sh &> /dev/null; then
+    echo "✅ Scripts are accessible in PATH"
+else
+    echo "⚠️  Restart terminal or run: source ~/.bashrc (or ~/.zshrc)"
+fi
 echo ""
 echo "Available commands:"
 echo "  graph-describe.sh <name>          - Describe a component/function"

--- a/install-memory-tools.sh
+++ b/install-memory-tools.sh
@@ -10,6 +10,17 @@ SHARE_DIR="$HOME/.local/share/aimaestro/shell-helpers"
 
 echo "AI Maestro Memory Tools Installer"
 echo "=================================="
+echo ""
+
+# Check for jq dependency
+echo "Checking dependencies..."
+if command -v jq &> /dev/null; then
+    echo "  ✅ jq is installed"
+else
+    echo "  ⚠️  jq is not installed (required for memory scripts)"
+    echo "     Install with: brew install jq (macOS) or apt install jq (Linux)"
+fi
+echo ""
 
 mkdir -p "$INSTALL_DIR"
 mkdir -p "$SKILL_DIR"
@@ -37,8 +48,22 @@ echo "Installing memory-search skill to $SKILL_DIR..."
 cp "$SCRIPT_DIR/skills/memory-search/SKILL.md" "$SKILL_DIR/SKILL.md"
 echo "  Installed: SKILL.md"
 
+# Setup PATH
+echo ""
+echo "Configuring PATH..."
+source "$SCRIPT_DIR/scripts/shell-helpers/common.sh"
+setup_local_bin_path
+
 echo ""
 echo "Installation complete!"
 echo ""
 echo "Available commands:"
 echo "  memory-search.sh \"<query>\"   - Search conversation history"
+echo ""
+
+# Verify installation
+if command -v memory-search.sh &> /dev/null; then
+    echo "✅ Scripts are accessible in PATH"
+else
+    echo "⚠️  Restart terminal or run: source ~/.bashrc (or ~/.zshrc)"
+fi

--- a/install-messaging.sh
+++ b/install-messaging.sh
@@ -360,26 +360,11 @@ EOF
     echo ""
     print_success "Installed $PORTABLE_SCRIPT_COUNT portable agent scripts"
 
-    # Check if ~/.local/bin is in PATH
-    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-        print_warning "~/.local/bin is not in your PATH"
-        echo ""
-        echo "Add this to your ~/.zshrc or ~/.bashrc:"
-        echo ""
-        echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
-        echo ""
-        read -p "Would you like me to add it to ~/.zshrc now? (y/n): " ADD_PATH
-        if [[ "$ADD_PATH" =~ ^[Yy]$ ]]; then
-            echo "" >> ~/.zshrc
-            echo "# AI Maestro - Added by installer" >> ~/.zshrc
-            echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >> ~/.zshrc
-            print_success "Added to ~/.zshrc - restart your terminal or run: source ~/.zshrc"
-        else
-            print_warning "Skipped PATH update - scripts may not work until PATH is configured"
-        fi
-    else
-        print_success "~/.local/bin is already in PATH"
-    fi
+    # Setup PATH using shared function (works in both interactive and non-interactive mode)
+    echo ""
+    print_info "Configuring PATH..."
+    source "$PWD/scripts/shell-helpers/common.sh"
+    setup_local_bin_path
 fi
 
 # Install Claude Code skill
@@ -435,13 +420,13 @@ if [ "$INSTALL_SCRIPTS" = true ]; then
         fi
     done
 
-    # Try to find scripts in PATH
+    # Verify scripts are in PATH
     echo ""
     if command -v send-aimaestro-message.sh &> /dev/null; then
         SCRIPT_PATH=$(which send-aimaestro-message.sh)
         print_success "Scripts are accessible in PATH: $SCRIPT_PATH"
     else
-        print_warning "Scripts not in PATH yet - restart terminal or run: source ~/.zshrc"
+        print_warning "Restart terminal or run: source ~/.bashrc (or ~/.zshrc)"
     fi
 fi
 
@@ -531,7 +516,7 @@ echo ""
 
 # Show warnings if any
 if [ "$INSTALL_SCRIPTS" = true ] && ! command -v send-aimaestro-message.sh &> /dev/null; then
-    print_warning "Remember to restart your terminal or run: source ~/.zshrc"
+    print_warning "Remember to restart your terminal or run: source ~/.bashrc (or ~/.zshrc)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Added shared `setup_local_bin_path()` function to `common.sh`
- All installer scripts now properly configure PATH for `~/.local/bin`
- Works on both macOS (zsh) and Linux (bash)
- Non-interactive mode (`-y`) now properly configures PATH

## Changes
- `scripts/shell-helpers/common.sh` - Added `setup_local_bin_path()` and `verify_scripts_in_path()` functions
- `install-memory-tools.sh` - Added PATH setup and jq dependency check
- `install-graph-tools.sh` - Replaced print-only logic with actual PATH setup
- `install-doc-tools.sh` - Added PATH setup and jq dependency check
- `install-messaging.sh` - Replaced interactive-only logic with shared function

## Test plan
- [ ] Run `./install-memory-tools.sh` on fresh Ubuntu server
- [ ] Verify `memory-search.sh` is accessible after restart
- [ ] Run `./install.sh -y` (non-interactive) and verify PATH is configured

Fixes #106

🤖 Generated with [Claude Code](https://claude.ai/code)