### PR TITLE
fix: soft-deleted agents reappear as hibernating + AMP cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.4
+**Current Version:** v0.25.5
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.4",
+      "softwareVersion": "0.25.5",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.4",
+      "softwareVersion": "0.25.5",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.4</span>
+                        <span>v0.25.5</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -686,12 +686,29 @@ export function deleteAgent(id: string, hard: boolean = false): boolean {
   killAgentSessions(agentToDelete)
 
   if (!hard) {
-    // --- Soft-delete path: mark as deleted, preserve all data on disk ---
+    // --- Soft-delete path: mark as deleted, preserve agent data on disk, clean AMP ---
     const agentIndex = agents.findIndex(a => a.id === id)
     agents[agentIndex].deletedAt = new Date().toISOString()
     agents[agentIndex].status = 'deleted'
     saveAgents(agents)
     invalidateAgentCache()
+
+    // Clean up AMP directory and index so deleted agents stop receiving messages
+    try {
+      const ampAgentsDir = path.join(os.homedir(), '.agent-messaging', 'agents')
+      const uuidDir = path.join(ampAgentsDir, id)
+      if (fs.existsSync(uuidDir)) {
+        fs.rmSync(uuidDir, { recursive: true })
+        console.log(`[Agent Registry] Cleaned up AMP dir for soft-deleted agent ${id}`)
+      }
+      if (agentName) {
+        removeFromIndex(agentName)
+        console.log(`[Agent Registry] Removed ${agentName} from AMP index on soft-delete`)
+      }
+    } catch (ampError) {
+      console.warn(`[Agent Registry] Could not clean up AMP for soft-deleted agent ${id}:`, ampError)
+    }
+
     console.log(`[Agent Registry] Soft-deleted agent ${agentName} (id: ${id})`)
     return true
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.4"
+VERSION="0.25.5"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -411,7 +411,9 @@ export async function listAgents(): Promise<ServiceResult<{
     const hostUrl = selfHost?.url || `http://${os.hostname().toLowerCase()}:23000`
 
     // 1. Load all registered agents from this host's registry
-    const agents = loadAgents()
+    // Filter out soft-deleted agents (those with deletedAt timestamp)
+    const allAgents = loadAgents()
+    const agents = allAgents.filter(a => !a.deletedAt)
 
     // 2. Discover local tmux sessions
     const discoveredSessions = await discoverLocalSessions()
@@ -1259,9 +1261,16 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
   try {
     const { startProgram = true, sessionIndex = 0, program: programOverride } = params
 
-    const agent = getAgent(agentId)
+    // Check including soft-deleted to give a better error message (410 Gone vs 404)
+    const agent = getAgent(agentId, true)
     if (!agent) {
       return { error: 'Agent not found', status: 404 }
+    }
+    if (agent.deletedAt) {
+      return {
+        error: `Agent was deleted on ${new Date(agent.deletedAt).toLocaleDateString()}. Restore from backup or create a new agent.`,
+        status: 410
+      }
     }
 
     const agentName = agent.name || agent.alias

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.4",
-  "releaseDate": "2026-03-14",
+  "version": "0.25.5",
+  "releaseDate": "2026-03-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

Three related soft-delete lifecycle fixes reported by @mvillmow:

- **#292**: `listAgents()` in the service layer called `loadAgents()` directly, which returns all agents including soft-deleted ones. Deleted agents showed up as "hibernating" in the sidebar. Fixed by filtering out agents with `deletedAt` before processing.

- **#294**: `wakeAgent()` returned generic 404 for both non-existent and deleted agents. Now uses `getAgent(id, true)` to check including deleted, returns **410 Gone** with deletion date and recovery guidance.

- **#295**: Soft-delete path in `agent-registry.ts` didn't clean up AMP data (UUID directory + name index), so deleted agents kept receiving messages. Added the same AMP cleanup that hard-delete already performs.

## Files changed
- `services/agents-core-service.ts` — filter deleted from listAgents, 410 in wakeAgent
- `lib/agent-registry.ts` — AMP cleanup on soft-delete

Closes #292, closes #294, closes #295

## Test plan
- [x] `yarn test` — 486/486 pass
- [x] `yarn build` — clean
- [ ] Soft-delete an agent → verify it doesn't reappear in sidebar
- [ ] Wake a deleted agent → verify 410 Gone response
- [ ] Soft-delete an agent → verify `~/.agent-messaging/agents/<id>/` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)