### PR TITLE
fix: correct ecosystem.config.cjs typo in BACKLOG.md

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2723,7 +2723,7 @@ create_macos_app() {
   mkdir -p "$HOME/Applications/AI Maestro.app/Contents/MacOS"
   cat > "$HOME/Applications/AI Maestro.app/Contents/MacOS/AI Maestro" << 'EOF'
 #!/bin/bash
-cd ~/ai-maestro && pm2 start ecosystem.config.cjs 2>/dev/null
+cd ~/ai-maestro && pm2 start ecosystem.config.js 2>/dev/null
 sleep 2
 open http://localhost:23000
 EOF


### PR DESCRIPTION
## Summary
- Fix same `ecosystem.config.cjs` → `ecosystem.config.js` typo found in docs/BACKLOG.md
- Follow-up to #269 by @weliu

🤖 Generated with [Claude Code](https://claude.com/claude-code)