### PR TITLE
feat: add federated email lookup across all hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.26-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.27-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/app/api/agents/email-index/route.ts
+++ b/app/api/agents/email-index/route.ts
@@ -1,6 +1,146 @@
 import { NextResponse } from 'next/server'
 import { getEmailIndex, findAgentByEmail, getAgent, getAgentEmailAddresses } from '@/lib/agent-registry'
-import type { EmailIndexResponse } from '@/types/agent'
+import { getHosts, getSelfHostId, isSelf } from '@/lib/hosts-config'
+import { getPublicUrl } from '@/lib/host-sync'
+import type { EmailIndexResponse, FederatedEmailIndexResponse } from '@/types/agent'
+
+const FEDERATED_TIMEOUT = 5000 // 5 seconds per host
+
+/**
+ * Fetch email index from a remote host
+ */
+async function fetchRemoteEmailIndex(
+  hostUrl: string,
+  addressQuery?: string
+): Promise<{ success: boolean; data?: EmailIndexResponse; error?: string }> {
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), FEDERATED_TIMEOUT)
+
+    // Build URL with optional address filter
+    let url = `${hostUrl}/api/agents/email-index`
+    if (addressQuery) {
+      url += `?address=${encodeURIComponent(addressQuery)}`
+    }
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'X-Federated-Query': 'true', // Prevent infinite recursion
+      },
+    })
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      return { success: false, error: `HTTP ${response.status}` }
+    }
+
+    const data: EmailIndexResponse = await response.json()
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * Perform federated email index lookup across all known hosts
+ */
+async function federatedEmailLookup(
+  addressQuery?: string
+): Promise<FederatedEmailIndexResponse> {
+  const startTime = Date.now()
+  const hosts = getHosts()
+  const selfHostId = getSelfHostId()
+  const selfUrl = getPublicUrl()
+
+  const aggregatedEmails: EmailIndexResponse = {}
+  const hostsFailed: string[] = []
+  let hostsSucceeded = 0
+
+  // Get local emails first
+  let localIndex: EmailIndexResponse
+  if (addressQuery) {
+    const agentId = findAgentByEmail(addressQuery)
+    if (agentId) {
+      const agent = getAgent(agentId)
+      const addresses = getAgentEmailAddresses(agentId)
+      const matchingAddr = addresses.find(
+        a => a.address.toLowerCase() === addressQuery.toLowerCase()
+      )
+      if (agent && matchingAddr) {
+        localIndex = {
+          [matchingAddr.address.toLowerCase()]: {
+            agentId: agent.id,
+            agentName: agent.name || agent.alias || 'unknown',
+            hostId: agent.hostId || selfHostId,
+            hostUrl: selfUrl,
+            displayName: matchingAddr.displayName,
+            primary: matchingAddr.primary || false,
+            metadata: matchingAddr.metadata,
+          }
+        }
+      } else {
+        localIndex = {}
+      }
+    } else {
+      localIndex = {}
+    }
+  } else {
+    localIndex = getEmailIndex()
+  }
+
+  // Add hostUrl to local entries
+  for (const [email, entry] of Object.entries(localIndex)) {
+    aggregatedEmails[email] = {
+      ...entry,
+      hostUrl: selfUrl,
+    }
+  }
+  hostsSucceeded++
+
+  // Query remote hosts in parallel
+  const remoteHosts = hosts.filter(h => !isSelf(h.id) && h.enabled)
+
+  const remoteResults = await Promise.all(
+    remoteHosts.map(async (host) => {
+      const result = await fetchRemoteEmailIndex(host.url, addressQuery)
+      return { hostId: host.id, hostUrl: host.url, ...result }
+    })
+  )
+
+  // Aggregate results
+  for (const result of remoteResults) {
+    if (result.success && result.data) {
+      hostsSucceeded++
+      // Add entries with hostUrl
+      for (const [email, entry] of Object.entries(result.data)) {
+        // Don't overwrite if we already have this email (first host wins)
+        if (!aggregatedEmails[email]) {
+          aggregatedEmails[email] = {
+            ...entry,
+            hostUrl: result.hostUrl,
+          }
+        }
+      }
+    } else {
+      hostsFailed.push(result.hostId)
+      console.warn(`[Email Index] Failed to query ${result.hostId}: ${result.error}`)
+    }
+  }
+
+  return {
+    emails: aggregatedEmails,
+    meta: {
+      federated: true,
+      hostsQueried: 1 + remoteHosts.length, // self + remotes
+      hostsSucceeded,
+      hostsFailed,
+      queryTime: Date.now() - startTime,
+    }
+  }
+}
 
 /**
  * GET /api/agents/email-index
@@ -11,15 +151,29 @@ import type { EmailIndexResponse } from '@/types/agent'
  * Query parameters:
  *   ?address=email@example.com - Lookup single address
  *   ?agentId=uuid-123 - Get all addresses for an agent
+ *   ?federated=true - Query all known hosts (not just local)
  *
- * Response format:
+ * Response format (standard):
  * {
  *   "email@example.com": {
  *     "agentId": "uuid-...",
  *     "agentName": "my-agent",
  *     "hostId": "mac-mini",
+ *     "hostUrl": "http://100.x.x.x:23000",
  *     "displayName": "My Agent",
  *     "primary": true
+ *   }
+ * }
+ *
+ * Response format (federated):
+ * {
+ *   "emails": { ... },
+ *   "meta": {
+ *     "federated": true,
+ *     "hostsQueried": 3,
+ *     "hostsSucceeded": 2,
+ *     "hostsFailed": ["offline-host"],
+ *     "queryTime": 234
  *   }
  * }
  */
@@ -28,8 +182,18 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
     const addressQuery = searchParams.get('address')
     const agentIdQuery = searchParams.get('agentId')
+    const federated = searchParams.get('federated') === 'true'
 
-    // Single address lookup
+    // Check if this is a federated sub-query (prevent infinite recursion)
+    const isFederatedSubQuery = request.headers.get('X-Federated-Query') === 'true'
+
+    // Federated lookup (query all hosts)
+    if (federated && !isFederatedSubQuery) {
+      const result = await federatedEmailLookup(addressQuery || undefined)
+      return NextResponse.json(result)
+    }
+
+    // Single address lookup (local only)
     if (addressQuery) {
       const agentId = findAgentByEmail(addressQuery)
       if (!agentId) {
@@ -55,6 +219,7 @@ export async function GET(request: Request) {
           agentId: agent.id,
           agentName: agent.name || agent.alias || 'unknown',
           hostId: agent.hostId || 'local',
+          hostUrl: getPublicUrl(),
           displayName: matchingAddr.displayName,
           primary: matchingAddr.primary || false,
           metadata: matchingAddr.metadata,
@@ -73,12 +238,14 @@ export async function GET(request: Request) {
 
       const addresses = getAgentEmailAddresses(agentIdQuery)
       const result: EmailIndexResponse = {}
+      const hostUrl = getPublicUrl()
 
       for (const addr of addresses) {
         result[addr.address.toLowerCase()] = {
           agentId: agent.id,
           agentName: agent.name || agent.alias || 'unknown',
           hostId: agent.hostId || 'local',
+          hostUrl,
           displayName: addr.displayName,
           primary: addr.primary || false,
           metadata: addr.metadata,
@@ -88,9 +255,20 @@ export async function GET(request: Request) {
       return NextResponse.json(result)
     }
 
-    // Return full index
+    // Return full index (local only)
     const index = getEmailIndex()
-    return NextResponse.json(index)
+    const hostUrl = getPublicUrl()
+
+    // Add hostUrl to each entry
+    const enrichedIndex: EmailIndexResponse = {}
+    for (const [email, entry] of Object.entries(index)) {
+      enrichedIndex[email] = {
+        ...entry,
+        hostUrl,
+      }
+    }
+
+    return NextResponse.json(enrichedIndex)
 
   } catch (error) {
     console.error('Failed to get email index:', error)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-27T16:29:25.632Z",
+  "generatedAt": "2026-01-27T19:18:29.639Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/AGENT-EMAIL-IDENTITY-SPEC.md
+++ b/docs/AGENT-EMAIL-IDENTITY-SPEC.md
@@ -136,6 +136,45 @@ Returns a mapping of email addresses to agent identity. Consumers use this to bu
 **Query parameters:**
 - `?address=titania@23blocks.23smartagents.com` - lookup single address
 - `?agentId=uuid-123` - get all addresses for an agent
+- `?federated=true` - query ALL known hosts (not just local)
+
+### Federated Lookup
+
+When `?federated=true` is specified, the endpoint queries all known hosts in the mesh and aggregates results. This is useful for gateways that need to find an agent by email without knowing which host it's on.
+
+**Request:**
+```
+GET /api/agents/email-index?address=titania@23blocks.23smartagents.com&federated=true
+```
+
+**Response:**
+```json
+{
+  "emails": {
+    "titania@23blocks.23smartagents.com": {
+      "agentId": "uuid-23blocks-iac",
+      "agentName": "23blocks-iac",
+      "hostId": "mac-mini",
+      "hostUrl": "http://100.x.x.x:23000",
+      "displayName": "Titania",
+      "primary": true
+    }
+  },
+  "meta": {
+    "federated": true,
+    "hostsQueried": 3,
+    "hostsSucceeded": 2,
+    "hostsFailed": ["offline-host"],
+    "queryTime": 234
+  }
+}
+```
+
+**Notes:**
+- `hostUrl` is included so gateways know where to route requests
+- Hosts are queried in parallel with a 5-second timeout per host
+- Duplicate email addresses: first host wins (no conflicts across hosts due to uniqueness enforcement)
+- The `meta` object provides visibility into query performance and failed hosts
 
 ### Email Address Management
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.26
+**Current Version:** v0.19.27
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.19.26",
+      "softwareVersion": "0.19.27",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.26",
+      "softwareVersion": "0.19.27",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -442,7 +442,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.26</span>
+                        <span>v0.19.27</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.26",
+  "version": "0.19.27",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.26"
+VERSION="0.19.27"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -428,9 +428,25 @@ export interface EmailIndexEntry {
   agentId: string
   agentName: string
   hostId: string
+  hostUrl?: string  // URL to reach the host (for federated lookups)
   displayName?: string
   primary: boolean
   metadata?: Record<string, string>
+}
+
+/**
+ * Response from federated email-index query
+ * Includes metadata about which hosts were queried
+ */
+export interface FederatedEmailIndexResponse {
+  emails: EmailIndexResponse
+  meta: {
+    federated: true
+    hostsQueried: number
+    hostsSucceeded: number
+    hostsFailed: string[]  // IDs of hosts that failed
+    queryTime: number      // ms
+  }
 }
 
 /**

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.26",
+  "version": "0.19.27",
   "releaseDate": "2026-01-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
Adds federated email lookup capability to query all known hosts in the mesh and aggregate results. This allows external gateways to find an agent by email without knowing which host it's on.

## What's New

### Federated Query Parameter
```
GET /api/agents/email-index?address=test@example.com&federated=true
```

### Response Format (federated)
```json
{
  "emails": {
    "test@example.com": {
      "agentId": "uuid-...",
      "agentName": "my-agent",
      "hostId": "mac-mini",
      "hostUrl": "http://100.x.x.x:23000",
      "displayName": "Test",
      "primary": true
    }
  },
  "meta": {
    "federated": true,
    "hostsQueried": 3,
    "hostsSucceeded": 2,
    "hostsFailed": ["offline-host"],
    "queryTime": 234
  }
}
```

### Key Features
- **Parallel queries** - All hosts queried simultaneously with 5s timeout
- **hostUrl included** - Gateways know where to route requests
- **Query metadata** - Visibility into performance and failed hosts
- **Recursion prevention** - X-Federated-Query header prevents infinite loops

## Why This Matters
Before: Gateways had to query each host's email-index separately to find an agent
After: Single federated query returns the agent from whichever host it's on

## Test Plan
- [ ] `curl localhost:23000/api/agents/email-index` - returns local only
- [ ] `curl localhost:23000/api/agents/email-index?federated=true` - returns all hosts
- [ ] `curl localhost:23000/api/agents/email-index?address=x@y.com&federated=true` - single lookup
- [ ] Verify offline hosts appear in `hostsFailed` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)