### PR TITLE
fix(amp): populate fromLabel/toLabel in convertAMPToMessage

### DIFF
--- a/lib/messageQueue.ts
+++ b/lib/messageQueue.ts
@@ -201,13 +201,21 @@ function convertAMPToMessage(ampMsg: any): Message | null {
   const id = normalizeMessageId(envelope.id)
   const status = ampMsg.metadata?.status || ampMsg.local?.status || 'unread'
 
+  // Resolve display labels from agent registry (falls back to name if no label set)
+  const fromAgent = getAgentByName(fromName) || getAgentByAlias(fromName)
+  const toAgent = getAgentByName(toName) || getAgentByAlias(toName)
+  const fromLabel = fromAgent?.label || fromName
+  const toLabel = toAgent?.label || toName
+
   return {
     id,
     from: fromName,
     fromAlias: fromName,
+    fromLabel,
     fromHost,
     to: toName,
     toAlias: toName,
+    toLabel,
     toHost,
     timestamp: envelope.timestamp,
     subject: envelope.subject,


### PR DESCRIPTION
## Summary

- AMP-format messages were missing display labels (`fromLabel`/`toLabel`) because `convertAMPToMessage()` never resolved agent labels from the registry
- Old flat-format messages had labels stored in the JSON file, but AMP envelopes only carry addresses
- Now resolves sender/receiver agents via `getAgentByName`/`getAgentByAlias` and populates labels, falling back to the raw name

## Test Plan

- [ ] Send AMP message between agents with labels set
- [ ] Verify UI shows display labels instead of raw session names
- [ ] Verify agents without labels fall back to name correctly

Closes #207