### PR TITLE
fix(skill): simplify agent-messaging to prevent identity confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.27-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.28-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-27T19:18:29.639Z",
+  "generatedAt": "2026-01-27T19:47:02.516Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.27
+**Current Version:** v0.19.28
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.19.27",
+      "softwareVersion": "0.19.28",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.27",
+      "softwareVersion": "0.19.28",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -442,7 +442,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.27</span>
+                        <span>v0.19.28</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.27",
+  "version": "0.19.28",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/plugin/skills/agent-messaging/SKILL.md
+++ b/plugin/skills/agent-messaging/SKILL.md
@@ -29,56 +29,25 @@ When the human operator says "check your messages" or "read your messages":
 - These are messages addressed TO `backend-api` (from any sender)
 - You DO NOT check: The operator's inbox or any other agent's inbox
 
-### Agent Identity
+### Agent Identity - AUTOMATIC, DO NOT SET MANUALLY
 
-- **Your inbox** = Messages addressed TO YOUR AGENT (from any sender)
-- **Your agent ID** = Unique identifier for this agent
-- **Your agent alias** = Human-friendly name for the agent (e.g., `backend-api`, `crm`)
-- **Your inbox location** = `~/.aimaestro/messages/inbox/YOUR-AGENT-ID/`
+**Your identity is detected automatically.** Just use the messaging scripts - they handle everything.
 
-**Identity Resolution (Priority Order):**
-1. **Environment variable** - `AI_MAESTRO_AGENT_ID` (explicit override)
-2. **Structured session name** - Parsed from tmux session if format is `agent@host`
-3. **Working directory** - Lookup agent in registry by workingDirectory
-4. **Git repo name** - Auto-detected from current repository (fallback)
+- **Your inbox** = Messages addressed TO YOUR AGENT
+- **Your agent alias** = Your name (e.g., `backend-api`, `lola`, `crm`)
+- **Your inbox location** = Handled automatically by the scripts
 
-**Note:** tmux is NOT required. External agents can set their identity via environment variable, run from an agent's working directory, or run from a git repository for auto-detection.
+**DO NOT:**
+- ❌ Set environment variables manually
+- ❌ Prefix messages with your agent ID
+- ❌ Try to configure your identity
 
-### External Agents (Not in AI Maestro)
+**JUST DO:**
+- ✅ Run `check-aimaestro-messages.sh` to check your inbox
+- ✅ Run `send-aimaestro-message.sh <target> <subject> <message>` to send
+- ✅ Run `reply-aimaestro-message.sh <msg-id> <reply>` to reply
 
-External agents are AI agents running **outside** of AI Maestro's tmux sessions. They can still send and receive messages using the messaging system.
-
-**Setting Identity for External Agents:**
-```bash
-# Option 1: Explicit identity via environment variable
-export AI_MAESTRO_AGENT_ID="my-project"
-export AI_MAESTRO_HOST_ID="my-hostname"  # Optional, defaults to current host
-
-# Option 2: Auto-detect from git repo (just run from within a git repository)
-cd /path/to/my-repo
-# Identity will be "my-repo" (the repo folder name)
-```
-
-**Using Messaging as External Agent:**
-```bash
-# Set identity
-export AI_MAESTRO_AGENT_ID="my-project"
-
-# Send messages
-send-aimaestro-message.sh lola@mini-lola "Hello" "Message from external agent"
-
-# Check your inbox
-check-aimaestro-messages.sh
-
-# Read messages
-read-aimaestro-message.sh msg-123...
-```
-
-**How Replies Work:**
-- When you send a message, your identity (`my-project@hostname`) is included
-- Recipients can reply to your identity
-- Replies are delivered to `~/.aimaestro/messages/inbox/my-project/`
-- Check your inbox to see replies
+The scripts detect who you are automatically from your tmux session or working directory.
 
 **You do NOT read:**
 - ❌ The operator's inbox
@@ -320,19 +289,13 @@ check-new-messages-arrived.sh
 ```
 
 ### 5. Read Specific Message FROM YOUR Inbox (Direct File Access - Advanced)
-**Command:**
+
+**NOTE:** Prefer using `read-aimaestro-message.sh` instead - it handles everything automatically.
+
+**Command (if needed):**
 ```bash
-# If in tmux:
 cat ~/.aimaestro/messages/inbox/$(tmux display-message -p '#S')/<message-id>.json | jq
-
-# If external agent:
-cat ~/.aimaestro/messages/inbox/$AI_MAESTRO_AGENT_ID/<message-id>.json | jq
 ```
-
-**What it does:**
-- Read a specific message file from YOUR inbox
-- Use `jq` for pretty formatting
-- Useful when you know the message ID
 
 **Directory structure:**
 ```
@@ -343,23 +306,6 @@ cat ~/.aimaestro/messages/inbox/$AI_MAESTRO_AGENT_ID/<message-id>.json | jq
 │   └── msg_*.json
 └── archived/YOUR-AGENT-ID/  # YOUR archived messages
     └── msg_*.json
-```
-
-**Example:**
-```bash
-# For tmux agents - get YOUR session name
-tmux display-message -p '#S'
-# Output: frontend-dev  ← This is YOU
-
-# For external agents - use your identity
-echo $AI_MAESTRO_AGENT_ID
-# Output: my-project  ← This is YOU
-
-# List all messages in YOUR inbox
-ls ~/.aimaestro/messages/inbox/my-project/
-
-# Read specific message sent TO YOU
-cat ~/.aimaestro/messages/inbox/my-project/msg_1234567890_abcde.json | jq
 ```
 
 ### 4. Mark Message as Read (via API)
@@ -762,26 +708,6 @@ send-aimaestro-message.sh backend-architect \
 
 ### RECEIVING Examples (Checking YOUR OWN Inbox)
 
-#### Scenario R0: External Agent Checking Messages
-```bash
-# YOU are an external agent (not running in AI Maestro tmux)
-# Set your identity
-export AI_MAESTRO_AGENT_ID="my-project"
-
-# Check your inbox
-check-aimaestro-messages.sh
-# Output shows messages sent TO my-project:
-# [msg-123...] 🔵 From: lola@mini-lola | 2025-01-26 10:30
-#     Subject: Re: Question about API
-#     Preview: Here's the answer you asked for...
-
-# Read the message
-read-aimaestro-message.sh msg-123...
-
-# Reply
-reply-aimaestro-message.sh msg-123... "Thanks for the help!"
-```
-
 #### Scenario R1: Responding to Message Notifications
 ```bash
 # YOU are agent "frontend-dev"
@@ -888,26 +814,6 @@ reply-aimaestro-message.sh msg-slack-123... "The auth API is 80% complete. Login
 ```
 
 ### SENDING Examples
-
-#### Scenario S0: External Agent Sending Messages
-```bash
-# YOU are an external agent (not running in AI Maestro tmux)
-# Set your identity
-export AI_MAESTRO_AGENT_ID="my-project"
-
-# Send a message to an AI Maestro agent
-send-aimaestro-message.sh lola@mini-lola \
-  "Need help with database schema" \
-  "Can you review the schema design in /docs/schema.md?" \
-  normal \
-  request
-
-# Output:
-# ✅ Message sent
-#    From: my-project@juans-macbook-pro
-#    To: lola@mini-lola
-#    Subject: Need help with database schema
-```
 
 #### Scenario S1: Request Work from Another Agent
 ```bash

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.27"
+VERSION="0.19.28"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.27",
+  "version": "0.19.28",
   "releaseDate": "2026-01-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Problem
Agents were reading the agent-messaging skill and incorrectly trying to set `AI_MAESTRO_AGENT_ID` environment variable, causing message delivery failures.

## Root Cause
The skill had an "External Agents" section with instructions to manually set environment variables. Agents running inside AI Maestro were reading these instructions and getting confused about their identity.

## Fix
- Removed all references to `AI_MAESTRO_AGENT_ID`
- Removed "External Agents" section with confusing examples
- Replaced identity docs with simple "AUTOMATIC, DO NOT SET MANUALLY"
- Removed scenarios R0 and S0 showing manual identity setup
- Emphasized: just use the scripts, they handle everything

## Before
```markdown
**Identity Resolution (Priority Order):**
1. **Environment variable** - `AI_MAESTRO_AGENT_ID` (explicit override)
2. **Structured session name** - ...

**Setting Identity for External Agents:**
export AI_MAESTRO_AGENT_ID="my-project"
```

## After
```markdown
### Agent Identity - AUTOMATIC, DO NOT SET MANUALLY

**Your identity is detected automatically.** Just use the messaging scripts.

**DO NOT:**
- ❌ Set environment variables manually
- ❌ Prefix messages with your agent ID
```

## Test Plan
- [ ] Agents stop using AI_MAESTRO_AGENT_ID incorrectly
- [ ] Message delivery returns to normal
- [ ] Scripts still auto-detect identity correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)