### PR TITLE
release: AI Maestro v0.25.0 — Agent Skills Standard Compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.24.24-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.24.24
+**Current Version:** v0.25.0
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.24.24",
+      "softwareVersion": "0.25.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.24.24",
+      "softwareVersion": "0.25.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.24.24</span>
+                        <span>v0.25.0</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.24.24",
+  "version": "0.25.0",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.24.24"
+VERSION="0.25.0"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.24.24",
+  "version": "0.25.0",
   "releaseDate": "2026-03-09",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Release v0.25.0

**Headline: Agent Skills Standard (skills.sh) Compliant**

All 6 AI Maestro skills now comply with the [Agent Skills standard](https://agentskills.io/specification), an open standard adopted by 30+ AI agent products. Skills are no longer Claude Code exclusive — they work with OpenCode, Codex CLI, Gemini CLI, Cursor, GitHub Copilot, and any compatible agent.

### Highlights

- **Agent Skills Standard compliance** — All 6 skills have valid YAML frontmatter (`name`, `description`, `compatibility`, `metadata`, `allowed-tools`), are under 500 lines, and use space-delimited tool lists
- **AMP repo integration** — Agent messaging skill now sourced from the upstream AMP repo which independently adopted the standard
- **Plugin builder improvements** — Composable build system, Plugin Builder page, ToxicSkills defense
- **Cerebellum subsystem** — Voice-enabled companion with FaceTime-style UI, OpenAI TTS, adaptive cooldown
- **Service layer extraction** — All ~100 API routes are thin wrappers over 23 service files
- **Headless mode** — API-only server mode (~1s startup, ~100MB RAM)
- **Security** — RCE command injection patch, AMP message signing hardening
- **Mobile** — 3-tier responsive experience, essential keys toolbar, touch copy/paste
- **Community contributions** — Integrated PRs from @barrie-cork (#256, #258, #260, #261)

### Skills (all standard-compliant)

| Skill | Standalone | Needs AI Maestro |
|-------|-----------|-----------------|
| planning | Yes | No |
| agent-messaging (AMP) | Yes | No |
| memory-search | — | Yes |
| docs-search | — | Yes |
| graph-query | — | Yes |
| ai-maestro-agents-management | — | Yes |

### Stats
- 78 commits since v0.21.24
- 23 service files extracted
- 6 standard-compliant skills
- 44 CLI scripts

## Test plan
- [x] `yarn build` passes
- [x] All skills have valid frontmatter
- [x] `./build-plugin.sh --clean` produces correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)