### PR TITLE
Promote OpenClaw agents to first-class citizens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.24.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.24.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.24.8
+**Current Version:** v0.24.9
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.24.8",
+      "softwareVersion": "0.24.9",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.24.8",
+      "softwareVersion": "0.24.9",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -446,7 +446,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.24.8</span>
+                        <span>v0.24.9</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.24.8"
+VERSION="0.24.9"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.24.8",
-  "releaseDate": "2026-02-18",
+  "version": "0.24.9",
+  "releaseDate": "2026-02-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

- OpenClaw agents auto-register in the agent registry on tmux discovery, enabling AMP messaging, kanban task assignment, and team meeting participation
- Session names validated against `[a-zA-Z0-9_-]+` to prevent path traversal / injection
- Working directory queried from tmux pane and stored on the agent
- AMP home + env vars (`AMP_DIR`, `AIM_AGENT_NAME`, `AIM_AGENT_ID`) initialized once on first registration only — zero overhead on subsequent polls
- Created GitHub issues for Cerebellum decoupling: #236 (conversation indexing) and #237 (voice subsystem)
- Version bump to v0.24.9

## Security

- Session name regex rejects `../`, spaces, quotes, shell metacharacters before any use in `createAgent` or `execFileAsync`
- All tmux calls use `execFileAsync` (argv, no shell interpolation)
- All new code gated behind `fs.existsSync(openclawSocketDir)` — zero impact on deployments without OpenClaw

## Test plan

- [x] `yarn test` — 486 tests pass
- [x] `yarn build` — clean, no type errors
- [ ] Without OpenClaw: verify no behavior change (socket dir doesn't exist)
- [ ] With OpenClaw: verify agents appear in registry, get AMP dirs, show `agentId` on sessions
- [ ] Verify OpenClaw agents visible in team meeting agent picker and kanban assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)