### PR TITLE
feat(agents): unified programArgs with first-launch resume stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.20.16-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.20.17-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/app/api/sessions/create/route.ts
+++ b/app/api/sessions/create/route.ts
@@ -49,7 +49,7 @@ async function httpPost(url: string, body: any, timeout: number = 10000): Promis
 
 export async function POST(request: Request) {
   try {
-    const { name, workingDirectory, agentId, hostId, label, avatar } = await request.json()
+    const { name, workingDirectory, agentId, hostId, label, avatar, programArgs } = await request.json()
 
     if (!name || typeof name !== 'string') {
       return NextResponse.json({ error: 'Session name is required' }, { status: 400 })
@@ -169,7 +169,8 @@ export async function POST(request: Request) {
           tags,
           owner: os.userInfo().username,
           createSession: true,
-          workingDirectory: cwd
+          workingDirectory: cwd,
+          programArgs: programArgs || '',
         })
         console.log(`[Sessions] Registered new agent: ${agentName} (${registeredAgent.id})`)
       } catch (createError) {

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -612,14 +612,14 @@ export default function AgentList({
     }
   }
 
-  const handleCreateAgent = async (name: string, workingDirectory?: string, hostId?: string, label?: string, avatar?: string): Promise<boolean> => {
+  const handleCreateAgent = async (name: string, workingDirectory?: string, hostId?: string, label?: string, avatar?: string, programArgs?: string): Promise<boolean> => {
     setActionLoading(true)
 
     try {
       const response = await fetch('/api/sessions/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, workingDirectory, hostId, label, avatar }),
+        body: JSON.stringify({ name, workingDirectory, hostId, label, avatar, programArgs }),
       })
 
       if (!response.ok) {
@@ -1569,13 +1569,14 @@ function CreateAgentModal({
   loading,
 }: {
   onClose: () => void
-  onCreate: (name: string, workingDirectory?: string, hostId?: string, label?: string, avatar?: string) => Promise<boolean>
+  onCreate: (name: string, workingDirectory?: string, hostId?: string, label?: string, avatar?: string, programArgs?: string) => Promise<boolean>
   onComplete: () => void
   loading: boolean
 }) {
   const { hosts } = useHosts()
   const [name, setName] = useState('')
   const [workingDirectory, setWorkingDirectory] = useState('')
+  const [programArgs, setProgramArgs] = useState('')
   const [selectedHostId, setSelectedHostId] = useState<string>('')
   const [animationPhase, setAnimationPhase] = useState<'naming' | 'preparing' | 'creating' | 'ready' | 'error'>('creating')
 
@@ -1714,7 +1715,7 @@ function CreateAgentModal({
       const personaName = getRandomAlias(name.trim())
       const avatarUrl = getPreviewAvatarUrl(name.trim())
       // Pass selectedHostId to create agent on the chosen host
-      const success = await onCreate(name.trim(), workingDirectory.trim() || undefined, selectedHostId || undefined, personaName, avatarUrl)
+      const success = await onCreate(name.trim(), workingDirectory.trim() || undefined, selectedHostId || undefined, personaName, avatarUrl, programArgs.trim() || undefined)
       if (success) {
         setCreationSuccess(true)
         // Animation continues, user will click "Let's Go!" to close
@@ -1802,6 +1803,22 @@ function CreateAgentModal({
                     placeholder={typeof process !== 'undefined' ? process.env?.HOME || '/home/user' : '/home/user'}
                     className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   />
+                </div>
+                <div>
+                  <label htmlFor="program-args" className="block text-sm font-medium text-gray-300 mb-1">
+                    Program Arguments (optional)
+                  </label>
+                  <input
+                    id="program-args"
+                    type="text"
+                    value={programArgs}
+                    onChange={(e) => setProgramArgs(e.target.value)}
+                    placeholder="--continue --chrome"
+                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    CLI flags passed to the program on launch (e.g. --continue --chrome)
+                  </p>
                 </div>
                 {hosts.length > 1 && (
                   <HostSelector

--- a/components/AgentProfile.tsx
+++ b/components/AgentProfile.tsx
@@ -8,7 +8,7 @@ import {
   ChevronDown, ChevronRight, Plus, Trash2, TrendingUp, TrendingDown,
   Cloud, Monitor, Server, Play, Wifi, WifiOff, Folder, Download, Send,
   GitBranch, FolderGit2, RefreshCw, ExternalLink, AlertTriangle, Brain,
-  FolderTree
+  FolderTree, Terminal
 } from 'lucide-react'
 import type { Agent, AgentDocumentation, AgentSessionStatus, Repository } from '@/types/agent'
 import TransferAgentDialog from './TransferAgentDialog'
@@ -522,6 +522,13 @@ export default function AgentProfile({ isOpen, onClose, agentId, sessionStatus, 
                       onChange={(value) => updateField('taskDescription', value)}
                       icon={<Code2 className="w-4 h-4" />}
                       multiline
+                    />
+
+                    <EditableField
+                      label="Program Arguments (e.g. --continue)"
+                      value={agent.programArgs || ''}
+                      onChange={(value) => updateField('programArgs', value)}
+                      icon={<Terminal className="w-4 h-4" />}
                     />
 
                     {/* Tags - Control sidebar tree position */}
@@ -1197,7 +1204,7 @@ function EditableField({ label, value, onChange, icon, placeholder, multiline }:
           onClick={() => setIsEditing(true)}
           className="px-3 py-2 rounded-lg hover:bg-gray-700/50 cursor-text transition-all group hover:ring-2 hover:ring-gray-600 min-h-[40px]"
         >
-          <span className="text-gray-200">{value || placeholder || 'Click to edit'}</span>
+          <span className={value ? 'text-gray-200' : 'text-gray-500'}>{value || placeholder || 'Click to edit'}</span>
           <Edit2 className="w-3 h-3 ml-2 inline opacity-0 group-hover:opacity-100 transition-opacity text-gray-400" />
         </div>
       )}

--- a/components/zoom/AgentProfileTab.tsx
+++ b/components/zoom/AgentProfileTab.tsx
@@ -8,7 +8,7 @@ import {
   ChevronDown, ChevronRight, Trash2,
   Cloud, Monitor, Wifi, WifiOff, Folder, Download, Send,
   GitBranch, FolderGit2, RefreshCw, AlertTriangle,
-  FolderTree, X
+  FolderTree, X, Terminal
 } from 'lucide-react'
 import type { Agent, AgentDocumentation, Repository } from '@/types/agent'
 import TransferAgentDialog from '@/components/TransferAgentDialog'
@@ -399,6 +399,13 @@ export default function AgentProfileTab({ agent: initialAgent, hostUrl, onClose 
                 onChange={(value) => updateField('taskDescription', value)}
                 icon={<Code2 className="w-4 h-4" />}
                 multiline
+              />
+
+              <EditableField
+                label="Program Arguments (e.g. --continue)"
+                value={agent.programArgs || ''}
+                onChange={(value) => updateField('programArgs', value)}
+                icon={<Terminal className="w-4 h-4" />}
               />
 
               {/* Tags */}

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-02-06T20:35:34.927Z",
+  "generatedAt": "2026-02-06T22:47:21.847Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.20.16
+**Current Version:** v0.20.17
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.20.16",
+      "softwareVersion": "0.20.17",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.20.16",
+      "softwareVersion": "0.20.17",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -444,7 +444,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.20.16</span>
+                        <span>v0.20.17</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.20.16",
+  "version": "0.20.17",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.20.16"
+VERSION="0.20.17"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -171,6 +171,8 @@ export interface Agent {
   program: string               // AI program (e.g., "Claude Code", "Aider", "Cursor")
   model?: string                // Model version (e.g., "Opus 4.1", "GPT-4")
   taskDescription: string       // What this agent is working on
+  programArgs?: string          // CLI arguments passed to the program on launch (e.g., "--continue --chrome")
+  launchCount?: number          // Number of times agent has been woken/launched (0 = never launched)
   tags?: string[]               // Optional tags (e.g., ["backend", "api", "typescript"])
   capabilities?: string[]       // Technical capabilities (e.g., ["typescript", "postgres"])
 
@@ -425,6 +427,7 @@ export interface CreateAgentRequest {
   program: string
   model?: string
   taskDescription: string
+  programArgs?: string          // CLI arguments passed to the program on launch
   tags?: string[]
   workingDirectory?: string
   createSession?: boolean       // Auto-create tmux session
@@ -449,6 +452,7 @@ export interface UpdateAgentRequest {
   avatar?: string
   model?: string
   taskDescription?: string
+  programArgs?: string          // CLI arguments passed to the program on launch
   tags?: string[]
   owner?: string
   team?: string

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.16",
+  "version": "0.20.17",
   "releaseDate": "2026-02-06",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

Based on PR #163 by @Emasoft — cherry-picked, fixed, and improved.

- **Unified field**: Rename `claudeArgs` → `programArgs` across types, UI, API, and CLI
- **First-launch detection**: New `launchCount` field; on first wake, resume flags are stripped since there's no session to resume
- **Per-program patterns**: Claude (`--continue`), Codex (`resume --last`), Gemini (`--resume`), Aider (`--restore-chat-history`), OpenCode (`--continue`), Cursor (`--resume`)
- **Create wizard**: New "Program Arguments" input with placeholder
- **CLI**: New `--args` option for update, `skill install/uninstall`, `plugin update/load`
- **Auto-migration**: Existing `claudeArgs` migrated to `programArgs` on load

### Security fixes (not in original PR)
- **Command injection fix**: `programArgs` is sanitized before shell interpolation in wake route — strips shell metacharacters (`; | $ \` "` etc.)
- **Regex global flag**: Resume patterns now use `/g` to strip all occurrences, not just the first

### Attribution
Original work by @Emasoft (PR #163). Supersedes that PR.

## Test plan
- [ ] Create agent via UI with programArgs → verify stored in registry
- [ ] Wake agent first time → `--continue` stripped from command
- [ ] Wake agent second time → full args used
- [ ] Edit programArgs in Agent Profile → verify saved
- [ ] Old agents with `claudeArgs` → auto-migrated on load
- [ ] Verify shell injection blocked: set programArgs to `; echo pwned` → sanitized to `echo pwned`
- [ ] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)