### PR TITLE
fix(chat): normalize tmux target quoting to double quotes

### DIFF
--- a/app/api/agents/[id]/chat/route.ts
+++ b/app/api/agents/[id]/chat/route.ts
@@ -171,7 +171,7 @@ export async function GET(
       if (sessionName) {
         try {
           const { stdout } = await execAsync(
-            `tmux capture-pane -t '${sessionName}' -p -S -40 2>/dev/null || echo ""`
+            `tmux capture-pane -t "${sessionName}" -p -S -40 2>/dev/null || echo ""`
           )
           const lines = stdout.trim().split('\n')
 
@@ -318,8 +318,8 @@ export async function POST(
     // Send message to tmux session
     // Using send-keys with the message followed by Enter
     // Note: Use -l (literal) to avoid interpreting special characters
-    const tmuxCommand = `tmux send-keys -t '${sessionName}' -l '${escapedMessage}'`
-    const enterCommand = `tmux send-keys -t '${sessionName}' Enter`
+    const tmuxCommand = `tmux send-keys -t "${sessionName}" -l '${escapedMessage}'`
+    const enterCommand = `tmux send-keys -t "${sessionName}" Enter`
 
     console.log('[Chat API] Session:', sessionName)
     console.log('[Chat API] Message:', message)


### PR DESCRIPTION
## Summary

- Normalized tmux target quoting in `chat/route.ts` from single quotes to double quotes
- All other tmux commands in the codebase use double-quoted targets (`-t "${sessionName}"`)
- Changed 3 occurrences: capture-pane GET handler, send-keys POST handler (command + enter)

## Test Plan

- [ ] Send chat message to agent, verify tmux delivery works
- [ ] Verify GET chat status reads terminal correctly

Closes #210