### PR TITLE
fix: pass initial terminal dimensions to PTY spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -195,7 +195,9 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
     sessionId: session.id,
     hostId: session.hostId,  // Pass host ID for remote session routing
     socketPath: session.socketPath,  // Custom tmux socket (e.g., OpenClaw agents)
-    autoConnect: isVisible,  // Only auto-connect when visible
+    initialCols: terminal?.cols,   // Pass actual terminal dimensions so PTY spawns at correct size
+    initialRows: terminal?.rows,
+    autoConnect: isVisible && isReady,  // Wait for terminal init so PTY gets correct dimensions
     onOpen: () => {
       // Reset historyLoaded - server will send new history on each connect
       setHistoryLoaded(false)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.8
+**Current Version:** v0.25.9
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.8",
+      "softwareVersion": "0.25.9",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.8",
+      "softwareVersion": "0.25.9",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.8</span>
+                        <span>v0.25.9</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/hooks/useWebSocket.ts
+++ b/hooks/useWebSocket.ts
@@ -10,6 +10,8 @@ interface UseWebSocketOptions {
   sessionId: string
   hostId?: string  // Host ID for remote sessions (peer mesh network)
   socketPath?: string  // Custom tmux socket path (e.g., OpenClaw agents)
+  initialCols?: number  // Initial terminal columns for PTY spawn (avoids 80-col default)
+  initialRows?: number  // Initial terminal rows for PTY spawn (avoids 24-row default)
   onMessage?: (data: string) => void
   onOpen?: () => void
   onClose?: () => void
@@ -21,6 +23,8 @@ export function useWebSocket({
   sessionId,
   hostId,
   socketPath,
+  initialCols,
+  initialRows,
   onMessage,
   onOpen,
   onClose,
@@ -67,8 +71,17 @@ export function useWebSocket({
       url += `&socket=${encodeURIComponent(socketPath)}`
     }
 
+    // Pass initial terminal dimensions so PTY spawns at correct size
+    // Without this, PTY defaults to 80x24 and history/output renders at wrong width
+    if (initialCols && initialCols > 0) {
+      url += `&cols=${initialCols}`
+    }
+    if (initialRows && initialRows > 0) {
+      url += `&rows=${initialRows}`
+    }
+
     return url
-  }, [sessionId, hostId, socketPath])
+  }, [sessionId, hostId, socketPath, initialCols, initialRows])
 
   const sendMessage = useCallback((data: string | WebSocketMessage) => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.8",
+  "version": "0.25.9",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.8"
+VERSION="0.25.9"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/server.mjs
+++ b/server.mjs
@@ -852,10 +852,16 @@ async function startServer(handleRequest) {
 
           const { getRuntime: getRt } = await import('./lib/agent-runtime.ts')
           const { command: attachCmd, args: attachArgs } = getRt().getAttachCommand(sessionName, socketPath)
+          // Use client-provided dimensions if available (passed via WebSocket URL query params)
+          // This ensures PTY spawns at the correct terminal size, preventing history/output
+          // from rendering at wrong width (the "overlapping text" bug when first connecting)
+          const initialCols = parseInt(query.cols, 10) || 80
+          const initialRows = parseInt(query.rows, 10) || 24
+
           ptyProcess = pty.spawn(attachCmd, attachArgs, {
             name: 'xterm-256color',
-            cols: 80,
-            rows: 24,
+            cols: initialCols,
+            rows: initialRows,
             cwd: process.env.HOME || process.cwd(),
             env: process.env
           })

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.8",
-  "releaseDate": "2026-03-20",
+  "version": "0.25.9",
+  "releaseDate": "2026-03-21",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- PTY was spawning at hardcoded 80×24 while browser terminal was wider, causing history/output to render at wrong width ("overlapping text" bug)
- Client now passes `cols`/`rows` via WebSocket URL query params so PTY spawns at correct dimensions
- WebSocket connection deferred until terminal is initialized (`autoConnect: isVisible && isReady`) so actual dimensions are available

## Files Changed
- `server.mjs` — Read `cols`/`rows` from query params for PTY spawn
- `hooks/useWebSocket.ts` — Accept `initialCols`/`initialRows`, include in WebSocket URL
- `components/TerminalView.tsx` — Pass terminal dimensions, delay connect until ready

## Test plan
- [ ] Open dashboard, verify terminal renders correctly on first connect (no overlapping text)
- [ ] Resize browser window, verify terminal reflows correctly
- [ ] Switch between agents, verify terminals display correctly
- [ ] `yarn build` passes
- [ ] `yarn test` passes (486/486)

🤖 Generated with [Claude Code](https://claude.com/claude-code)