### PR TITLE
Fix: remove broken resume flag stripping from wake route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.22.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.22.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.22.2
+**Current Version:** v0.22.3
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.22.2",
+      "softwareVersion": "0.22.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.22.2",
+      "softwareVersion": "0.22.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -446,7 +446,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.22.2</span>
+                        <span>v0.22.3</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.22.2"
+VERSION="0.22.3"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.22.2",
-  "releaseDate": "2026-02-09",
+  "version": "0.22.3",
+  "releaseDate": "2026-02-15",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

- **Removes** the resume flag stripping logic from `POST /api/agents/[id]/wake` that silently dropped `--continue`, `--resume`, and similar flags on first agent launch
- **Bug fixed**: creating a new agent pointing at a directory with existing Claude Code conversations caused `--continue` to be stripped because `launchCount === 0` (per-agent counter, not per-project-folder) — agent started fresh instead of resuming
- **Version bump**: 0.22.2 → 0.22.3

## Root Cause

The `isFirstLaunch` check used `agent.launchCount === 0` as a proxy for "no prior session to resume." This is fundamentally broken because `launchCount` is per-agent, not per-project-folder. A newly created agent can point at a directory that already has Claude Code conversations from manual CLI usage or other agents.

## Why removal is the right fix

All supported programs handle resume flags gracefully when no prior session exists:

| Program | Flag | Behavior when no session exists |
|---------|------|---------------------------------|
| Claude Code | `--continue` | Starts a new session |
| Codex | `resume --last` | Shows "no sessions" message |
| Gemini | `--resume` | Starts fresh |
| Aider | `--restore-chat-history` | No-op (no history file) |
| OpenCode | `--continue` | Starts fresh |
| Cursor | `--resume` | Starts fresh |

The stripping added complexity and bugs without solving a real problem.

## What changed

**Removed** from `app/api/agents/[id]/wake/route.ts`:
- `RESUME_PATTERNS` regex map (6 programs × multiple patterns)
- `stripResumeFlags()` function
- `isFirstLaunch` conditional stripping block

**Kept**:
- `sanitizeArgs()` shell injection protection
- `launchCount` field and increment (useful metadata, just no longer drives flag decisions)
- `programArgs` passthrough to program command

**Note**: The `plugin/` SKILL.md documents this behavior (lines 359–368) — that update belongs in a separate PR to the plugins submodule repo.

## Test plan

- [ ] Create agent with `programArgs: "--continue"` pointing at a directory WITH existing Claude Code conversations → verify `--continue` is preserved on first wake
- [ ] Create agent with `programArgs: "--continue"` pointing at an empty directory → verify `--continue` is passed through (Claude handles it gracefully)
- [ ] Wake agent multiple times → verify `programArgs` are always passed through unchanged
- [ ] Verify `launchCount` still increments correctly on each wake
- [ ] `yarn build` passes