### PR TITLE
fix: PTY debug endpoint now correctly shows AI Maestro sessions

### DIFF
--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-26T01:16:53.689Z",
+  "generatedAt": "2026-01-26T02:33:00.401Z",
   "documentCount": 136,
   "documents": [
     {


### PR DESCRIPTION
## Summary
- Fixed `/api/debug/pty` endpoint to correctly display AI Maestro session data
- Added internal endpoint `/api/internal/pty-sessions` in server.mjs to expose session Map data
- Added `cache: 'no-store'` to prevent stale cached responses

## Problem
The debug endpoint was showing 0 active sessions because Next.js API routes run in a separate process from `server.mjs` and cannot access the global `sessions` Map.

## Solution
Created an internal endpoint that the Next.js API route calls to fetch session data from the server process.

## Test plan
- [ ] Visit `/api/debug/pty` with active terminal sessions
- [ ] Verify `aiMaestro.activeSessions` shows correct count
- [ ] Verify session details (clients, PIDs) are populated
- [ ] Refresh page multiple times to confirm no caching issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)