### PR TITLE
fix: recover from WebGL context loss on Mac Mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -217,22 +217,31 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
         if (parsed.type === 'history-complete') {
           setHistoryLoaded(true)
           if (terminalInstanceRef.current) {
-            const term = terminalInstanceRef.current
-
             // Wait for xterm.js to finish processing history
             setTimeout(() => {
+              const t = terminalInstanceRef.current
+              if (!t) return
+
               // 1. CRITICAL: Refit terminal to ensure correct dimensions
               fitTerminal()
 
               // 2. Send resize to PTY to sync tmux with correct dimensions
               // This also triggers a redraw which helps with color issues
-              const resizeMsg = createResizeMessage(term.cols, term.rows)
+              const resizeMsg = createResizeMessage(t.cols, t.rows)
               sendMessage(resizeMsg)
 
               // 3. Scroll to bottom and focus
+              // try-catch guards against xterm.js renderer being undefined
+              // (WebGL context loss leaves RenderService.dimensions broken)
               setTimeout(() => {
-                term.scrollToBottom()
-                term.focus()
+                try {
+                  if (terminalInstanceRef.current) {
+                    terminalInstanceRef.current.scrollToBottom()
+                    terminalInstanceRef.current.focus()
+                  }
+                } catch {
+                  // Renderer not ready — safe to ignore, terminal will recover
+                }
               }, 50)
             }, 100)
           }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.3
+**Current Version:** v0.25.4
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.3",
+      "softwareVersion": "0.25.4",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.3",
+      "softwareVersion": "0.25.4",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.3</span>
+                        <span>v0.25.4</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -143,8 +143,19 @@ export function useTerminal(options: UseTerminalOptions = {}) {
         console.warn(`[Terminal] WebGL context lost for session ${optionsRef.current.sessionId}, falling back to canvas`)
         try { webglAddon.dispose() } catch { /* ignore */ }
         webglAddonRef.current = null
-        if (terminalRef.current) {
-          terminalRef.current.refresh(0, terminalRef.current.rows - 1)
+        // After WebGL disposal, xterm.js _renderer.value becomes undefined.
+        // RenderService.dimensions uses an unsafe non-null assertion (!), so any
+        // call to scrollToBottom/scrollLines/fit will crash with:
+        //   "Cannot read properties of undefined (reading 'dimensions')"
+        // The only recovery is to re-open the terminal element, which forces
+        // xterm.js to create a new canvas renderer.
+        const term = terminalRef.current
+        const parent = term?.element?.parentElement
+        if (term && parent) {
+          term.open(parent)
+          if (fitAddonRef.current) {
+            try { fitAddonRef.current.fit() } catch { /* ignore */ }
+          }
         }
       })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.3"
+VERSION="0.25.4"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.3",
+  "version": "0.25.4",
   "releaseDate": "2026-03-14",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- **Root cause**: Mac Mini's GPU triggers WebGL context loss, leaving xterm.js's internal `_renderer.value` as `undefined`. `RenderService.dimensions` uses an unsafe `!` non-null assertion that crashes on any `scrollToBottom()`/`fit()` call
- **Fix**: `onContextLoss` handler now re-opens the terminal element (`term.open(parent)`), forcing xterm.js to create a new canvas fallback renderer instead of leaving the terminal in a broken state with no renderer
- **Safety net**: Wrapped `scrollToBottom()`/`focus()` in try-catch in TerminalView to handle the brief race window during renderer recovery

### Call chain that crashes
```
scrollToBottom() → CoreBrowserTerminal.scrollToBottom()
  → scrollLines() → Viewport.scrollLines()
    → this._renderService.dimensions.css.cell.height
      → RenderService: this._renderer.value!.dimensions  ← CRASH
```

### Why Mac Mini only
The Mac Mini has a weaker/shared GPU (or headless display) that triggers WebGL context loss more frequently. Primary Mac (M-series) never loses WebGL context, so this path is never hit.

Closes #278

## Test plan
- [x] `yarn test` — 486/486 pass
- [x] `yarn build` — clean
- [ ] Verify on Mac Mini: terminal should recover from WebGL context loss and fall back to canvas renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)