### PR TITLE
fix: use C-m instead of Enter for tmux send-keys

### DIFF
--- a/lib/agent-runtime.ts
+++ b/lib/agent-runtime.ts
@@ -181,7 +181,7 @@ export class TmuxRuntime implements AgentRuntime {
       const escaped = keys.replace(/'/g, "'\\''")
       if (enter) {
         await execAsync(
-          `tmux send-keys -t "${name}" -l '${escaped}' \\; send-keys -t "${name}" Enter`
+          `tmux send-keys -t "${name}" -l '${escaped}' \\; send-keys -t "${name}" C-m`
         )
       } else {
         await execAsync(`tmux send-keys -t "${name}" -l '${escaped}'`)
@@ -189,7 +189,7 @@ export class TmuxRuntime implements AgentRuntime {
     } else {
       // Non-literal: keys is a raw key sequence (e.g. "C-c", "exit Enter", quoted command)
       if (enter) {
-        await execAsync(`tmux send-keys -t "${name}" ${keys} Enter`)
+        await execAsync(`tmux send-keys -t "${name}" ${keys} C-m`)
       } else {
         await execAsync(`tmux send-keys -t "${name}" ${keys}`)
       }


### PR DESCRIPTION
## Summary
- Replace `Enter` with `C-m` in `sendKeys()` method in `lib/agent-runtime.ts`
- `Enter` doesn't work with Claude Code (and potentially other CLI tools)
- `C-m` (carriage return) is consistent with the rest of the Maestro docs

Fixes #250

## Test plan
- [ ] Send a message to a Claude Code agent via the dashboard
- [ ] Verify the message is submitted (not just typed)
- [ ] Test with both literal and non-literal send-keys paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)