### PR TITLE
feat: Add Claude Code plugin marketplace for easy installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "ai-maestro-marketplace",
+  "owner": {
+    "name": "23blocks",
+    "email": "hello@23blocks.com"
+  },
+  "metadata": {
+    "description": "Official AI Maestro plugins for Claude Code - agent orchestration, memory search, code graph queries, and more",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "ai-maestro",
+      "source": "./plugin",
+      "description": "Skills for AI agent orchestration - memory search, code graph queries, documentation search, inter-agent messaging, and task planning",
+      "version": "1.0.0",
+      "author": {
+        "name": "23blocks"
+      },
+      "homepage": "https://github.com/23blocks-OS/ai-maestro",
+      "repository": "https://github.com/23blocks-OS/ai-maestro",
+      "license": "MIT",
+      "keywords": ["ai", "agents", "orchestration", "memory", "graph", "messaging"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-26T02:33:00.401Z",
+  "generatedAt": "2026-01-26T04:11:20.164Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.11
+**Current Version:** v0.19.12
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.19.11",
+      "softwareVersion": "0.19.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.11",
+      "softwareVersion": "0.19.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -440,7 +440,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.11</span>
+                        <span>v0.19.12</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.11",
+  "version": "0.19.12",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -63,7 +63,21 @@ A Claude Code plugin providing skills, hooks, and CLI scripts for AI agent orche
 
 ## Installation
 
-### Option 1: Local Development (--plugin-dir)
+### Option 1: Install from GitHub (Recommended)
+
+```bash
+# Add the AI Maestro marketplace
+/plugin marketplace add 23blocks-OS/ai-maestro
+
+# Install the plugin
+/plugin install ai-maestro@ai-maestro-marketplace
+```
+
+That's it! Skills are immediately available with the `ai-maestro:` namespace.
+
+### Option 2: Local Development (--plugin-dir)
+
+For testing or development:
 
 ```bash
 # Clone the repo
@@ -73,38 +87,15 @@ git clone https://github.com/23blocks-OS/ai-maestro.git
 claude --plugin-dir ./ai-maestro/plugin
 ```
 
-### Option 2: Add to Plugin Marketplace
+### Installing CLI Scripts (Optional)
 
-Add to your marketplace's `plugins.json`:
-
-```json
-{
-  "plugins": [
-    {
-      "id": "ai-maestro",
-      "name": "AI Maestro",
-      "description": "Skills, hooks, and scripts for AI agent orchestration",
-      "repository": "https://github.com/23blocks-OS/ai-maestro",
-      "path": "plugin"
-    }
-  ]
-}
-```
-
-Then install via:
-```
-/plugin install ai-maestro
-```
-
-### Installing CLI Scripts
-
-After plugin installation, add scripts to your PATH:
+The plugin includes 32 CLI scripts for terminal use. To install them:
 
 ```bash
-# Add to ~/.zshrc or ~/.bashrc
-export PATH="$PATH:$CLAUDE_PLUGIN_ROOT/scripts"
+# Run the installer from the repo
+./install-messaging.sh -y
 
-# Or copy to ~/.local/bin
+# Or manually copy to your PATH
 cp plugin/scripts/*.sh ~/.local/bin/
 ```
 

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.11"
+VERSION="0.19.12"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.11",
+  "version": "0.19.12",
   "releaseDate": "2026-01-25",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` for plugin distribution via Claude Code's native plugin system
- Update `plugin/README.md` with marketplace installation instructions

## Installation (after merge)
Anyone in the world can now install with two commands:
```
/plugin marketplace add 23blocks-OS/ai-maestro
/plugin install ai-maestro@ai-maestro-marketplace
```

## What this enables
- **No manual cloning** - Claude Code fetches the repo automatically
- **Version tracking** - Users get updates via `/plugin marketplace update`
- **Standard distribution** - Uses Claude Code's official plugin infrastructure

## Test plan
- [x] Validated marketplace with `claude plugin validate .`
- [x] Tested local installation with `claude plugin marketplace add /path/to/repo`
- [x] Verified all 5 skills load correctly

🤖 Generated with [Claude Code](https://claude.ai/code)