### PR TITLE
fix(messaging): mark remote AI Maestro agents as verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.15-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.22-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -135,7 +135,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { from, to, subject, content, priority, inReplyTo, fromHost, toHost, fromAlias, toAlias } = body
+    const { from, to, subject, content, priority, inReplyTo, fromHost, toHost, fromAlias, toAlias, fromLabel, toLabel, fromVerified } = body
 
     // Validate required fields
     if (!from || !to || !subject || !content) {
@@ -160,6 +160,9 @@ export async function POST(request: NextRequest) {
       toHost,
       fromAlias,
       toAlias,
+      fromLabel,
+      toLabel,
+      fromVerified,
     })
 
     // Notify target agent immediately (fire-and-forget, doesn't block response)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-26T17:02:43.511Z",
+  "generatedAt": "2026-01-26T19:29:29.099Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.15
+**Current Version:** v0.19.22
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Zero-configuration terminal multiplexer with agent-to-agent communication.",
-      "softwareVersion": "0.19.15",
+      "softwareVersion": "0.19.22",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.15",
+      "softwareVersion": "0.19.22",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -440,7 +440,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.15</span>
+                        <span>v0.19.22</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.15",
+  "version": "0.19.22",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.15"
+VERSION="0.19.22"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.15",
+  "version": "0.19.22",
   "releaseDate": "2026-01-26",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- Fix remote mesh agents incorrectly showing as external (globe icon instead of shield)
- `fromVerified` now checks if `fromHost` is a known host in the mesh network
- Pass `fromVerified` flag in cross-host message forwarding
- Add `fromLabel`/`toLabel` options for cross-host messages
- Improve message detail layout: address + timestamp on same line

## Problem

When an agent on Mac Mini (like "customers-zoom-cleo") sent a message to an agent on this host, the message was marked with the globe icon (external agent) instead of the green shield (AI Maestro agent). This happened because `resolveAgent()` only checked the LOCAL registry.

## Solution

Now `fromVerified` is determined by:
1. If explicitly provided in cross-host messages, use that
2. If sender is found in local registry → verified ✅
3. **NEW:** If `fromHost` is a known host in the mesh network → verified ✅
4. Otherwise → external (unverified)

## Test plan

- [ ] Send a message from an agent on Mac Mini to an agent on this host
- [ ] Verify the message shows green shield icon (not blue globe)
- [ ] Verify external agents (not in mesh) still show blue globe

🤖 Generated with [Claude Code](https://claude.com/claude-code)