### PR TITLE
Add CHANGELOG.md, version docs, bump to v0.23.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to AI Maestro are documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.23.10] - 2026-02-16
+
+### Added
+- CHANGELOG.md with structured per-version change tracking (Issue #226)
+
+### Fixed
+- Auto-trust mechanism: new agents no longer require manual tool approval (Issue #223, plugin PR #4)
+- AMP reply routing: `in_reply_to` and `thread_id` fields now tracked in envelope (partial fix for Issue #224)
+
+### Changed
+- Documented CLI script versioning policy: `aimaestro-agent.sh` uses independent semver (Issue #225)
+
+## [0.23.9] - 2026-02-15
+
+### Changed
+- Replace help embedding system with AI Maestro Assistant agent
+
+## [0.23.8] - 2026-02-15
+
+### Added
+- Essential keys toolbar for mobile terminal mode
+
+### Fixed
+- Query param left in URL when switching from Immersive to Dashboard (#57)
+
+## [0.23.7] - 2026-02-15
+
+### Added
+- 3-tier responsive experience (phone/tablet/desktop)
+- Mobile chat view with touch copy/paste
+- AIM-222: Consolidated fix for 65+ issues across memory, terminal, installers, skills, and API
+- ToxicSkills defense for skill/plugin install
+
+### Changed
+- Improved README docs organization, Windows install clarity, AMP example
+
+## [0.23.4] - 2026-02-08
+
+### Fixed
+- Intermittent terminal attachment failures with PTY spawn retry logic
+
+### Added
+- Cerebellum and plugin documentation
+
+## [0.23.3] - 2026-02-08
+
+### Added
+- Speech history, adaptive cooldown, event classification, template fallbacks
+- OpenAI TTS provider
+
+### Fixed
+- Voice switching and speech prompt improvements
+
+## [0.23.2] - 2026-02-07
+
+### Added
+- Voice commands for companion input
+- Enhanced Cerebellum voice subsystem
+
+## [0.23.1] - 2026-02-07
+
+### Added
+- Cerebellum subsystem coordinator
+- FaceTime-style companion with pop-out window
+
+## [0.22.4] - 2026-02-01
+
+### Added
+- Create Agent dropdown with Advanced mode
+- Docker container support for agents
+- AIM environment variables
+
+## [0.22.2] - 2026-01-31
+
+### Changed
+- Removed root clutter (.aimaestro/ and .claude-plugin/)
+
+## [0.22.1] - 2026-01-31
+
+### Fixed
+- Graceful shutdown no longer kills tmux sessions
+- Remove messaging-helper.sh from CI test expectations
+
+## [0.22.0] - 2026-01-29
+
+### Added
+- Composable plugin system with dedicated marketplace repo
+- Installer and updater now sync marketplace plugin CLAUDE.md
+
+### Fixed
+- Replaced old messaging script references with AMP commands
+- Removed leftover old messaging scripts that confused agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ This script updates ALL version references across the codebase:
 
 **DO NOT manually edit version numbers in individual files.** Always use the script to ensure consistency.
 
+**CLI Script Versioning:** The `aimaestro-agent.sh` CLI tool uses an independent semver (`v1.0.1`) separate from the app version (`0.23.x`). This is intentional — the CLI is distributed via the plugin repo and has its own release cadence. The app version tracks the dashboard/server, while the CLI version tracks the agent management script.
+
 ## Pre-PR Checklist (MANDATORY)
 
 **⚠️ STOP! Before creating ANY Pull Request to main, complete this checklist:**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.23.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.23.10-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.23.9
+**Current Version:** v0.23.10
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.23.9",
+      "softwareVersion": "0.23.10",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.23.9",
+      "softwareVersion": "0.23.10",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -446,7 +446,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.23.9</span>
+                        <span>v0.23.10</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.23.9"
+VERSION="0.23.10"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.23.9",
-  "releaseDate": "2026-02-15",
+  "version": "0.23.10",
+  "releaseDate": "2026-02-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

- Add structured `CHANGELOG.md` tracking changes from v0.22.0 to v0.23.10 (Closes #226)
- Document CLI script versioning policy in `CLAUDE.md` — explains that `aimaestro-agent.sh` uses independent semver separate from the app version (Closes #225)
- Bump version 0.23.9 → 0.23.10 via `bump-version.sh`

**9 files changed** (108 additions, 9 deletions)

## Companion PRs

- **Plugin repo PR #4** (`ai-maestro-plugins`): Auto-trust mechanism — writes `.claude/settings.local.json` during agent creation (Closes #223)
- **Plugin repo PR #1** (`ai-maestro-plugins`): AIM-222 skill docs + security scanner fixes (still open)

## Open issues (deferred to future PRs)

- #224: AMP reply routing cached return address
- #227: Agent type programArgs/owner restructuring

## v0.23.9 Verification Report

Full report: verified 14 items from the AIM-222 comprehensive audit.

| Category | Fixed | Partial | Unfixed |
|----------|-------|---------|---------|
| Critical/Major | 3 | 1 | 1 |
| Improvements | 2 | 1 | 4 |

Key fixes confirmed in v0.23.9: CLAUDECODE env var (#9), tmux race conditions (#5), null-field inbox (#2).

## Test plan

- [ ] Verify `CHANGELOG.md` renders correctly on GitHub
- [ ] Verify `version.json` shows `0.23.10`
- [ ] Verify `yarn build` passes
- [ ] Verify CLI versioning note in CLAUDE.md is accurate