### PR TITLE
fix(cli): consolidate agent resolvers, fix HOST_URLS crash, fix BSD sed (v0.21.25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Stop juggling terminal windows. Orchestrate your AI coding agents from one dashboard.**
 
-[![Version](https://img.shields.io/badge/version-0.21.24-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.21.25-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.17-brightgreen)](https://nodejs.org)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.21.24
+**Current Version:** v0.21.25
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.21.24",
+      "softwareVersion": "0.21.25",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.21.24",
+      "softwareVersion": "0.21.25",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -446,7 +446,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.21.24</span>
+                        <span>v0.21.25</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.21.24",
+  "version": "0.21.25",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -16,7 +16,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Version
-VERSION="0.21.24"
+VERSION="0.21.25"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.21.24",
-  "releaseDate": "2026-02-07",
+  "version": "0.21.25",
+  "releaseDate": "2026-02-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

Fixes #190 — `messaging-helper.sh:171: HOST_URLS: unbound variable` crash affecting `export`, `plugin list`, and any command using `resolve_agent` from messaging-helper.

This PR consolidates **three separate agent resolution code paths** into a single unified `resolve_agent()` in `agent-helper.sh`, fixes the HOST_URLS crash, adds localhost auto-injection to multi-host search, adds input sanitization for the `@host` part, and fixes the BSD sed bug in `bump-version.sh`.

### Changes

**Unified agent resolver (`agent-helper.sh`)**
- Replaces `resolve_agent_simple()` (local-only), messaging-helper's `resolve_agent()` (multi-host only), and inline code in `cmd_show()`
- Three-phase strategy: `@host` routing → local API (fast) → multi-host search (comprehensive)
- Sets all globals needed by both CLI and messaging functions
- Input sanitization on both agent and host parts prevents shell injection

**Localhost auto-injection (`messaging-helper.sh`)**
- `search_agent_all_hosts()` now always probes and includes `localhost:23000` in the search list
- Fixes the case where `hosts.json` only has remote/Tailscale entries but agents are on localhost

**Helpful error messages**
- "Agent not found" now lists which hosts were searched and available agents on localhost
- Non-interactive format so AI agents can parse errors and retry with correct `agent@host` address

**BSD sed fix (`bump-version.sh`)**
- Replaced `sed -i ''` (macOS-only) with portable `sed -i.bak` + rm pattern
- Added early exit when target version already matches current version

**cmd_show cleanup (`aimaestro-agent.sh`)**
- Replaced 35 lines of inline duplicate resolution code with unified `resolve_agent()` call

### Files changed

| File | Change |
|------|--------|
| `plugin/scripts/agent-helper.sh` | Unified `resolve_agent()`, removed `resolve_agent_simple` + conditional override |
| `plugin/scripts/messaging-helper.sh` | Removed old `resolve_agent()`, added localhost injection to `search_agent_all_hosts()` |
| `plugin/scripts/aimaestro-agent.sh` | `cmd_show` uses unified resolver |
| `scripts/bump-version.sh` | Portable sed, early exit guard |
| Version files | Bump to 0.21.25 |

## Test plan

- [x] `cmd_show` existing agent — returns JSON data
- [x] `cmd_show` nonexistent agent — helpful error with host list
- [x] `cmd_export` (was crashing with HOST_URLS) — clean error, no crash
- [x] `cmd_plugin list` (was crashing with HOST_URLS) — clean error, no crash
- [x] `bump-version.sh` same version — exits cleanly (was failing with BSD sed error)
- [x] Input sanitization — rejects `injection-attempt;ls` with proper error
- [x] `@host` syntax — routes to correct host
- [x] `yarn build` — passes