### PR TITLE
fix(ui): include programArgs in Agent Profile save payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.21.16-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.21.17-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/components/AgentProfile.tsx
+++ b/components/AgentProfile.tsx
@@ -197,6 +197,7 @@ export default function AgentProfile({ isOpen, onClose, agentId, sessionStatus, 
           team: agent.team,
           model: agent.model,
           taskDescription: agent.taskDescription,
+          programArgs: agent.programArgs,
           tags: agent.tags,
           documentation: agent.documentation,
           metadata: agent.metadata

--- a/components/zoom/AgentProfileTab.tsx
+++ b/components/zoom/AgentProfileTab.tsx
@@ -144,6 +144,7 @@ export default function AgentProfileTab({ agent: initialAgent, hostUrl, onClose 
           team: agent.team,
           model: agent.model,
           taskDescription: agent.taskDescription,
+          programArgs: agent.programArgs,
           tags: agent.tags,
           documentation: agent.documentation,
           metadata: agent.metadata

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.21.16
+**Current Version:** v0.21.17
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.21.16",
+      "softwareVersion": "0.21.17",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.21.16",
+      "softwareVersion": "0.21.17",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -446,7 +446,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.21.16</span>
+                        <span>v0.21.17</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.21.16",
+  "version": "0.21.17",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.21.16"
+VERSION="0.21.17"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.21.16",
+  "version": "0.21.17",
   "releaseDate": "2026-02-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- **Bug:** `programArgs` was missing from the PATCH body in both `AgentProfile.tsx` and `AgentProfileTab.tsx`. The `handleSave` function hardcodes which fields to send, and `programArgs` was never added when the field was introduced. Local React state updated correctly (making it *look* saved), but the value was silently dropped on every API call — reverting to the old value on page reload.
- **Fix:** Added `programArgs: agent.programArgs` to the PATCH JSON body in both components.
- Version bump to 0.21.17.

## Affected Files

- `components/AgentProfile.tsx` — added `programArgs` to save payload
- `components/zoom/AgentProfileTab.tsx` — added `programArgs` to save payload
- Version files (8 files)

## Test plan

- [ ] Open Agent Profile panel for any agent
- [ ] Edit the "Program Arguments" field (e.g. type `--continue`)
- [ ] Click Save
- [ ] Close and reopen the panel — value should persist
- [ ] Repeat in zoom view (AgentProfileTab)
- [ ] Verify wake uses the saved programArgs