### PR TITLE
feat: community contributions from @barrie-cork (v0.24.19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.24.18-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.24.19-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.24.18
+**Current Version:** v0.24.19
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.24.18",
+      "softwareVersion": "0.24.19",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.24.18",
+      "softwareVersion": "0.24.19",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -447,7 +447,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.24.18</span>
+                        <span>v0.24.19</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/hooks/useTasks.ts
+++ b/hooks/useTasks.ts
@@ -114,7 +114,9 @@ export function useTasks(teamId: string | null): UseTasksResult {
       completed: [],
     }
     tasks.forEach(t => {
-      map[t.status].push(t)
+      if (map[t.status]) {
+        map[t.status].push(t)
+      }
     })
     return map
   }, [tasks])

--- a/lib/amp-inbox-writer.ts
+++ b/lib/amp-inbox-writer.ts
@@ -336,6 +336,7 @@ export async function writeToAMPInbox(
         timestamp: envelope.timestamp,
         thread_id: envelope.thread_id || envelope.in_reply_to || envelope.id,
         in_reply_to: envelope.in_reply_to || null,
+        reply_to: envelope.reply_to || envelope.from,
         expires_at: envelope.expires_at || null,
         signature: envelope.signature || null
       },
@@ -402,6 +403,7 @@ export async function writeToAMPSent(
         timestamp: envelope.timestamp,
         thread_id: envelope.thread_id || envelope.in_reply_to || envelope.id,
         in_reply_to: envelope.in_reply_to || null,
+        reply_to: envelope.reply_to || envelope.from,
         expires_at: envelope.expires_at || null,
         signature: envelope.signature || null
       },

--- a/lib/cerebellum/voice-subsystem.ts
+++ b/lib/cerebellum/voice-subsystem.ts
@@ -241,84 +241,22 @@ export class VoiceSubsystem implements Subsystem {
    */
   private readRecentConversation(maxTurns = 6): ConversationTurn[] {
     try {
-      const fs = require('fs')
-      const path = require('path')
-      const os = require('os')
-
-      // Get agent's working directory from registry
       const { getAgent: getRegistryAgent } = require('../agent-registry')
+      const { getConversationSource } = require('../conversation-source')
+
       if (!this.context) return []
       const registryAgent = getRegistryAgent(this.context.agentId)
       const workingDir = registryAgent?.workingDirectory
         || registryAgent?.sessions?.[0]?.workingDirectory
       if (!workingDir) return []
 
-      // Derive the Claude projects directory path (same as chat route.ts)
-      const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-      const projectDirName = workingDir.replace(/\//g, '-')
-      const conversationDir = path.join(claudeProjectsDir, projectDirName)
+      const source = getConversationSource(registryAgent?.program)
+      const recentFile = source.findMostRecentFile(workingDir)
+      if (!recentFile) return []
 
-      if (!fs.existsSync(conversationDir)) return []
-
-      // Find the most recently modified .jsonl file
-      const files = fs.readdirSync(conversationDir)
-        .filter((f: string) => f.endsWith('.jsonl'))
-        .map((f: string) => ({
-          name: f,
-          path: path.join(conversationDir, f),
-          mtime: fs.statSync(path.join(conversationDir, f)).mtime,
-        }))
-        .sort((a: { mtime: Date }, b: { mtime: Date }) => b.mtime.getTime() - a.mtime.getTime())
-
-      if (files.length === 0) return []
-
-      const content = fs.readFileSync(files[0].path, 'utf-8')
-      const lines = content.split('\n').filter((line: string) => line.trim())
-
-      // Parse and extract last N turns
-      const turns: ConversationTurn[] = []
-      for (const line of lines) {
-        try {
-          const msg = JSON.parse(line)
-          if (msg.type === 'human' || msg.role === 'user') {
-            // Extract text from human message
-            const text = typeof msg.message === 'string'
-              ? msg.message
-              : msg.message?.content
-                ? (typeof msg.message.content === 'string'
-                  ? msg.message.content
-                  : msg.message.content
-                    .filter((b: { type: string }) => b.type === 'text')
-                    .map((b: { text: string }) => b.text)
-                    .join(' '))
-                : null
-            if (text) {
-              turns.push({ role: 'user', text: text.substring(0, 400) })
-            }
-          } else if (msg.type === 'assistant' || msg.role === 'assistant') {
-            const text = typeof msg.message === 'string'
-              ? msg.message
-              : msg.message?.content
-                ? (typeof msg.message.content === 'string'
-                  ? msg.message.content
-                  : msg.message.content
-                    .filter((b: { type: string }) => b.type === 'text')
-                    .map((b: { text: string }) => b.text)
-                    .join(' '))
-                : null
-            if (text) {
-              turns.push({ role: 'assistant', text: text.substring(0, 400) })
-            }
-          }
-        } catch {
-          // Skip malformed lines
-        }
-      }
-
-      // Return last N turns
-      return turns.slice(-maxTurns)
+      return source.readRecentTurns(recentFile.path, maxTurns)
     } catch (err) {
-      console.error('[Cerebellum:Voice] Failed to read conversation JSONL:', err)
+      console.error('[Cerebellum:Voice] Failed to read conversation:', err)
       return []
     }
   }

--- a/lib/conversation-source.ts
+++ b/lib/conversation-source.ts
@@ -1,0 +1,332 @@
+/**
+ * ConversationSource — abstraction layer for conversation file discovery and parsing.
+ * Decouples memory indexing, chat, and voice from Claude Code's specific file format.
+ *
+ * Each source knows how to:
+ *   1. Discover conversation files for a given working directory
+ *   2. Extract metadata (sessionId, cwd, timestamps, model names)
+ *   3. Parse messages into a normalized format
+ *   4. Read recent conversation turns (for voice/chat)
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+// ============================================================================
+// Normalized types — all sources produce these
+// ============================================================================
+
+export interface ConversationFile {
+  path: string
+  sessionId: string | null
+  cwd: string | null
+  mtime: number
+}
+
+export interface ConversationMetadata {
+  sessionId: string | null
+  cwd: string | null
+  firstUserMessage: string | null
+  gitBranch: string | null
+  claudeVersion: string | null
+  firstMessageAt: number | null
+  lastMessageAt: number | null
+  modelNames: string
+  messageCount: number
+}
+
+export interface ConversationTurn {
+  role: 'user' | 'assistant' | 'system'
+  text: string
+  timestamp?: string
+}
+
+export interface ConversationMessage {
+  type?: string
+  role?: string
+  message?: any
+  content?: any
+  timestamp?: string
+  uuid?: string
+  sessionId?: string
+  cwd?: string
+  gitBranch?: string
+  version?: string
+  [key: string]: any
+}
+
+// ============================================================================
+// ConversationSource interface
+// ============================================================================
+
+export interface ConversationSource {
+  /** Source name (e.g., "claude-code", "terminal-logs") */
+  readonly name: string
+
+  /**
+   * Discover all conversation files, optionally filtered by working directories.
+   * Returns files with lightweight metadata extracted from headers.
+   */
+  discoverFiles(workingDirectories?: string[]): ConversationFile[]
+
+  /**
+   * Get the conversation directory for a specific working directory.
+   * Returns null if no directory exists.
+   */
+  getConversationDir(workingDirectory: string): string | null
+
+  /**
+   * Find the most recent conversation file for a working directory.
+   * Returns null if none found.
+   */
+  findMostRecentFile(workingDirectory: string): ConversationFile | null
+
+  /**
+   * Extract full metadata from a conversation file.
+   */
+  extractMetadata(filePath: string, projectPath?: string): ConversationMetadata
+
+  /**
+   * Read recent conversation turns from a file (for voice/chat context).
+   */
+  readRecentTurns(filePath: string, maxTurns: number): ConversationTurn[]
+
+  /**
+   * Parse raw messages from a file starting at a line offset.
+   * Used for delta indexing.
+   */
+  parseMessages(filePath: string, startLine?: number): ConversationMessage[]
+}
+
+// ============================================================================
+// Claude Code source — reads ~/.claude/projects/*.jsonl
+// ============================================================================
+
+export class ClaudeCodeSource implements ConversationSource {
+  readonly name = 'claude-code'
+
+  private get projectsDir(): string {
+    return path.join(os.homedir(), '.claude', 'projects')
+  }
+
+  discoverFiles(workingDirectories?: string[]): ConversationFile[] {
+    if (!fs.existsSync(this.projectsDir)) return []
+
+    const allFiles = this.findJsonlRecursive(this.projectsDir)
+    const results: ConversationFile[] = []
+
+    for (const filePath of allFiles) {
+      const { sessionId, cwd } = this.readFileHeader(filePath)
+
+      if (workingDirectories && workingDirectories.length > 0) {
+        if (!cwd || !workingDirectories.includes(cwd)) continue
+      }
+
+      let mtime = 0
+      try { mtime = fs.statSync(filePath).mtimeMs } catch { /* skip */ }
+
+      results.push({ path: filePath, sessionId, cwd, mtime })
+    }
+
+    return results
+  }
+
+  getConversationDir(workingDirectory: string): string | null {
+    const projectDirName = workingDirectory.replace(/\//g, '-')
+    const dir = path.join(this.projectsDir, projectDirName)
+    return fs.existsSync(dir) ? dir : null
+  }
+
+  findMostRecentFile(workingDirectory: string): ConversationFile | null {
+    const dir = this.getConversationDir(workingDirectory)
+    if (!dir) return null
+
+    const jsonlPaths = this.findJsonlRecursive(dir)
+    if (jsonlPaths.length === 0) return null
+
+    let best: { path: string; mtime: number } | null = null
+    for (const p of jsonlPaths) {
+      try {
+        const mtime = fs.statSync(p).mtimeMs
+        if (!best || mtime > best.mtime) best = { path: p, mtime }
+      } catch { /* skip */ }
+    }
+
+    if (!best) return null
+
+    const { sessionId, cwd } = this.readFileHeader(best.path)
+    return { path: best.path, sessionId, cwd, mtime: best.mtime }
+  }
+
+  extractMetadata(filePath: string, projectPath?: string): ConversationMetadata {
+    const fileContent = fs.readFileSync(filePath, 'utf-8')
+    const allLines = fileContent.split('\n').filter(line => line.trim())
+
+    let sessionId: string | null = null
+    let cwd: string | null = null
+    let firstUserMessage: string | null = null
+    let gitBranch: string | null = null
+    let claudeVersion: string | null = null
+    let firstMessageAt: number | null = null
+    let lastMessageAt: number | null = null
+    const modelSet = new Set<string>()
+
+    for (const line of allLines.slice(0, 50)) {
+      try {
+        const msg = JSON.parse(line)
+        if (msg.sessionId && !sessionId) sessionId = msg.sessionId
+        if (msg.cwd && !cwd) cwd = msg.cwd
+        if (msg.gitBranch && !gitBranch) gitBranch = msg.gitBranch
+        if (msg.version && !claudeVersion) claudeVersion = msg.version
+        if (msg.timestamp) {
+          const ts = new Date(msg.timestamp).getTime()
+          if (!firstMessageAt || ts < firstMessageAt) firstMessageAt = ts
+        }
+        if (msg.type === 'user' && msg.message?.content && !firstUserMessage) {
+          const content = msg.message.content
+          firstUserMessage = (typeof content === 'string' ? content : JSON.stringify(content))
+            .substring(0, 100).replace(/[\n\r]/g, ' ').trim()
+        }
+        if (msg.type === 'assistant' && msg.message?.model) {
+          const model = msg.message.model
+          if (model.includes('sonnet')) modelSet.add('Sonnet 4.5')
+          else if (model.includes('haiku')) modelSet.add('Haiku 4.5')
+          else if (model.includes('opus')) modelSet.add('Opus 4.5')
+        }
+      } catch { /* skip */ }
+    }
+
+    for (let i = allLines.length - 1; i >= Math.max(0, allLines.length - 20); i--) {
+      try {
+        const msg = JSON.parse(allLines[i])
+        if (msg.timestamp) {
+          lastMessageAt = new Date(msg.timestamp).getTime()
+          break
+        }
+      } catch { /* skip */ }
+    }
+
+    return {
+      sessionId,
+      cwd: cwd || projectPath || null,
+      firstUserMessage,
+      gitBranch,
+      claudeVersion,
+      firstMessageAt,
+      lastMessageAt,
+      modelNames: Array.from(modelSet).join(', '),
+      messageCount: allLines.length,
+    }
+  }
+
+  readRecentTurns(filePath: string, maxTurns: number): ConversationTurn[] {
+    let content: string
+    try { content = fs.readFileSync(filePath, 'utf-8') } catch { return [] }
+
+    const lines = content.split('\n').filter(line => line.trim())
+    const turns: ConversationTurn[] = []
+
+    for (const line of lines) {
+      try {
+        const msg = JSON.parse(line)
+        const role = this.normalizeRole(msg)
+        if (!role || role === 'system') continue
+
+        const text = this.extractText(msg)
+        if (text) {
+          turns.push({ role, text: text.substring(0, 400), timestamp: msg.timestamp })
+        }
+      } catch { /* skip */ }
+    }
+
+    return turns.slice(-maxTurns)
+  }
+
+  parseMessages(filePath: string, startLine: number = 0): ConversationMessage[] {
+    const fileContent = fs.readFileSync(filePath, 'utf-8')
+    const allLines = fileContent.split('\n').filter(line => line.trim())
+    const messages: ConversationMessage[] = []
+
+    for (let i = startLine; i < allLines.length; i++) {
+      try {
+        messages.push(JSON.parse(allLines[i]))
+      } catch { /* skip */ }
+    }
+
+    return messages
+  }
+
+  // --- Private helpers ---
+
+  private findJsonlRecursive(dir: string): string[] {
+    const results: string[] = []
+    try {
+      for (const entry of fs.readdirSync(dir)) {
+        const entryPath = path.join(dir, entry)
+        try {
+          const stat = fs.statSync(entryPath)
+          if (stat.isDirectory()) {
+            results.push(...this.findJsonlRecursive(entryPath))
+          } else if (entry.endsWith('.jsonl')) {
+            results.push(entryPath)
+          }
+        } catch { /* skip */ }
+      }
+    } catch { /* skip */ }
+    return results
+  }
+
+  private readFileHeader(filePath: string): { sessionId: string | null; cwd: string | null } {
+    let sessionId: string | null = null
+    let cwd: string | null = null
+    try {
+      const fd = fs.openSync(filePath, 'r')
+      const buf = Buffer.alloc(4096)
+      const bytesRead = fs.readSync(fd, buf, 0, 4096, 0)
+      fs.closeSync(fd)
+
+      const header = buf.toString('utf-8', 0, bytesRead)
+      const firstLine = header.split('\n')[0]
+      if (firstLine) {
+        const parsed = JSON.parse(firstLine)
+        sessionId = parsed.sessionId || null
+        cwd = parsed.cwd || null
+      }
+    } catch { /* skip */ }
+    return { sessionId, cwd }
+  }
+
+  private normalizeRole(msg: any): 'user' | 'assistant' | 'system' | null {
+    if (msg.type === 'human' || msg.role === 'user' || msg.type === 'user') return 'user'
+    if (msg.type === 'assistant' || msg.role === 'assistant') return 'assistant'
+    if (msg.type === 'system' || msg.role === 'system') return 'system'
+    return null
+  }
+
+  private extractText(msg: any): string | null {
+    if (typeof msg.message === 'string') return msg.message
+    if (msg.message?.content) {
+      if (typeof msg.message.content === 'string') return msg.message.content
+      if (Array.isArray(msg.message.content)) {
+        return msg.message.content
+          .filter((b: any) => b.type === 'text')
+          .map((b: any) => b.text)
+          .join(' ')
+      }
+    }
+    return null
+  }
+}
+
+// ============================================================================
+// Factory — returns source based on agent program
+// ============================================================================
+
+const claudeCodeSource = new ClaudeCodeSource()
+
+export function getConversationSource(_program?: string): ConversationSource {
+  // Currently only Claude Code is supported.
+  // Future: add AiderSource, CursorSource, etc. based on program name.
+  return claudeCodeSource
+}

--- a/lib/index-delta.ts
+++ b/lib/index-delta.ts
@@ -221,7 +221,13 @@ async function autoDiscoverProjects(
       matchedConversations++
       if (!discoveredProjects.has(file.cwd)) {
         const projectName = file.cwd.split('/').pop() || 'unknown'
-        const claudeDir = path.dirname(file.path)
+        // Derive the top-level Claude project directory, not a subdirectory.
+        // Files may be nested (e.g. <project-slug>/<session>/subagents/agent.jsonl)
+        // but the project dir is always ~/.claude/projects/<project-slug>/
+        const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
+        const relToProjects = path.relative(claudeProjectsDir, file.path)
+        const projectSlug = relToProjects.split(path.sep)[0]
+        const claudeDir = path.join(claudeProjectsDir, projectSlug)
         discoveredProjects.set(file.cwd, { projectName, claudeDir })
         console.log(`[Delta Index] Auto-discovered project: ${projectName} (${file.cwd})`)
       }
@@ -482,15 +488,33 @@ export async function runIndexDelta(
       const existingConvosResult = await getConversations(agentDb, projectPath)
       const existingFiles = new Set(existingConvosResult.rows.map((row: unknown[]) => row[0] as string))
 
-      try {
-        const files = fs.readdirSync(claudeDir)
-        const jsonlFiles = files.filter(f => f.endsWith('.jsonl'))
+      // Recursively find all .jsonl files (Claude Code stores subagent
+      // conversations in <session-id>/subagents/ subdirectories)
+      const findJsonlRecursive = (dir: string): string[] => {
+        const results: string[] = []
+        try {
+          for (const entry of fs.readdirSync(dir)) {
+            const entryPath = path.join(dir, entry)
+            try {
+              const stat = fs.statSync(entryPath)
+              if (stat.isDirectory()) {
+                results.push(...findJsonlRecursive(entryPath))
+              } else if (entry.endsWith('.jsonl')) {
+                results.push(entryPath)
+              }
+            } catch { /* skip inaccessible */ }
+          }
+        } catch { /* skip */ }
+        return results
+      }
 
-        for (const jsonlFile of jsonlFiles) {
-          const fullPath = path.join(claudeDir, jsonlFile)
+      try {
+        const jsonlPaths = findJsonlRecursive(claudeDir)
+
+        for (const fullPath of jsonlPaths) {
           if (existingFiles.has(fullPath)) continue
 
-          console.log(`[Delta Index] Discovered new conversation: ${jsonlFile}`)
+          console.log(`[Delta Index] Discovered new conversation: ${path.relative(claudeDir, fullPath)}`)
 
           try {
             const metadata = extractConversationMetadata(fullPath, projectPath)
@@ -514,7 +538,7 @@ export async function runIndexDelta(
 
             newConversationsDiscovered++
           } catch (err) {
-            console.error(`[Delta Index] Failed to process ${jsonlFile}:`, err)
+            console.error(`[Delta Index] Failed to process ${path.relative(claudeDir, fullPath)}:`, err)
           }
         }
       } catch (err) {

--- a/lib/message-send.ts
+++ b/lib/message-send.ts
@@ -86,6 +86,7 @@ function buildAMPEnvelope(message: Message): { envelope: AMPEnvelope; payload: A
     timestamp: message.timestamp,
     signature: message.amp?.signature || '',
     thread_id: message.inReplyTo || msgIdNormalized,
+    reply_to: `${message.fromAlias || message.from}@${selfHostId}.aimaestro.local`,
   }
   if (message.inReplyTo) {
     envelope.in_reply_to = message.inReplyTo

--- a/lib/types/amp-message.ts
+++ b/lib/types/amp-message.ts
@@ -62,6 +62,9 @@ export interface AMPEnvelope {
   /** ID of message being replied to */
   in_reply_to: string | null;
 
+  /** Cached return address for replies (avoids re-resolving sender) */
+  reply_to: string | null;
+
   /** ISO 8601 expiration time (null = no expiration) */
   expires_at: string | null;
 
@@ -252,6 +255,7 @@ export function createAMPMessage(
       timestamp,
       thread_id: options.inReplyTo || id,
       in_reply_to: options.inReplyTo || null,
+      reply_to: from, // Cache sender address for reply routing
       expires_at: options.expiresAt || null,
       signature: null, // Set by signing function for external messages
     },

--- a/lib/types/amp.ts
+++ b/lib/types/amp.ts
@@ -139,6 +139,9 @@ export interface AMPEnvelope {
 
   /** Thread ID for conversation tracking (ID of first message in thread) */
   thread_id: string
+
+  /** Cached return address for replies (avoids re-resolving sender) */
+  reply_to?: string
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.24.18",
+  "version": "0.24.19",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",
@@ -55,7 +55,7 @@
     "minisearch": "^7.2.0",
     "next": "14.2.35",
     "node-pty": "^1.0.0",
-    "onnxruntime-node": "^1.21.0",
+    "onnxruntime-node": "1.17.0",
     "pg": "^8.16.3",
     "react": "^18.3.0",
     "react-cytoscapejs": "^2.0.0",
@@ -85,5 +85,8 @@
     "to-ico": "^1.1.5",
     "typescript": "^5.4.0",
     "vitest": "^4.0.18"
+  },
+  "resolutions": {
+    "onnxruntime-node": "1.17.0"
   }
 }

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.24.18"
+VERSION="0.24.19"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -868,6 +868,7 @@ export async function routeMessage(
       signature: '',
       in_reply_to: body.in_reply_to,
       thread_id: body.in_reply_to || messageId,
+      reply_to: senderAddress,
     }
 
     // ── Signature Handling ─────────────────────────────────────────────

--- a/services/teams-service.ts
+++ b/services/teams-service.ts
@@ -148,8 +148,15 @@ export function getTeamById(id: string): ServiceResult<{ team: any }> {
  */
 export function updateTeamById(id: string, params: UpdateTeamParams): ServiceResult<{ team: any }> {
   try {
-    const { name, description, agentIds, lastMeetingAt, instructions, lastActivityAt } = params
-    const team = updateTeam(id, { name, description, agentIds, lastMeetingAt, instructions, lastActivityAt })
+    // Filter out undefined values to avoid overwriting existing fields
+    const updates: Record<string, unknown> = {}
+    if (params.name !== undefined) updates.name = params.name
+    if (params.description !== undefined) updates.description = params.description
+    if (params.agentIds !== undefined) updates.agentIds = params.agentIds
+    if (params.lastMeetingAt !== undefined) updates.lastMeetingAt = params.lastMeetingAt
+    if (params.instructions !== undefined) updates.instructions = params.instructions
+    if (params.lastActivityAt !== undefined) updates.lastActivityAt = params.lastActivityAt
+    const team = updateTeam(id, updates as any)
     if (!team) {
       return { error: 'Team not found', status: 404 }
     }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.24.18",
+  "version": "0.24.19",
   "releaseDate": "2026-03-09",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

Integrates code from 4 community PRs by @barrie-cork that had version conflicts against main (based on v0.24.12, main is v0.24.18). Changes were manually applied and tested.

- **PR #256**: Crash guard for unknown task statuses in `useTasks` hook + pin `onnxruntime-node` to v1.17.0 (fixes native module build failures)
- **PR #258**: Fix memory indexing — correct `claudeDir` derivation using project slug + recursive JSONL discovery for subagent conversations
- **PR #260**: Add `reply_to` field to AMP envelope for proper message threading across inbox, sent, and routing
- **PR #261**: `ConversationSource` interface abstracting conversation file parsing, decoupling voice subsystem from Claude Code JSONL specifics

## Test plan
- [x] All 486 tests pass (`yarn test`)
- [x] Production build succeeds (`yarn build`)
- [x] Version bumped to 0.24.19

🤖 Generated with [Claude Code](https://claude.com/claude-code)