### PR TITLE
feat: Add external agent messaging support with security markers

### DIFF
--- a/plugin/scripts/check-aimaestro-messages.sh
+++ b/plugin/scripts/check-aimaestro-messages.sh
@@ -121,12 +121,14 @@ echo "$RESPONSE" | jq -r '.messages[] |
    elif .priority == "normal" then "🔵"
    else "⚪" end) +
   (if .viaSlack then " 📱" else "" end) +
+  (if .fromVerified == false then " ⚠️" else "" end) +
   " From: \u001b[36m\(.fromAlias // .from)\u001b[0m" +
   (if .fromHost and .fromHost != "local" then " @\(.fromHost)" else "" end) +
   " | \(.timestamp)\n" +
   "    Subject: \(.subject)\n" +
   "    Preview: \(.preview)" +
-  (if .viaSlack then " [via Slack]" else "" end) + "\n"'
+  (if .viaSlack then " [via Slack]" else "" end) +
+  (if .fromVerified == false then " [EXTERNAL]" else "" end) + "\n"'
 
 # Store message IDs if we need to mark as read
 if [ "$MARK_READ" = true ]; then


### PR DESCRIPTION
## Summary
- External agents (not running in AI Maestro tmux sessions) can now send/receive messages
- Security markers clearly identify messages from unverified/external senders
- Agent-first identity resolution: environment variables → tmux → git repo name

## Changes
- **lib/messageQueue.ts**: Added `fromVerified` field to mark messages from unregistered senders
- **scripts/shell-helpers/common.sh**: Refactored `init_common()` for agent-first identity
- **plugin/scripts/check-aimaestro-messages.sh**: Show ⚠️ [EXTERNAL] markers in list
- **plugin/scripts/read-aimaestro-message.sh**: Warning banner for external senders
- **plugin/skills/agent-messaging/SKILL.md**: External agent documentation

## Test plan
- [x] Send message as external agent using `AI_MAESTRO_AGENT_ID` env var
- [x] Send message using git repo name auto-detection
- [x] Verify `fromVerified: false` stored for external agents
- [x] Check script shows ⚠️ and [EXTERNAL] markers
- [x] Read script shows yellow warning banner

🤖 Generated with [Claude Code](https://claude.ai/code)