### PR TITLE
fix: WSL2/NAT agent connectivity, jq compat, TerminalView ResizeObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ import { useAgents } from '@/hooks/useAgents'
 import { TerminalProvider } from '@/contexts/TerminalContext'
 import { useToast } from '@/contexts/ToastContext'
 import { Terminal, Mail, User, GitBranch, MessageSquare, Share2, FileText, Moon, Power, Loader2, Brain, Plus, Search, Download, Play, ExternalLink } from 'lucide-react'
-import { agentToSession } from '@/lib/agent-utils'
+import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 
 // Dynamic imports for heavy components that are conditionally rendered
@@ -292,7 +292,7 @@ export default function DashboardPage() {
       console.log(`[Dashboard] Initializing memory for ${agents.length} agents...`)
 
       const initPromises = agents.map(async (agent) => {
-        const baseUrl = agent.hostUrl || ''
+        const baseUrl = getAgentBaseUrl(agent)
         const timeout = baseUrl ? INIT_TIMEOUT_REMOTE : INIT_TIMEOUT_LOCAL
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), timeout)
@@ -345,7 +345,7 @@ export default function DashboardPage() {
     const fetchUnreadCount = async () => {
       try {
         // Use agent's hostUrl to route to the correct host for remote agents
-        const baseUrl = activeAgent.hostUrl || ''
+        const baseUrl = getAgentBaseUrl(activeAgent)
         const response = await fetch(`${baseUrl}/api/messages?agent=${encodeURIComponent(activeAgentId)}&action=unread-count`)
         if (response.ok) {
           const data = await response.json()
@@ -387,7 +387,7 @@ export default function DashboardPage() {
   const handleDeleteAgent = async (agentId: string) => {
     try {
       // Use profileAgent's hostUrl to route to correct host for remote agents
-      const baseUrl = profileAgent?.hostUrl || ''
+      const baseUrl = getAgentBaseUrl(profileAgent)
       const response = await fetch(`${baseUrl}/api/agents/${agentId}`, {
         method: 'DELETE',
       })
@@ -825,7 +825,7 @@ export default function DashboardPage() {
                     </button>
                     <div className="flex-1" />
                     <div className="flex items-center">
-                      <AgentSubconsciousIndicator agentId={agent.id} hostUrl={agent.hostUrl} />
+                      <AgentSubconsciousIndicator agentId={agent.id} hostUrl={getAgentBaseUrl(agent)} />
                       <button
                         onClick={() => handleShowAgentProfile(agent)}
                         className="flex items-center gap-2 px-4 py-3 text-sm font-medium transition-all duration-200 text-gray-400 hover:text-gray-300 hover:bg-gray-800/30"
@@ -933,7 +933,7 @@ export default function DashboardPage() {
                             tmuxSessionName: a.session?.tmuxSessionName,
                             hostId: a.hostId
                           }))}
-                          hostUrl={agent.hostUrl}
+                          hostUrl={getAgentBaseUrl(agent)}
                           isActive={true}
                         />
                       </ErrorBoundary>
@@ -950,13 +950,13 @@ export default function DashboardPage() {
                         sessionName={session.id}
                         agentId={agent.id}
                         workingDirectory={session.workingDirectory}
-                        hostUrl={agent.hostUrl}
+                        hostUrl={getAgentBaseUrl(agent)}
                         isActive={true}
                       />
                     ) : activeTab === 'memory' ? (
                       <MemoryViewer
                         agentId={agent.id}
-                        hostUrl={agent.hostUrl}
+                        hostUrl={getAgentBaseUrl(agent)}
                         isActive={true}
                       />
                     ) : activeTab === 'docs' ? (
@@ -964,7 +964,7 @@ export default function DashboardPage() {
                         sessionName={session.id}
                         agentId={agent.id}
                         workingDirectory={session.workingDirectory}
-                        hostUrl={agent.hostUrl}
+                        hostUrl={getAgentBaseUrl(agent)}
                         isActive={true}
                       />
                     ) : activeTab === 'search' ? (
@@ -1044,7 +1044,7 @@ export default function DashboardPage() {
             onStartSession={() => handleStartSession(profileAgent)}
             onDeleteAgent={handleDeleteAgent}
             scrollToDangerZone={profileScrollToDangerZone}
-            hostUrl={profileAgent.hostUrl}
+            hostUrl={getAgentBaseUrl(profileAgent)}
           />
         )}
 

--- a/app/zoom/agent/page.tsx
+++ b/app/zoom/agent/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import { useAgents } from '@/hooks/useAgents'
 import { TerminalProvider } from '@/contexts/TerminalContext'
 import { ArrowLeft, Loader2, AlertCircle, X } from 'lucide-react'
-import { agentToSession } from '@/lib/agent-utils'
+import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 
 // Dynamic import for AgentCardView
@@ -59,7 +59,7 @@ function ZoomAgentContent() {
 
     setIsWaking(true)
     try {
-      const baseUrl = agent.hostUrl || ''
+      const baseUrl = getAgentBaseUrl(agent)
       await fetch(`${baseUrl}/api/agents/${agent.id}/wake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/app/zoom/page.tsx
+++ b/app/zoom/page.tsx
@@ -7,7 +7,7 @@ import { useAgents } from '@/hooks/useAgents'
 import { TerminalProvider } from '@/contexts/TerminalContext'
 import { ArrowLeft, Loader2, RefreshCw, AlertCircle, X, ExternalLink, Search, Mail } from 'lucide-react'
 import { VersionChecker } from '@/components/VersionChecker'
-import { agentToSession } from '@/lib/agent-utils'
+import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 import './zoom.css'
 
@@ -54,7 +54,7 @@ export default function ZoomPage() {
 
       for (const agent of agents) {
         try {
-          const baseUrl = agent.hostUrl || ''
+          const baseUrl = getAgentBaseUrl(agent)
           const response = await fetch(`${baseUrl}/api/messages?agent=${encodeURIComponent(agent.id)}&action=unread-count`)
           if (response.ok) {
             const data = await response.json()
@@ -135,7 +135,7 @@ export default function ZoomPage() {
 
   const handleWake = async (agent: Agent) => {
     try {
-      const baseUrl = agent.hostUrl || ''
+      const baseUrl = getAgentBaseUrl(agent)
       await fetch(`${baseUrl}/api/agents/${agent.id}/wake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -50,6 +50,7 @@ import SidebarViewSwitcher, { type SidebarView } from './sidebar/SidebarViewSwit
 import TeamListView from './sidebar/TeamListView'
 import MeetingListView from './sidebar/MeetingListView'
 import { useToast } from '@/contexts/ToastContext'
+import { getAgentBaseUrl } from '@/lib/agent-utils'
 
 interface AgentListProps {
   agents: UnifiedAgent[]
@@ -380,7 +381,7 @@ export default function AgentList({
         agents.map(async (agent) => {
           try {
             // Use agent's hostUrl to route to the correct host for remote agents
-            const baseUrl = agent.hostUrl || ''
+            const baseUrl = getAgentBaseUrl(agent)
             const response = await fetch(`${baseUrl}/api/messages?agent=${encodeURIComponent(agent.id)}&action=unread-count`)
             const data = await response.json()
             return { agentId: agent.id, count: data.count || 0 }
@@ -641,7 +642,7 @@ export default function AgentList({
 
     try {
       // Use agent's hostUrl for remote agents
-      const baseUrl = draggedAgent.hostUrl || ''
+      const baseUrl = getAgentBaseUrl(draggedAgent)
       const response = await fetch(`${baseUrl}/api/agents/${draggedAgent.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/components/MobileDashboard.tsx
+++ b/components/MobileDashboard.tsx
@@ -8,7 +8,7 @@ import MobileWorkTree from './MobileWorkTree'
 import MobileHostsList from './MobileHostsList'
 import MobileConversationDetail from './MobileConversationDetail'
 import { Terminal, Mail, RefreshCw, Activity, Server, MessageSquare, Phone } from 'lucide-react'
-import { agentToSession } from '@/lib/agent-utils'
+import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 import { useHosts } from '@/hooks/useHosts'
 import versionInfo from '@/version.json'
@@ -225,7 +225,7 @@ export default function MobileDashboard({
                     tmuxSessionName: a.session?.tmuxSessionName,
                     hostId: a.hostId
                   }))}
-                  hostUrl={agent.hostUrl}
+                  hostUrl={getAgentBaseUrl(agent)}
                 />
               )}
             </div>

--- a/components/TabletDashboard.tsx
+++ b/components/TabletDashboard.tsx
@@ -7,7 +7,7 @@ import MobileMessageCenter from './MobileMessageCenter'
 import MobileWorkTree from './MobileWorkTree'
 import MobileConversationDetail from './MobileConversationDetail'
 import { Terminal, Mail, RefreshCw, Activity, Phone, MessageSquare } from 'lucide-react'
-import { agentToSession } from '@/lib/agent-utils'
+import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 import { useHosts } from '@/hooks/useHosts'
 import versionInfo from '@/version.json'
@@ -261,7 +261,7 @@ export default function TabletDashboard({
                     tmuxSessionName: a.session?.tmuxSessionName,
                     hostId: a.hostId
                   }))}
-                  hostUrl={activeAgent.hostUrl}
+                  hostUrl={getAgentBaseUrl(activeAgent)}
                 />
               </div>
             )

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -279,49 +279,58 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
   useEffect(() => {
     let cleanup: (() => void) | undefined
     let retryCount = 0
-    const maxRetries = 20
-    const retryDelay = 150 // ms
+    const maxRefRetries = 10 // Quick retries for DOM ref only
+    const refRetryDelay = 50 // ms
     let retryTimer: NodeJS.Timeout | null = null
+    let resizeObserver: ResizeObserver | null = null
     let mounted = true
 
-    const tryInit = async () => {
+    const doInit = async (containerElement: HTMLDivElement) => {
       if (!mounted) return
-
-      // Wait for the DOM ref to be ready
-      if (!terminalRef.current) {
-        if (retryCount < maxRetries) {
-          retryCount++
-          retryTimer = setTimeout(tryInit, retryDelay)
-        }
-        return
-      }
-
-      // Check if container is actually visible and has dimensions
-      const rect = terminalRef.current.getBoundingClientRect()
-      if (rect.width === 0 || rect.height === 0) {
-        if (retryCount < maxRetries) {
-          retryCount++
-          retryTimer = setTimeout(tryInit, retryDelay)
-        } else {
-          console.warn(`[Terminal] Failed to get valid dimensions after ${maxRetries} retries for session ${session.id}`)
-        }
-        return
-      }
-
-      const containerElement = terminalRef.current
-      if (!containerElement) {
-        console.error(`❌ [INIT-ERROR] Container disappeared during init for session ${session.id}`)
-        return
-      }
-
       try {
         cleanup = await initializeTerminal(containerElement)
         if (mounted) {
           setIsReady(true)
         }
       } catch (error) {
-        console.error(`❌ [INIT-ERROR] Failed to initialize terminal for session ${session.id}:`, error)
+        console.error(`[INIT-ERROR] Failed to initialize terminal for session ${session.id}:`, error)
       }
+    }
+
+    const tryInit = () => {
+      if (!mounted) return
+
+      // Wait for the DOM ref to be ready (quick retries)
+      if (!terminalRef.current) {
+        if (retryCount < maxRefRetries) {
+          retryCount++
+          retryTimer = setTimeout(tryInit, refRetryDelay)
+        }
+        return
+      }
+
+      const containerElement = terminalRef.current
+
+      // Check if container already has dimensions
+      const rect = containerElement.getBoundingClientRect()
+      if (rect.width > 0 && rect.height > 0) {
+        doInit(containerElement)
+        return
+      }
+
+      // Use ResizeObserver to wait for non-zero dimensions (no polling cap)
+      resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const { width, height } = entry.contentRect
+          if (width > 0 && height > 0) {
+            resizeObserver?.disconnect()
+            resizeObserver = null
+            doInit(containerElement)
+            return
+          }
+        }
+      })
+      resizeObserver.observe(containerElement)
     }
 
     tryInit()
@@ -331,6 +340,9 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
       mounted = false
       if (retryTimer) {
         clearTimeout(retryTimer)
+      }
+      if (resizeObserver) {
+        resizeObserver.disconnect()
       }
       if (cleanup) {
         cleanup()

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.0
+**Current Version:** v0.25.1
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.0",
+      "softwareVersion": "0.25.1",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.0",
+      "softwareVersion": "0.25.1",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.0</span>
+                        <span>v0.25.1</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/hooks/useAgents.ts
+++ b/hooks/useAgents.ts
@@ -47,7 +47,7 @@ interface HostFetchResult {
  * Fetch agents from a specific host
  */
 async function fetchHostAgents(host: Host): Promise<HostFetchResult> {
-  const isSelf = isLocalhostUrl(host.url)
+  const isSelf = host.isSelf || isLocalhostUrl(host.url)
   const baseUrl = isSelf ? '' : host.url
   const timeout = isSelf ? SELF_FETCH_TIMEOUT : PEER_FETCH_TIMEOUT
 
@@ -72,7 +72,8 @@ async function fetchHostAgents(host: Host): Promise<HostFetchResult> {
       ...agent,
       hostId: host.id,
       hostName: host.name,
-      hostUrl: host.url
+      hostUrl: host.url,
+      isSelf,
     }))
 
     // Cache peer host agents for offline access (not self host)

--- a/install-agent-cli.sh
+++ b/install-agent-cli.sh
@@ -413,6 +413,14 @@ cmd_install() {
         skill_installed_json="true"
     fi
 
+    # Build files array in bash to avoid jq array concatenation (breaks on older jq)
+    local files_json
+    files_json="[\"${INSTALL_DIR}/aimaestro-agent.sh\", \"${HELPERS_DIR}/agent-helper.sh\""
+    if [[ "$skill_installed_json" == "true" ]]; then
+        files_json+=", \"${skill_dir}/SKILL.md\""
+    fi
+    files_json+="]"
+
     manifest=$(jq -n \
         --arg version "$INSTALLER_VERSION" \
         --arg installed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -422,6 +430,7 @@ cmd_install() {
         --arg skill_dir "$skill_dir" \
         --argjson path_modified "$path_modified_json" \
         --argjson skill_installed "$skill_installed_json" \
+        --argjson files "$files_json" \
         --arg shell_config "${shell_config:-}" \
         '{
             version: $version,
@@ -430,10 +439,7 @@ cmd_install() {
             install_dir: $install_dir,
             helpers_dir: $helpers_dir,
             skill_dir: $skill_dir,
-            files: [
-                ($install_dir + "/aimaestro-agent.sh"),
-                ($helpers_dir + "/agent-helper.sh")
-            ] + (if $skill_installed then [($skill_dir + "/SKILL.md")] else [] end),
+            files: $files,
             path_modified: $path_modified,
             skill_installed: $skill_installed,
             shell_config_file: $shell_config

--- a/lib/agent-utils.ts
+++ b/lib/agent-utils.ts
@@ -9,6 +9,25 @@ import type { Agent } from '@/types/agent'
 import type { Session } from '@/types/session'
 
 /**
+ * Get the base URL for API calls to an agent's host.
+ *
+ * Returns '' (empty string = relative fetch) when the agent lives on the same
+ * machine as the dashboard, even if hostUrl is a WSL2/NAT internal IP that
+ * the browser can't reach.
+ *
+ * Components that receive `hostUrl` as a prop should have callers pass the
+ * result of this function instead of raw `agent.hostUrl`.
+ */
+export function getAgentBaseUrl(agent: { hostUrl?: string; isSelf?: boolean } | null | undefined): string {
+  if (!agent) return ''
+  if (agent.isSelf) return ''
+  if (!agent.hostUrl) return ''
+  const lowered = agent.hostUrl.toLowerCase()
+  if (lowered.includes('localhost') || lowered.includes('127.0.0.1')) return ''
+  return agent.hostUrl
+}
+
+/**
  * Convert an Agent to a Session-like object for TerminalView compatibility.
  *
  * TerminalView expects a Session (tmux session metadata) for WebSocket connections.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.0"
+VERSION="0.25.1"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -172,6 +172,7 @@ export interface Agent {
   hostId: string                // Host identifier (e.g., "local", "mac-mini")
   hostName?: string             // Human-readable host name
   hostUrl?: string              // Host URL for API/WebSocket (e.g., "http://100.80.12.6:23000")
+  isSelf?: boolean              // Whether agent is on the same host as the dashboard
 
   // Metadata
   program: string               // AI program (e.g., "Claude Code", "Aider", "Cursor")

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.0",
-  "releaseDate": "2026-03-09",
+  "version": "0.25.1",
+  "releaseDate": "2026-03-13",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- **WSL2/NAT fix**: Add `isSelf` flag to Agent type and `getAgentBaseUrl()` helper so browser-side fetches use relative URLs for self-host agents, fixing WSL2/NAT where the internal IP (172.20.x.x) is unreachable from the Windows browser
- **jq compat**: Replace `] + (if...end)` array concatenation in `install-agent-cli.sh` with bash-built JSON + `--argjson`, fixing failures on older jq versions
- **TerminalView**: Replace 20×150ms polling retry loop with `ResizeObserver` — no arbitrary cap, works on slow page loads

## Issues Closed
Closes #268, #272, #273, #274, #275, #276, #277, #278

## Files Changed (18)
| File | Change |
|------|--------|
| `types/agent.ts` | Add `isSelf?: boolean` to Agent |
| `hooks/useAgents.ts` | Use `host.isSelf`, stamp `isSelf` on agents |
| `lib/agent-utils.ts` | Add `getAgentBaseUrl()` helper |
| `app/page.tsx` | Use `getAgentBaseUrl()` at 6 call sites |
| `app/zoom/page.tsx` | Use `getAgentBaseUrl()` |
| `app/zoom/agent/page.tsx` | Use `getAgentBaseUrl()` |
| `components/AgentList.tsx` | Use `getAgentBaseUrl()` for fetches |
| `components/MobileDashboard.tsx` | Pass `getAgentBaseUrl(agent)` |
| `components/TabletDashboard.tsx` | Pass `getAgentBaseUrl(agent)` |
| `install-agent-cli.sh` | Restructure jq to avoid array concat |
| `components/TerminalView.tsx` | Replace retry loop with ResizeObserver |
| Version files (7) | Bump to 0.25.1 |

## Test plan
- [x] `yarn test` — 486/486 pass
- [x] `yarn build` — clean
- [x] `bash -n install-agent-cli.sh` — syntax valid
- [ ] On localhost/Mac: dashboard works as before (relative fetches unchanged)
- [ ] On WSL2: dashboard shows agents (self-host uses relative URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)