### PR TITLE
feat: DJB2 hash dedup, tablet nav, layout toggle, pin onnxruntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,8 +98,19 @@ export default function DashboardPage() {
   })
   const [isResizing, setIsResizing] = useState(false)
   const { deviceType } = useDeviceType()
-  const isMobile = deviceType === 'phone'
-  const isTablet = deviceType === 'tablet'
+  const [layoutOverride, setLayoutOverride] = useState<'desktop' | 'tablet' | null>(() => {
+    if (typeof window === 'undefined') return null
+    const saved = localStorage.getItem('aimaestro-layout-mode')
+    return (saved === 'desktop' || saved === 'tablet') ? saved : null
+  })
+  const effectiveLayout = layoutOverride || (deviceType === 'phone' ? 'phone' : deviceType)
+  const isMobile = effectiveLayout === 'phone'
+  const isTablet = effectiveLayout === 'tablet'
+  const toggleLayout = () => {
+    const next = isTablet ? 'desktop' : 'tablet'
+    setLayoutOverride(next)
+    localStorage.setItem('aimaestro-layout-mode', next)
+  }
   const [activeTab, setActiveTab] = useState<'terminal' | 'chat' | 'messages' | 'worktree' | 'graph' | 'memory' | 'docs' | 'search' | 'export' | 'playback'>('terminal')
   const [unreadCount, setUnreadCount] = useState(0)
   const [isProfileOpen, setIsProfileOpen] = useState(false)
@@ -578,6 +589,7 @@ export default function DashboardPage() {
           loading={agentsLoading}
           error={agentsError?.message || null}
           onRefresh={refreshAgents}
+          onSwitchLayout={toggleLayout}
         />
       </TerminalProvider>
     )
@@ -593,6 +605,7 @@ export default function DashboardPage() {
           sidebarCollapsed={sidebarCollapsed}
           activeAgentId={activeAgentId}
           onOpenHelp={() => setIsHelpOpen(true)}
+          onSwitchLayout={toggleLayout}
         />
 
         {/* Migration Banner */}

--- a/components/AgentBadge.tsx
+++ b/components/AgentBadge.tsx
@@ -13,6 +13,7 @@ import {
   Mail,
   Box,
 } from 'lucide-react'
+import { computeHash, getAvatarUrl } from '@/lib/hash-utils'
 import { Agent, AgentSession } from '@/types/agent'
 import { SessionActivityStatus } from '@/hooks/useSessionActivity'
 
@@ -32,26 +33,6 @@ interface AgentBadgeProps {
   showActions?: boolean
 }
 
-// Generate a consistent unique avatar URL from agent ID using RandomUser.me
-// RandomUser.me has 100 men + 100 women = 200 unique portraits
-function getAvatarUrl(agentId: string): string {
-  // Hash the agent ID to get a consistent number
-  let hash = 0
-  for (let i = 0; i < agentId.length; i++) {
-    const char = agentId.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash = hash & hash // Convert to 32-bit integer
-  }
-
-  // Use absolute value and mod to get index 0-99
-  const index = Math.abs(hash) % 100
-
-  // Alternate between men and women based on another bit of the hash
-  const gender = (Math.abs(hash >> 8) % 2 === 0) ? 'men' : 'women'
-
-  return `/avatars/${gender}_${index.toString().padStart(2, '0')}.png`
-}
-
 // Generate a consistent color from a string (for avatar ring/fallback)
 function stringToRingColor(str: string): string {
   const colors = [
@@ -67,10 +48,7 @@ function stringToRingColor(str: string): string {
     'ring-pink-500',
   ]
 
-  let hash = 0
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash)
-  }
+  const hash = computeHash(str)
 
   return colors[Math.abs(hash) % colors.length]
 }

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -51,6 +51,7 @@ import TeamListView from './sidebar/TeamListView'
 import MeetingListView from './sidebar/MeetingListView'
 import { useToast } from '@/contexts/ToastContext'
 import { getAgentBaseUrl, getRandomAlias } from '@/lib/agent-utils'
+import { computeHash } from '@/lib/hash-utils'
 
 interface AgentListProps {
   agents: UnifiedAgent[]
@@ -469,9 +470,7 @@ export default function AgentList({
       }
     }
 
-    const hash = category.split('').reduce((acc, char) => {
-      return char.charCodeAt(0) + ((acc << 5) - acc)
-    }, 0)
+    const hash = computeHash(category)
 
     const colorIndex = Math.abs(hash) % COLOR_PALETTE.length
     return COLOR_PALETTE[colorIndex]

--- a/components/CreateAgentAnimation.tsx
+++ b/components/CreateAgentAnimation.tsx
@@ -2,6 +2,7 @@
 
 import { motion, AnimatePresence } from 'framer-motion'
 import { Sparkles, Star, Cpu, Terminal, Zap, Heart, Code, Folder, GitBranch, FolderOpen, Play, MessageSquare, Server } from 'lucide-react'
+import { getAvatarUrl } from '@/lib/hash-utils'
 
 interface CreateAgentAnimationProps {
   phase: 'naming' | 'preparing' | 'creating' | 'ready' | 'error'
@@ -12,18 +13,8 @@ interface CreateAgentAnimationProps {
   showNextSteps?: boolean  // Show next steps guide in ready phase
 }
 
-// Generate a preview avatar URL from agent name (same logic as AgentBadge)
-export function getPreviewAvatarUrl(agentName: string): string {
-  let hash = 0
-  for (let i = 0; i < agentName.length; i++) {
-    const char = agentName.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash = hash & hash
-  }
-  const index = Math.abs(hash) % 100
-  const gender = (Math.abs(hash >> 8) % 2 === 0) ? 'men' : 'women'
-  return `/avatars/${gender}_${index.toString().padStart(2, '0')}.png`
-}
+// Re-export for backward compatibility with existing callers
+export const getPreviewAvatarUrl = getAvatarUrl
 
 const PHASE_CONFIG = {
   naming: {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { Menu, HelpCircle, Grid3X3, Users, FolderKanban, UserCircle, Puzzle } from 'lucide-react'
+import { Menu, HelpCircle, Grid3X3, Users, FolderKanban, UserCircle, Puzzle, Tablet } from 'lucide-react'
 
 interface HeaderProps {
   onToggleSidebar?: () => void
   sidebarCollapsed?: boolean
   activeAgentId?: string | null
   onOpenHelp?: () => void
+  onSwitchLayout?: () => void
 }
 
-export default function Header({ onToggleSidebar, sidebarCollapsed, activeAgentId, onOpenHelp }: HeaderProps) {
+export default function Header({ onToggleSidebar, sidebarCollapsed, activeAgentId, onOpenHelp, onSwitchLayout }: HeaderProps) {
   const immersiveUrl = activeAgentId ? `/immersive?agent=${encodeURIComponent(activeAgentId)}` : '/immersive'
   const companionUrl = activeAgentId ? `/companion?agent=${encodeURIComponent(activeAgentId)}` : '/companion'
   const zoomUrl = '/zoom'
@@ -86,6 +87,16 @@ export default function Header({ onToggleSidebar, sidebarCollapsed, activeAgentI
           >
             Immersive Experience
           </a>
+          {onSwitchLayout && (
+            <button
+              onClick={onSwitchLayout}
+              className="p-1.5 rounded-lg hover:bg-gray-800 transition-colors text-gray-400 hover:text-gray-300"
+              aria-label="Switch to tablet layout"
+              title="Switch to tablet layout"
+            >
+              <Tablet className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </div>
     </header>

--- a/components/TabletDashboard.tsx
+++ b/components/TabletDashboard.tsx
@@ -6,7 +6,7 @@ import MobileChatView from './MobileChatView'
 import MobileMessageCenter from './MobileMessageCenter'
 import MobileWorkTree from './MobileWorkTree'
 import MobileConversationDetail from './MobileConversationDetail'
-import { Terminal, Mail, RefreshCw, Activity, Phone, MessageSquare } from 'lucide-react'
+import { Terminal, Mail, RefreshCw, Activity, Phone, MessageSquare, Plus, Settings, Monitor } from 'lucide-react'
 import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 import { useHosts } from '@/hooks/useHosts'
@@ -17,13 +17,15 @@ interface TabletDashboardProps {
   loading: boolean
   error: string | null
   onRefresh: () => void
+  onSwitchLayout?: () => void
 }
 
 export default function TabletDashboard({
   agents,
   loading,
   error,
-  onRefresh
+  onRefresh,
+  onSwitchLayout
 }: TabletDashboardProps) {
   const { hosts } = useHosts()
   const [activeAgentId, setActiveAgentId] = useState<string | null>(null)
@@ -94,14 +96,34 @@ export default function TabletDashboard({
             </span>
           </div>
 
-          <button
-            onClick={onRefresh}
-            disabled={loading}
-            className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors disabled:opacity-50 flex-shrink-0"
-            aria-label="Refresh agents"
-          >
-            <RefreshCw className={`w-5 h-5 text-gray-400 ${loading ? 'animate-spin' : ''}`} />
-          </button>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {onSwitchLayout && (
+              <button
+                onClick={onSwitchLayout}
+                className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+                aria-label="Switch to desktop layout"
+                title="Switch to desktop layout"
+              >
+                <Monitor className="w-5 h-5 text-gray-400" />
+              </button>
+            )}
+            <a
+              href="/settings"
+              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+              aria-label="Settings"
+              title="Settings"
+            >
+              <Settings className="w-5 h-5 text-gray-400" />
+            </a>
+            <button
+              onClick={onRefresh}
+              disabled={loading}
+              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors disabled:opacity-50"
+              aria-label="Refresh agents"
+            >
+              <RefreshCw className={`w-5 h-5 text-gray-400 ${loading ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
         </div>
 
         {error && (
@@ -115,8 +137,16 @@ export default function TabletDashboard({
       <div className="flex-1 flex overflow-hidden" style={{ minHeight: 0 }}>
         {/* Left: Agent sidebar */}
         <aside className="w-60 flex-shrink-0 border-r border-gray-800 bg-gray-950 overflow-y-auto">
-          <div className="px-3 py-2 border-b border-gray-800">
+          <div className="px-3 py-2 border-b border-gray-800 flex items-center justify-between">
             <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">Agents</p>
+            <a
+              href="/zoom"
+              className="p-1 rounded hover:bg-gray-800 transition-colors"
+              aria-label="Create agent"
+              title="Create agent"
+            >
+              <Plus className="w-4 h-4 text-gray-500 hover:text-gray-300" />
+            </a>
           </div>
           {onlineAgents.length === 0 && (
             <div className="px-4 py-8 text-center">

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.2
+**Current Version:** v0.25.3
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.2",
+      "softwareVersion": "0.25.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.2",
+      "softwareVersion": "0.25.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.2</span>
+                        <span>v0.25.3</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -8,6 +8,7 @@ import { getSelfHost, getSelfHostId } from '@/lib/hosts-config'
 import { renameInIndex, removeFromIndex } from '@/lib/amp-inbox-writer'
 import { invalidateAgentCache } from '@/lib/messageQueue'
 import { sessionExistsSync, killSessionSync, renameSessionSync } from '@/lib/agent-runtime'
+import { computeHash, getGenderFromHash, getAvatarUrl } from '@/lib/hash-utils'
 
 const AIMAESTRO_DIR = path.join(os.homedir(), '.aimaestro')
 const AGENTS_DIR = path.join(AIMAESTRO_DIR, 'agents')
@@ -31,35 +32,17 @@ const MALE_NAMES = [
 ]
 
 /**
- * Compute hash from string (same algorithm as AgentBadge.tsx)
- */
-function computeHash(str: string): number {
-  let hash = 0
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash = hash & hash
-  }
-  return hash
-}
-
-/**
- * Determine gender from agent ID (same logic as avatar selection)
+ * Determine gender from agent ID (convenience wrapper)
  */
 function getGenderFromId(agentId: string): 'male' | 'female' {
-  const hash = computeHash(agentId)
-  return (Math.abs(hash >> 8) % 2 === 0) ? 'male' : 'female'
+  return getGenderFromHash(computeHash(agentId))
 }
 
 /**
- * Generate avatar URL from agent ID (same as AgentBadge.tsx)
- * RandomUser.me has 100 men + 100 women = 200 unique portraits
+ * Generate avatar URL from agent ID (delegates to shared hash-utils)
  */
 function generateAvatarUrl(agentId: string): string {
-  const hash = computeHash(agentId)
-  const index = Math.abs(hash) % 100
-  const gender = getGenderFromId(agentId) === 'male' ? 'men' : 'women'
-  return `/avatars/${gender}_${index.toString().padStart(2, '0')}.png`
+  return getAvatarUrl(agentId)
 }
 
 /**

--- a/lib/agent-utils.ts
+++ b/lib/agent-utils.ts
@@ -7,6 +7,7 @@
 
 import type { Agent } from '@/types/agent'
 import type { Session } from '@/types/session'
+import { computeHash, getGenderFromHash } from '@/lib/hash-utils'
 
 /**
  * Get the base URL for API calls to an agent's host.
@@ -44,13 +45,8 @@ export const MALE_ALIASES = [
  * Uses same hash logic as AgentBadge avatar selection for consistency.
  */
 export function getRandomAlias(agentName: string): string {
-  let hash = 0
-  for (let i = 0; i < agentName.length; i++) {
-    const char = agentName.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash = hash & hash
-  }
-  const isMale = (Math.abs(hash >> 8) % 2 === 0)
+  const hash = computeHash(agentName)
+  const isMale = getGenderFromHash(hash) === 'male'
   const aliases = isMale ? MALE_ALIASES : FEMALE_ALIASES
   return aliases[Math.abs(hash) % aliases.length]
 }

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -18,6 +18,7 @@ import { hostHints } from './host-hints'
 import { getAgent as getAgentFromRegistry } from './agent-registry'
 import { getSelfHost } from './hosts-config'
 import { computeSessionName } from '@/types/agent'
+import { computeHash } from './hash-utils'
 import { Cerebellum } from './cerebellum/cerebellum'
 import { MemorySubsystem } from './cerebellum/memory-subsystem'
 import { VoiceSubsystem } from './cerebellum/voice-subsystem'
@@ -186,10 +187,7 @@ class AgentSubconscious {
    * This ensures consistent spreading of agents across time
    */
   private calculateStaggerOffset(): number {
-    // Hash the agentId to get a consistent number
-    const hash = this.agentId.split('').reduce(
-      (acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0
-    )
+    const hash = computeHash(this.agentId)
     // Spread across 5 minutes (300 seconds) to avoid clustering
     const maxOffset = 5 * 60 * 1000 // 5 minutes
     return Math.abs(hash) % maxOffset
@@ -282,9 +280,7 @@ class AgentSubconscious {
     }
 
     // Add stagger offset to prevent all agents from running at once
-    const staggerMinutes = Math.abs(this.agentId.split('').reduce(
-      (acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0
-    )) % 30  // Spread across 30 minutes
+    const staggerMinutes = Math.abs(computeHash(this.agentId)) % 30  // Spread across 30 minutes
     nextRun.setMinutes(staggerMinutes)
 
     const timeUntilRun = nextRun.getTime() - now.getTime()

--- a/lib/hash-utils.ts
+++ b/lib/hash-utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared DJB2 hash utilities
+ *
+ * Single source of truth for the hash algorithm used across:
+ * - Avatar URL generation
+ * - Gender determination
+ * - Category color assignment
+ * - Stagger offset calculation
+ */
+
+/**
+ * Compute a DJB2-style hash from a string.
+ * Returns a 32-bit integer (may be negative).
+ */
+export function computeHash(str: string): number {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash = hash & hash // Convert to 32-bit integer
+  }
+  return hash
+}
+
+/**
+ * Determine gender from an ID string (for avatar/alias matching).
+ */
+export function getGenderFromHash(hash: number): 'male' | 'female' {
+  return (Math.abs(hash >> 8) % 2 === 0) ? 'male' : 'female'
+}
+
+/**
+ * Generate a consistent avatar URL from an agent ID or name.
+ * Uses local avatar files: /avatars/{gender}_{index}.png
+ */
+export function getAvatarUrl(id: string): string {
+  const hash = computeHash(id)
+  const index = Math.abs(hash) % 100
+  const gender = getGenderFromHash(hash) === 'male' ? 'men' : 'women'
+  return `/avatars/${gender}_${index.toString().padStart(2, '0')}.png`
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",
@@ -55,7 +55,7 @@
     "minisearch": "^7.2.0",
     "next": "14.2.35",
     "node-pty": "^1.0.0",
-    "onnxruntime-node": "1.23.2",
+    "onnxruntime-node": "1.17.0",
     "pg": "^8.16.3",
     "react": "^18.3.0",
     "react-cytoscapejs": "^2.0.0",
@@ -87,6 +87,6 @@
     "vitest": "^4.0.18"
   },
   "resolutions": {
-    "onnxruntime-node": "1.23.2"
+    "onnxruntime-node": "1.17.0"
   }
 }

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.2"
+VERSION="0.25.3"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.2",
-  "releaseDate": "2026-03-13",
+  "version": "0.25.3",
+  "releaseDate": "2026-03-14",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- **DRY**: Create `lib/hash-utils.ts` with shared `computeHash()`, `getGenderFromHash()`, `getAvatarUrl()` — replaces 8 duplicate DJB2 hash implementations (#282)
- **Tablet nav**: Add Plus button (links to /zoom) and Settings gear to TabletDashboard header (#280)
- **Layout toggle**: Add Monitor/Tablet toggle button to both TabletDashboard and desktop Header — persists in localStorage (#281)
- **Build fix**: Pin `onnxruntime-node` to 1.17.0 — last version with darwin/x64 binaries (#233)

## Files changed
| File | Change |
|------|--------|
| `lib/hash-utils.ts` | **NEW** — shared DJB2 hash, gender, avatar utilities |
| `lib/agent-registry.ts` | Import from hash-utils, remove local computeHash/generateAvatarUrl |
| `lib/agent.ts` | Import computeHash for stagger offset calculations |
| `lib/agent-utils.ts` | Import computeHash/getGenderFromHash for getRandomAlias |
| `components/AgentBadge.tsx` | Import getAvatarUrl/computeHash, remove local implementations |
| `components/AgentList.tsx` | Import computeHash for getCategoryColor |
| `components/CreateAgentAnimation.tsx` | Re-export getAvatarUrl as getPreviewAvatarUrl |
| `components/TabletDashboard.tsx` | Add Plus, Settings, Monitor buttons; onSwitchLayout prop |
| `components/Header.tsx` | Add Tablet toggle button; onSwitchLayout prop |
| `app/page.tsx` | Layout override state with localStorage, pass toggleLayout |
| `package.json` | Pin onnxruntime-node to 1.17.0 |

## Test plan
- [x] `yarn test` — 486/486 pass
- [x] `yarn build` — clean production build
- [ ] Verify avatar generation unchanged (hash algorithm identical)
- [ ] Verify tablet layout shows Plus, Settings, Monitor buttons
- [ ] Verify desktop layout shows Tablet toggle
- [ ] Verify layout toggle persists across page reloads

Closes #282, closes #280, closes #281, closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)