### PR TITLE
fix(mesh): propagate aliases in peer-exchange + fix test inbox (v0.21.22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.21.21-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.21.22-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/app/api/hosts/exchange-peers/route.ts
+++ b/app/api/hosts/exchange-peers/route.ts
@@ -167,7 +167,7 @@ export async function POST(request: Request): Promise<NextResponse<PeerExchangeR
           .replace(/[\x00-\x1F\x7F]/g, '')
           .substring(0, 500)
 
-        // Add the new host
+        // Add the new host (include aliases for hostname/IP resolution)
         const newHost: Host = {
           id: peerHost.id,
           name: peerHost.name,
@@ -175,6 +175,7 @@ export async function POST(request: Request): Promise<NextResponse<PeerExchangeR
           type: 'remote',  // CRITICAL: Mark as remote for routing decisions
           enabled: true,
           description: sanitizedDescription,
+          aliases: peerHost.aliases || [],
           syncedAt: new Date().toISOString(),
           syncSource: `peer-exchange:${body.fromHost.id}`,
         }

--- a/data/help-embeddings.json
+++ b/data/help-embeddings.json
@@ -1,6 +1,6 @@
 {
   "modelVersion": "Xenova/bge-small-en-v1.5",
-  "generatedAt": "2026-02-08T02:59:23.623Z",
+  "generatedAt": "2026-02-08T03:42:16.092Z",
   "documentCount": 136,
   "documents": [
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.21.21
+**Current Version:** v0.21.22
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.21.21",
+      "softwareVersion": "0.21.22",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.21.21",
+      "softwareVersion": "0.21.22",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -446,7 +446,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.21.21</span>
+                        <span>v0.21.22</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.21.21",
+  "version": "0.21.22",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.21.21"
+VERSION="0.21.22"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.21.21",
+  "version": "0.21.22",
   "releaseDate": "2026-02-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- **exchange-peers**: Include `aliases` when adding hosts discovered via peer exchange, so mesh-forwarded requests can resolve hostnames (e.g., Leonidas as "npc" vs IP)
- **test-amp-cross-host.sh**: Phase 5 inbox verification now uses `/api/messages?action=unread-count` (actual file inbox) instead of `/api/v1/messages/pending` (relay queue). Also stores `agent_id` from registration for reliable lookups.

## Test plan

- [ ] `yarn build` passes
- [ ] Cross-host mesh test: `./scripts/test-amp-cross-host.sh` — Phase 5 inbox counts should now pass
- [ ] New host discovered via peer exchange includes aliases in hosts.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)