### PR TITLE
feat: add Podman dev container for CI simulation

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.git
+*.md
+!package.json
+marketing/
+docs/images/
+.env*
+.DS_Store

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,34 @@
+# AI Maestro Dev Container
+# Build: podman build -t ai-maestro-dev -f Containerfile .
+# Test:  podman run --rm ai-maestro-dev yarn test
+
+FROM docker.io/library/node:20.19.2-bookworm-slim
+
+# Install system deps for native modules (node-pty, cozo-node)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy dependency manifests first for layer caching
+COPY package.json yarn.lock ./
+
+# Install dependencies as root (native modules need build tools)
+RUN yarn install --frozen-lockfile && yarn cache clean
+
+# Copy full source
+COPY . .
+
+# Ensure non-root user owns the workspace
+RUN chown -R node:node /app
+
+USER node
+
+# Ensure enough heap for Next.js builds
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
+# Default command: run tests
+CMD ["yarn", "test"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.6-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.7-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.6
+**Current Version:** v0.25.7
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.6",
+      "softwareVersion": "0.25.7",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.6",
+      "softwareVersion": "0.25.7",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.6</span>
+                        <span>v0.25.7</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",
@@ -35,7 +35,13 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:services": "vitest run tests/services/",
-    "test:lib": "vitest run --exclude 'tests/services/**'"
+    "test:lib": "vitest run --exclude 'tests/services/**'",
+    "container:build": "podman build -t ai-maestro-dev -f Containerfile .",
+    "container:test": "podman run --rm ai-maestro-dev yarn test",
+    "container:lint": "podman run --rm ai-maestro-dev yarn lint",
+    "container:build-app": "podman run --rm ai-maestro-dev sh -c 'rm -rf .next && yarn build'",
+    "container:shell": "podman run --rm -it ai-maestro-dev bash",
+    "container:ci": "podman run --rm ai-maestro-dev sh -c 'yarn test && yarn lint && npx tsc --noEmit && rm -rf .next && yarn build'"
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.6"
+VERSION="0.25.7"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.6",
-  "releaseDate": "2026-03-19",
+  "version": "0.25.7",
+  "releaseDate": "2026-03-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

Adds a Podman-based dev container so the full CI pipeline can run inside a container. Purely additive — doesn't change existing macOS workflow.

- **Containerfile** — `node:20.19.2-bookworm-slim`, build-essential + python3 for native modules, non-root, 4GB heap
- **.containerignore** — excludes node_modules, .next, .git, .env*
- **6 `container:*` scripts** in package.json for convenience

```bash
yarn container:build      # Build the image
yarn container:ci         # Full pipeline: test → lint → tsc → build
yarn container:test       # Just tests
yarn container:shell      # Interactive shell
```

Based on patch by @mvillmow. Closes #296.

## Test plan
- [x] `yarn test` — 486/486 pass
- [x] `yarn build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)