### PR TITLE
fix(skill): restore external agent docs with clear warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.19.28-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.19.29-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-01-27T19:47:02.516Z",
+  "generatedAt": "2026-01-27T20:27:53.889Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.19.28
+**Current Version:** v0.19.29
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.19.28",
+      "softwareVersion": "0.19.29",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.19.28",
+      "softwareVersion": "0.19.29",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -442,7 +442,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.19.28</span>
+                        <span>v0.19.29</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.19.28",
+  "version": "0.19.29",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/plugin/skills/agent-messaging/SKILL.md
+++ b/plugin/skills/agent-messaging/SKILL.md
@@ -49,6 +49,36 @@ When the human operator says "check your messages" or "read your messages":
 
 The scripts detect who you are automatically from your tmux session or working directory.
 
+---
+
+### ONLY FOR EXTERNAL AGENTS (Skip if you're in AI Maestro)
+
+⚠️ **READ THIS FIRST:** If you are running inside AI Maestro (in a tmux session managed by the dashboard), **SKIP THIS SECTION**. Your identity is automatic. The section below is ONLY for agents running OUTSIDE of AI Maestro.
+
+**What is an "External Agent"?**
+- An agent running in a separate Claude Code instance (not managed by AI Maestro)
+- An agent in CI/CD pipelines
+- An agent on a machine without AI Maestro installed
+- NOT you, if you see tmux sessions in the AI Maestro dashboard
+
+**For External Agents ONLY:**
+```bash
+# Set identity ONLY if you're external (not in AI Maestro)
+export AI_MAESTRO_AGENT_ID="my-project"
+export AI_MAESTRO_HOST_ID="my-hostname"  # Optional
+
+# Then use messaging normally
+send-aimaestro-message.sh lola@mini-lola "Hello" "Message from external"
+check-aimaestro-messages.sh
+```
+
+**How to know if you're external:**
+- You DON'T see yourself in the AI Maestro dashboard
+- You're NOT in a tmux session named after an agent
+- You're running from a random directory, not an agent's workingDirectory
+
+---
+
 **You do NOT read:**
 - ❌ The operator's inbox
 - ❌ Other agents' inboxes
@@ -963,6 +993,51 @@ send-aimaestro-message.sh frontend-dev \
 - Use `list-agents.sh` to see all agents on local host
 - Use `list-agents.sh <host-id>` to see agents on a specific remote host
 - Try partial names - fuzzy matching handles typos and abbreviations
+
+---
+
+## APPENDIX: External Agents (ONLY if not in AI Maestro)
+
+⚠️ **SKIP THIS SECTION** if you're running inside AI Maestro. This is ONLY for agents that:
+- Are NOT managed by the AI Maestro dashboard
+- Are NOT in a tmux session
+- Are running from CI/CD, external scripts, or separate machines
+
+### External Agent Setup
+```bash
+# ONLY do this if you're external (not in AI Maestro)
+export AI_MAESTRO_AGENT_ID="my-project"
+export AI_MAESTRO_HOST_ID="my-hostname"  # Optional, defaults to current host
+```
+
+### External Agent Example: Checking Messages
+```bash
+# Set identity (ONLY if external)
+export AI_MAESTRO_AGENT_ID="my-project"
+
+# Check inbox
+check-aimaestro-messages.sh
+
+# Read message
+read-aimaestro-message.sh msg-123...
+
+# Reply
+reply-aimaestro-message.sh msg-123... "Thanks!"
+```
+
+### External Agent Example: Sending Messages
+```bash
+# Set identity (ONLY if external)
+export AI_MAESTRO_AGENT_ID="my-project"
+
+# Send message to AI Maestro agent
+send-aimaestro-message.sh lola@mini-lola \
+  "Need help with schema" \
+  "Can you review /docs/schema.md?" \
+  normal request
+```
+
+---
 
 ## References
 

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.19.28"
+VERSION="0.19.29"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.19.28",
+  "version": "0.19.29",
   "releaseDate": "2026-01-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## What Changed

Restores external agent documentation that was accidentally removed in PR #131, but with much clearer separation to prevent confusion.

## Structure Now

**Main Section (for AI Maestro agents):**
```markdown
### Agent Identity - AUTOMATIC, DO NOT SET MANUALLY
DO NOT:
- ❌ Set environment variables manually
- ❌ Prefix messages with your agent ID
```

**Middle Section (clear separator):**
```markdown
### ONLY FOR EXTERNAL AGENTS (Skip if you're in AI Maestro)
⚠️ READ THIS FIRST: If you are running inside AI Maestro... SKIP THIS SECTION
```

**Appendix (at end of file):**
```markdown
## APPENDIX: External Agents (ONLY if not in AI Maestro)
⚠️ SKIP THIS SECTION if you're running inside AI Maestro
```

## Why This Matters
- AI Maestro agents: See "AUTOMATIC, DO NOT SET" first
- External agents: Still have full setup instructions
- Clear warnings prevent confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)