### PR TITLE
fix: CozoDB injection, deduplicate aliases & debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/immersive/page.tsx
+++ b/app/immersive/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useAgents } from '@/hooks/useAgents'
+import { debounce } from '@/lib/utils'
 import type { UnifiedAgent } from '@/types/agent'
 
 // Import xterm CSS
@@ -131,28 +132,22 @@ export default function ImmersivePage() {
       fitAddonRef.current = fitAddon
 
       // ResizeObserver instead of window resize event (handles container size changes too)
-      const debouncedFit = (() => {
-        let timer: ReturnType<typeof setTimeout> | null = null
-        return () => {
-          if (timer) clearTimeout(timer)
-          timer = setTimeout(() => {
-            if (fitAddon && term) {
-              try {
-                fitAddon.fit()
-                if (wsRef.current?.readyState === WebSocket.OPEN) {
-                  wsRef.current.send(JSON.stringify({
-                    type: 'resize',
-                    cols: term.cols,
-                    rows: term.rows
-                  }))
-                }
-              } catch (e) {
-                console.warn('[Immersive] Fit failed during resize:', e)
-              }
+      const debouncedFit = debounce(() => {
+        if (fitAddon && term) {
+          try {
+            fitAddon.fit()
+            if (wsRef.current?.readyState === WebSocket.OPEN) {
+              wsRef.current.send(JSON.stringify({
+                type: 'resize',
+                cols: term.cols,
+                rows: term.rows
+              }))
             }
-          }, 150)
+          } catch (e) {
+            console.warn('[Immersive] Fit failed during resize:', e)
+          }
         }
-      })()
+      }, 150)
 
       resizeObserver = new ResizeObserver(() => debouncedFit())
       resizeObserver.observe(terminalRef.current!)

--- a/components/AgentCreationWizard.tsx
+++ b/components/AgentCreationWizard.tsx
@@ -6,6 +6,7 @@ import { X, ArrowLeft, ExternalLink, ChevronRight } from 'lucide-react'
 import CreateAgentAnimation, { getPreviewAvatarUrl } from './CreateAgentAnimation'
 import { useHosts } from '@/hooks/useHosts'
 import type { Host } from '@/types/host'
+import { getRandomAlias } from '@/lib/agent-utils'
 
 // --- Types ---
 
@@ -31,28 +32,6 @@ const PROGRAM_OPTIONS = [
   { value: 'opencode', label: 'OpenCode', desc: 'Open-source AI coding' },
   { value: 'terminal', label: 'Terminal Only', desc: 'Plain shell, no AI' },
 ]
-
-const FEMALE_ALIASES = [
-  'MarIA', 'SofIA', 'LucIA', 'JulIA', 'NatalIA', 'OlivIA', 'VictorIA', 'ValerIA',
-  'NovaIA', 'StellaIA', 'AuroraIA', 'CelestIA', 'HarmonIA', 'SerenIA', 'DataIA',
-]
-const MALE_ALIASES = [
-  'LunAI', 'NovAI', 'AriAI', 'ZarAI', 'KAI', 'SkyAI', 'MaxAI', 'LeoAI',
-  'MirAI', 'EchoAI', 'ZenAI', 'NeoAI', 'PixAI', 'BytAI', 'CodeAI',
-  'AtlAI', 'OrionAI', 'PhoenixAI', 'TitanAI', 'VegAI', 'CosmAI',
-]
-
-function getRandomAlias(agentName: string): string {
-  let hash = 0
-  for (let i = 0; i < agentName.length; i++) {
-    const char = agentName.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash = hash & hash
-  }
-  const isMale = (Math.abs(hash >> 8) % 2 === 0)
-  const aliases = isMale ? MALE_ALIASES : FEMALE_ALIASES
-  return aliases[Math.abs(hash) % aliases.length]
-}
 
 // --- Step logic ---
 

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -50,7 +50,7 @@ import SidebarViewSwitcher, { type SidebarView } from './sidebar/SidebarViewSwit
 import TeamListView from './sidebar/TeamListView'
 import MeetingListView from './sidebar/MeetingListView'
 import { useToast } from '@/contexts/ToastContext'
-import { getAgentBaseUrl } from '@/lib/agent-utils'
+import { getAgentBaseUrl, getRandomAlias } from '@/lib/agent-utils'
 
 interface AgentListProps {
   agents: UnifiedAgent[]
@@ -1727,33 +1727,6 @@ function CreateAgentModal({
   const [creationSuccess, setCreationSuccess] = useState(false)  // Agent created successfully
   const [showButton, setShowButton] = useState(false)  // Show "Let's Go!" button
 
-  // Fun AI-themed aliases - split by gender to match avatar photos
-  // IA names are feminine (Spanish style), AI names are masculine
-  const FEMALE_ALIASES = [
-    'MarIA', 'SofIA', 'LucIA', 'JulIA', 'NatalIA', 'OlivIA', 'VictorIA', 'ValerIA',
-    'NovaIA', 'StellaIA', 'AuroraIA', 'CelestIA', 'HarmonIA', 'SerenIA', 'DataIA',
-  ]
-  const MALE_ALIASES = [
-    'LunAI', 'NovAI', 'AriAI', 'ZarAI', 'KAI', 'SkyAI', 'MaxAI', 'LeoAI',
-    'MirAI', 'EchoAI', 'ZenAI', 'NeoAI', 'PixAI', 'BytAI', 'CodeAI',
-    'AtlAI', 'OrionAI', 'PhoenixAI', 'TitanAI', 'VegAI', 'CosmAI',
-  ]
-
-  // Get a gender-matched alias based on the agent name
-  // Uses same hash logic as AgentBadge avatar selection for consistency
-  const getRandomAlias = (agentName: string): string => {
-    let hash = 0
-    for (let i = 0; i < agentName.length; i++) {
-      const char = agentName.charCodeAt(i)
-      hash = ((hash << 5) - hash) + char
-      hash = hash & hash
-    }
-    // Same gender logic as avatar - ensures name matches photo gender
-    const isMale = (Math.abs(hash >> 8) % 2 === 0)
-    const aliases = isMale ? MALE_ALIASES : FEMALE_ALIASES
-    return aliases[Math.abs(hash) % aliases.length]
-  }
-
   // Animate through phases when creating - spread over 10 seconds for a delightful experience
   useEffect(() => {
     if (isCreating) {
@@ -2041,29 +2014,6 @@ function CreateAgentAdvancedModal({
       setRuntime('tmux')
     }
   }, [selectedHostId, dockerAvailable, runtime])
-
-  // Fun AI-themed aliases (same as simple modal)
-  const FEMALE_ALIASES = [
-    'MarIA', 'SofIA', 'LucIA', 'JulIA', 'NatalIA', 'OlivIA', 'VictorIA', 'ValerIA',
-    'NovaIA', 'StellaIA', 'AuroraIA', 'CelestIA', 'HarmonIA', 'SerenIA', 'DataIA',
-  ]
-  const MALE_ALIASES = [
-    'LunAI', 'NovAI', 'AriAI', 'ZarAI', 'KAI', 'SkyAI', 'MaxAI', 'LeoAI',
-    'MirAI', 'EchoAI', 'ZenAI', 'NeoAI', 'PixAI', 'BytAI', 'CodeAI',
-    'AtlAI', 'OrionAI', 'PhoenixAI', 'TitanAI', 'VegAI', 'CosmAI',
-  ]
-
-  const getRandomAlias = (agentName: string): string => {
-    let hash = 0
-    for (let i = 0; i < agentName.length; i++) {
-      const char = agentName.charCodeAt(i)
-      hash = ((hash << 5) - hash) + char
-      hash = hash & hash
-    }
-    const isMale = (Math.abs(hash >> 8) % 2 === 0)
-    const aliases = isMale ? MALE_ALIASES : FEMALE_ALIASES
-    return aliases[Math.abs(hash) % aliases.length]
-  }
 
   // Animation effect
   useEffect(() => {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.1
+**Current Version:** v0.25.2
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.1",
+      "softwareVersion": "0.25.2",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.1",
+      "softwareVersion": "0.25.2",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.1</span>
+                        <span>v0.25.2</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -14,14 +14,7 @@ export interface UseTerminalOptions {
   onUnregister?: () => void
 }
 
-// Debounce utility for resize events
-function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): T {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null
-  return ((...args: unknown[]) => {
-    if (timeoutId) clearTimeout(timeoutId)
-    timeoutId = setTimeout(() => fn(...args), ms)
-  }) as T
-}
+import { debounce } from '@/lib/utils'
 
 export function useTerminal(options: UseTerminalOptions = {}) {
   const terminalRef = useRef<Terminal | null>(null)

--- a/lib/agent-utils.ts
+++ b/lib/agent-utils.ts
@@ -27,6 +27,34 @@ export function getAgentBaseUrl(agent: { hostUrl?: string; isSelf?: boolean } | 
   return agent.hostUrl
 }
 
+// Fun AI-themed aliases - split by gender to match avatar photos
+// IA names are feminine (Spanish style), AI names are masculine
+export const FEMALE_ALIASES = [
+  'MarIA', 'SofIA', 'LucIA', 'JulIA', 'NatalIA', 'OlivIA', 'VictorIA', 'ValerIA',
+  'NovaIA', 'StellaIA', 'AuroraIA', 'CelestIA', 'HarmonIA', 'SerenIA', 'DataIA',
+]
+export const MALE_ALIASES = [
+  'LunAI', 'NovAI', 'AriAI', 'ZarAI', 'KAI', 'SkyAI', 'MaxAI', 'LeoAI',
+  'MirAI', 'EchoAI', 'ZenAI', 'NeoAI', 'PixAI', 'BytAI', 'CodeAI',
+  'AtlAI', 'OrionAI', 'PhoenixAI', 'TitanAI', 'VegAI', 'CosmAI',
+]
+
+/**
+ * Get a gender-matched alias based on the agent name.
+ * Uses same hash logic as AgentBadge avatar selection for consistency.
+ */
+export function getRandomAlias(agentName: string): string {
+  let hash = 0
+  for (let i = 0; i < agentName.length; i++) {
+    const char = agentName.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash = hash & hash
+  }
+  const isMale = (Math.abs(hash >> 8) % 2 === 0)
+  const aliases = isMale ? MALE_ALIASES : FEMALE_ALIASES
+  return aliases[Math.abs(hash) % aliases.length]
+}
+
 /**
  * Convert an Agent to a Session-like object for TerminalView compatibility.
  *

--- a/lib/cozo-db.ts
+++ b/lib/cozo-db.ts
@@ -12,6 +12,7 @@ import { CozoDb } from 'cozo-node'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
+import { escapeForCozo } from './cozo-utils'
 
 export interface AgentDatabaseConfig {
   agentId: string
@@ -133,8 +134,8 @@ export class AgentDatabase {
       const now = Date.now()
       await this.run(`
         ?[key, value, created_at, updated_at] <- [
-          ['agent_id', '${this.agentId}', ${now}, ${now}],
-          ['created_at', '${now}', ${now}, ${now}],
+          ['agent_id', ${escapeForCozo(this.agentId)}, ${now}, ${now}],
+          ['created_at', ${escapeForCozo(String(now))}, ${now}, ${now}],
           ['db_version', '0.1.0', ${now}, ${now}]
         ]
         :put agent_metadata {key => value, created_at, updated_at}

--- a/lib/cozo-schema-rag.ts
+++ b/lib/cozo-schema-rag.ts
@@ -203,7 +203,7 @@ export async function initializeRagSchema(agentDb: AgentDatabase): Promise<void>
             if (existingData.rows.length > 0) {
               for (const row of existingData.rows) {
                 await agentDb.run(`
-                  ?[component_id, name, file_id, class_type] <- [['${row[0]}', '${row[1]}', '${row[2]}', 'class']]
+                  ?[component_id, name, file_id, class_type] <- [[${escapeForCozo(row[0])}, ${escapeForCozo(row[1])}, ${escapeForCozo(row[2])}, 'class']]
                   :put components
                 `)
               }
@@ -835,7 +835,7 @@ export async function upsertMessage(
     const base64Vec = embedding.toString('base64')
     await agentDb.run(`
       ?[msg_id, vec] <- [[
-        '${message.msg_id}',
+        ${escapeForCozo(message.msg_id)},
         decode_base64('${base64Vec}')
       ]]
       :put msg_vec
@@ -886,7 +886,7 @@ export async function getMessagesByIds(
 }>> {
   if (msgIds.length === 0) return []
 
-  const ids = msgIds.map((id) => `'${id}'`).join(', ')
+  const ids = msgIds.map((id) => escapeForCozo(id)).join(', ')
   const result = await agentDb.run(`
     ?[msg_id, conversation_file, role, ts, text] :=
       *messages{msg_id, conversation_file, role, ts, text},
@@ -910,7 +910,7 @@ export async function searchMessagesByTerm(
   term: string
 ): Promise<Array<{ msg_id: string }>> {
   const result = await agentDb.run(`
-    ?[msg_id] := *msg_terms{msg_id, term}, term = '${term.toLowerCase()}'
+    ?[msg_id] := *msg_terms{msg_id, term}, term = ${escapeForCozo(term.toLowerCase())}
   `)
 
   return result.rows.map((row: any[]) => ({
@@ -926,7 +926,7 @@ export async function searchMessagesBySymbol(
   symbol: string
 ): Promise<Array<{ msg_id: string }>> {
   const result = await agentDb.run(`
-    ?[msg_id] := *code_symbols{msg_id, symbol}, symbol = '${symbol}'
+    ?[msg_id] := *code_symbols{msg_id, symbol}, symbol = ${escapeForCozo(symbol)}
   `)
 
   return result.rows.map((row: any[]) => ({

--- a/lib/rag/doc-indexer.ts
+++ b/lib/rag/doc-indexer.ts
@@ -10,6 +10,7 @@ import * as path from 'path'
 import * as crypto from 'crypto'
 import { glob } from 'glob'
 import { AgentDatabase } from '../cozo-db'
+import { escapeForCozo } from '../cozo-utils'
 import { embedTexts, vectorToBuffer } from './embeddings'
 import { extractTerms } from './keywords'
 
@@ -320,18 +321,6 @@ async function parseDocument(filePath: string, projectPath: string): Promise<Ind
   }
 }
 
-/**
- * CozoDB string escaping helper
- */
-function escapeForCozo(s: string): string {
-  return "'" + s
-    .replace(/\\/g, '\\\\')
-    .replace(/'/g, "\\'")
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t')
-    + "'"
-}
 
 /**
  * Clear documentation graph for a project

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -36,18 +36,3 @@ export function debounce<T extends (...args: any[]) => any>(
     timeout = setTimeout(later, wait)
   }
 }
-
-export function throttle<T extends (...args: any[]) => any>(
-  func: T,
-  limit: number
-): (...args: Parameters<T>) => void {
-  let inThrottle: boolean
-
-  return function executedFunction(...args: Parameters<T>) {
-    if (!inThrottle) {
-      func(...args)
-      inThrottle = true
-      setTimeout(() => (inThrottle = false), limit)
-    }
-  }
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.1"
+VERSION="0.25.2"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.1",
+  "version": "0.25.2",
   "releaseDate": "2026-03-13",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Security**: Escape all user-controlled strings in CozoDB queries via `escapeForCozo()` to prevent query injection (#286)
- **DRY**: Hoist `FEMALE_ALIASES`, `MALE_ALIASES`, `getRandomAlias()` to `lib/agent-utils.ts` — removes 3 duplicate copies (#284)
- **DRY**: Replace inline debounce implementations in `useTerminal.ts` and `immersive/page.tsx` with import from `lib/utils.ts`, remove unused `throttle()` (#283)
- Remove duplicate `escapeForCozo()` from `lib/rag/doc-indexer.ts`, import canonical version from `cozo-utils`

## Files changed
| File | Change |
|------|--------|
| `lib/cozo-db.ts` | Escape agentId in metadata queries |
| `lib/cozo-schema-rag.ts` | Escape msg_id, term, symbol in 3 query functions |
| `lib/rag/doc-indexer.ts` | Remove duplicate escapeForCozo, import from cozo-utils |
| `lib/agent-utils.ts` | Add shared alias arrays + getRandomAlias() |
| `components/AgentList.tsx` | Import getRandomAlias from agent-utils, remove 2 local copies |
| `components/AgentCreationWizard.tsx` | Import getRandomAlias from agent-utils, remove local copy |
| `hooks/useTerminal.ts` | Import debounce from lib/utils, remove local copy |
| `app/immersive/page.tsx` | Import debounce from lib/utils, replace inline IIFE |
| `lib/utils.ts` | Remove unused throttle() export |

## Test plan
- [x] `yarn test` — 486/486 pass
- [x] `yarn build` — clean production build
- [ ] Verify alias generation still works in agent creation modal
- [ ] Verify terminal resize debouncing works in immersive mode

Closes #286, closes #284, closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)