### PR TITLE
fix: Installer scripts fail with set -e due to arithmetic increment bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.7-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-25T21:46:27.353Z",
+  "generatedAt": "2026-01-25T22:54:37.513Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.7
+**Current Version:** v0.19.8
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.19.7",
+      "softwareVersion": "0.19.8",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.7",
+      "softwareVersion": "0.19.8",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -440,7 +440,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.7</span>
+                        <span>v0.19.8</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/install-messaging.sh
+++ b/install-messaging.sh
@@ -323,7 +323,7 @@ EOF
             cp "$script" ~/.local/bin/
             chmod +x ~/.local/bin/"$SCRIPT_NAME"
             print_success "Installed: $SCRIPT_NAME"
-            ((SCRIPT_COUNT++))
+            SCRIPT_COUNT=$((SCRIPT_COUNT + 1))
         fi
     done
 
@@ -339,7 +339,7 @@ EOF
             cp "$script" ~/.local/bin/
             chmod +x ~/.local/bin/"$SCRIPT_NAME"
             print_success "Installed: $SCRIPT_NAME"
-            ((DOCS_SCRIPT_COUNT++))
+            DOCS_SCRIPT_COUNT=$((DOCS_SCRIPT_COUNT + 1))
         fi
     done
     echo ""
@@ -354,7 +354,7 @@ EOF
             cp "$script" ~/.local/bin/
             chmod +x ~/.local/bin/"$SCRIPT_NAME"
             print_success "Installed: $SCRIPT_NAME"
-            ((PORTABLE_SCRIPT_COUNT++))
+            PORTABLE_SCRIPT_COUNT=$((PORTABLE_SCRIPT_COUNT + 1))
         fi
     done
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -262,13 +262,13 @@ echo ""
 
 # Count missing items
 MISSING_COUNT=0
-if [ "$NEED_HOMEBREW" = true ]; then ((MISSING_COUNT++)); fi
-if [ "$NEED_GIT" = true ]; then ((MISSING_COUNT++)); fi
-if [ "$NEED_NODE" = true ]; then ((MISSING_COUNT++)); fi
-if [ "$NEED_YARN" = true ]; then ((MISSING_COUNT++)); fi
-if [ "$NEED_TMUX" = true ]; then ((MISSING_COUNT++)); fi
-if [ "$NEED_CLAUDE" = true ]; then ((MISSING_COUNT++)); fi
-if [ "$NEED_JQ" = true ]; then ((MISSING_COUNT++)); fi
+if [ "$NEED_HOMEBREW" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
+if [ "$NEED_GIT" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
+if [ "$NEED_NODE" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
+if [ "$NEED_YARN" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
+if [ "$NEED_TMUX" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
+if [ "$NEED_CLAUDE" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
+if [ "$NEED_JQ" = true ]; then MISSING_COUNT=$((MISSING_COUNT + 1)); fi
 
 if [ $MISSING_COUNT -eq 0 ]; then
     print_success "All prerequisites are installed!"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.7"
+VERSION="0.19.8"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/update-messaging.sh
+++ b/update-messaging.sh
@@ -116,7 +116,7 @@ if [ "$SCRIPTS_INSTALLED" = true ]; then
             cp "$script" ~/.local/bin/
             chmod +x ~/.local/bin/"$SCRIPT_NAME"
             print_success "Updated: $SCRIPT_NAME"
-            ((SCRIPT_COUNT++))
+            SCRIPT_COUNT=$((SCRIPT_COUNT + 1))
         fi
     done
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.7",
+  "version": "0.19.8",
   "releaseDate": "2026-01-25",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Fixed bash arithmetic increment bug that caused installer scripts to abort with `set -e`
- `((VAR++))` returns exit code 1 when incrementing from 0, causing script failure
- Changed to `VAR=$((VAR + 1))` which always returns exit code 0

## Files Changed
| File | Occurrences | Variables |
|------|-------------|-----------|
| `install-messaging.sh` | 3 | SCRIPT_COUNT, DOCS_SCRIPT_COUNT, PORTABLE_SCRIPT_COUNT |
| `update-messaging.sh` | 1 | SCRIPT_COUNT |
| `install.sh` | 7 | MISSING_COUNT |

## Test plan
- [x] Verified fix with: `bash -c 'set -e; VAR=0; VAR=$((VAR + 1)); echo $VAR'`
- [x] Validated syntax: `bash -n <script>.sh` for all affected files

Fixes #110

🤖 Generated with [Claude Code](https://claude.ai/code)