### PR TITLE
fix: prevent undefined values from overwriting task fields on update

### DIFF
--- a/lib/task-registry.ts
+++ b/lib/task-registry.ts
@@ -139,9 +139,14 @@ export function updateTask(
   const wasCompleted = tasks[index].status === 'completed'
   const isNowCompleted = updates.status === 'completed'
 
+  // Filter out undefined values to prevent overwriting existing fields
+  const cleanUpdates = Object.fromEntries(
+    Object.entries(updates).filter(([, v]) => v !== undefined)
+  )
+
   tasks[index] = {
     ...tasks[index],
-    ...updates,
+    ...cleanUpdates,
     updatedAt: now,
   }
 


### PR DESCRIPTION
## Summary
- Filter out `undefined` values in `updateTask()` before spreading into existing task
- Prevents data loss when updating a task with a partial payload (e.g., only changing status)
- Without this fix, `blockedBy` becomes `undefined` causing `resolveTaskDeps()` to crash with `TypeError: Cannot read properties of undefined (reading 'includes')`

Fixes #251

## Test plan
- [ ] Create a task with all fields populated
- [ ] Update only the status via PUT
- [ ] Verify all other fields (subject, description, blockedBy, priority) are preserved
- [ ] Verify the tasks API still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)