### PR TITLE
feat: add DELETE /api/v1/messages/pending/:id route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.25.10] - 2026-03-21
+
+### Added
+- **`DELETE /api/v1/messages/pending/:id`** — Path-param route for acknowledging pending relay messages. Both `DELETE /pending/:id` and `DELETE /pending?id=X` are now supported for client compatibility.
+
 ## [0.25.9] - 2026-03-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.10-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/v1/messages/pending/[id]/route.ts
+++ b/app/api/v1/messages/pending/[id]/route.ts
@@ -1,0 +1,23 @@
+/**
+ * AMP v1 Pending Message by ID
+ *
+ * DELETE /api/v1/messages/pending/:id
+ *
+ * Path-param variant of DELETE /api/v1/messages/pending?id=X
+ * Both are supported for client compatibility.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { acknowledgePendingMessage } from '@/services/amp-service'
+import type { AMPError } from '@/lib/types/amp'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse<{ acknowledged: boolean } | AMPError>> {
+  const authHeader = request.headers.get('Authorization')
+  const { id } = await params
+
+  const result = acknowledgePendingMessage(authHeader, id)
+  return NextResponse.json(result.data!, { status: result.status })
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.9
+**Current Version:** v0.25.10
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.9",
+      "softwareVersion": "0.25.10",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.9",
+      "softwareVersion": "0.25.10",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.9</span>
+                        <span>v0.25.10</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.9",
+  "version": "0.25.10",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.9"
+VERSION="0.25.10"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -1116,7 +1116,7 @@ export function acknowledgePendingMessage(
 
   if (!messageId) {
     return {
-      data: { error: 'missing_field', message: 'Message ID required (use ?id=<messageId>)', field: 'id' } as AMPError,
+      data: { error: 'missing_field', message: 'Message ID required (use DELETE /pending/:id or DELETE /pending?id=<messageId>)', field: 'id' } as AMPError,
       status: 400
     }
   }

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -1043,6 +1043,10 @@ const routes: Route[] = [
     const authHeader = getHeader(req, 'Authorization')
     sendServiceResult(res, acknowledgePendingMessage(authHeader, query.id || null))
   }},
+  { method: 'DELETE', pattern: /^\/api\/v1\/messages\/pending\/([^/]+)$/, paramNames: ['id'], handler: async (req, res, params) => {
+    const authHeader = getHeader(req, 'Authorization')
+    sendServiceResult(res, acknowledgePendingMessage(authHeader, params.id))
+  }},
   { method: 'POST', pattern: /^\/api\/v1\/messages\/pending$/, paramNames: [], handler: async (req, res) => {
     const body = await readJsonBody(req)
     const authHeader = getHeader(req, 'Authorization')

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.9",
+  "version": "0.25.10",
   "releaseDate": "2026-03-21",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- AMP plugin (PR #7) standardized on `DELETE /api/v1/messages/pending/:id` (path param) for message acknowledgment
- Server only had `DELETE /api/v1/messages/pending?id=X` (query param)
- Now both formats are supported for client compatibility
- Added Next.js route + headless router entry

## Changes
- `app/api/v1/messages/pending/[id]/route.ts` — New path-param DELETE route
- `services/headless-router.ts` — Added headless router entry
- `services/amp-service.ts` — Updated error message
- `CHANGELOG.md` — Added v0.25.10 entry

## Re: delivery bug report
The delivery code (`message-delivery.ts` → `writeToAMPInbox()`) is correct — it writes to the filesystem inbox. The reported delivery failures were likely caused by the case-sensitivity bug fixed in v0.25.6 (AMP name lookups not normalizing to lowercase).

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn test` passes (486/486)
- [ ] `curl -X DELETE .../api/v1/messages/pending/test123` returns proper response (not 404 HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)