### PR TITLE
fix(installer): auto-initialize git submodules during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.20.17-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.20.18-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-02-06T22:47:21.847Z",
+  "generatedAt": "2026-02-06T23:29:10.881Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.20.17
+**Current Version:** v0.20.18
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.20.17",
+      "softwareVersion": "0.20.18",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.20.17",
+      "softwareVersion": "0.20.18",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -444,7 +444,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.20.17</span>
+                        <span>v0.20.18</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/install-messaging.sh
+++ b/install-messaging.sh
@@ -89,15 +89,30 @@ print_info() {
 }
 
 # Check if we're in the right directory
-if [ ! -d "plugins/amp-messaging" ]; then
-    print_error "Error: AMP plugin not found. Run from AI Maestro root directory."
-    echo ""
-    echo "If this is a fresh clone, initialize submodules:"
-    echo "  git submodule update --init --recursive"
-    echo ""
-    echo "Then run:"
-    echo "  ./install-messaging.sh"
-    exit 1
+if [ ! -d "plugins/amp-messaging" ] || [ ! -f "plugins/amp-messaging/plugin.json" ]; then
+    # Try to auto-initialize the submodule
+    if [ -f ".gitmodules" ] && command -v git &> /dev/null; then
+        print_warning "AMP plugin submodule not initialized. Initializing now..."
+        git submodule update --init --recursive
+        if [ -d "plugins/amp-messaging" ] && [ -f "plugins/amp-messaging/plugin.json" ]; then
+            print_success "Submodule initialized"
+        else
+            print_error "Error: Failed to initialize AMP plugin submodule."
+            echo ""
+            echo "Try manually:"
+            echo "  git submodule update --init --recursive"
+            exit 1
+        fi
+    else
+        print_error "Error: AMP plugin not found. Run from AI Maestro root directory."
+        echo ""
+        echo "If this is a fresh clone, initialize submodules:"
+        echo "  git submodule update --init --recursive"
+        echo ""
+        echo "Then run:"
+        echo "  ./install-messaging.sh"
+        exit 1
+    fi
 fi
 
 # Migration function

--- a/install.sh
+++ b/install.sh
@@ -509,9 +509,15 @@ if [ -n "$INSTALL_DIR" ]; then
         print_success "Repository cloned"
     fi
 
+    cd "$INSTALL_DIR"
+
+    # Initialize git submodules (AMP messaging plugin, etc.)
+    print_step "Initializing git submodules..."
+    git submodule update --init --recursive
+    print_success "Git submodules initialized"
+
     echo ""
     print_step "Installing dependencies..."
-    cd "$INSTALL_DIR"
     yarn install
     print_success "Dependencies installed"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.20.17",
+  "version": "0.20.18",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.20.17"
+VERSION="0.20.18"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 
@@ -285,6 +285,7 @@ install() {
                 print_info "Updating..."
                 cd "$INSTALL_DIR"
                 git pull origin main
+                git submodule update --init --recursive
                 yarn install
                 yarn build
                 print_success "Updated to latest version"
@@ -316,6 +317,11 @@ install() {
     print_success "Repository cloned"
 
     cd "$INSTALL_DIR"
+
+    # Initialize git submodules (AMP messaging plugin, etc.)
+    print_info "Initializing git submodules..."
+    git submodule update --init --recursive
+    print_success "Submodules initialized"
 
     # Run the full installer
     if [ -f "install.sh" ]; then

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.17",
+  "version": "0.20.18",
   "releaseDate": "2026-02-06",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- All three install paths now run `git submodule update --init --recursive` automatically
- `install-messaging.sh` auto-initializes the submodule instead of erroring with a manual instruction
- Fixes fresh clone installs failing on AMP messaging because `plugins/amp-messaging/` was empty

## Files changed
- `install.sh` — added submodule init after clone, before `yarn install`
- `scripts/remote-install.sh` — added submodule init after `git clone` and after `git pull`
- `install-messaging.sh` — auto-detects uninitialized submodule and runs `git submodule update --init`

## Test plan
- [ ] Fresh clone + `./install.sh` → submodules initialized, messaging installs correctly
- [ ] `curl ... | sh` remote install → submodules initialized
- [ ] Existing install + update path → submodules updated
- [ ] `./install-messaging.sh` on uninitialized clone → auto-inits, then installs

Reported by community user. Bump version to 0.20.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)