### PR TITLE
fix: AMP .index.json name→UUID mapping on registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.25.11] - 2026-03-21
+
+### Fixed
+- **AMP inbox name→UUID resolution** — `registerAgent()` now calls `initAgentAMPHome()` so `.index.json` maps agent names to UUIDs. Previously, server wrote messages to UUID-based directories but CLI tools resolved via name-based paths, causing delivered messages to be invisible to `amp-inbox.sh`.
+
 ## [0.25.10] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.10-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.10
+**Current Version:** v0.25.11
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.10",
+      "softwareVersion": "0.25.11",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.10",
+      "softwareVersion": "0.25.11",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.10</span>
+                        <span>v0.25.11</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.10",
+  "version": "0.25.11",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.10"
+VERSION="0.25.11"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -35,6 +35,7 @@ import { authenticateRequest, createApiKey, hashApiKey, extractApiKeyFromHeader,
 import { saveKeyPair, loadKeyPair, calculateFingerprint, verifySignature, generateKeyPair } from '@/lib/amp-keys'
 import { queueMessage, getPendingMessages, acknowledgeMessage, acknowledgeMessages, cleanupAllExpiredMessages } from '@/lib/amp-relay'
 import { deliver } from '@/lib/message-delivery'
+import { initAgentAMPHome } from '@/lib/amp-inbox-writer'
 import { deliverViaWebSocket } from '@/lib/amp-websocket'
 import { resolveAgentIdentifier } from '@/lib/messageQueue'
 import { getSelfHostId, getSelfHost, getHostById, isSelf, getOrganization } from '@/lib/hosts-config-server.mjs'
@@ -672,6 +673,15 @@ export async function registerAgent(
       })
     } catch (err) {
       console.error('[AMP Register] Failed to save public key:', err)
+    }
+
+    // Initialize AMP home directory and update .index.json with name→UUID mapping
+    // Without this, amp-inbox.sh resolves to a name-based directory instead of the UUID directory
+    // where the server writes incoming messages
+    try {
+      await initAgentAMPHome(normalizedName, agent.id)
+    } catch (err) {
+      console.warn('[AMP Register] Failed to init AMP home:', err)
     }
 
     // Get provider domain based on organization

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.10",
+  "version": "0.25.11",
   "releaseDate": "2026-03-21",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- `registerAgent()` in `amp-service.ts` now calls `initAgentAMPHome(name, uuid)` after agent creation
- This ensures `.index.json` maps agent names to UUIDs, so CLI tools (`amp-inbox.sh`) find messages written by the server to UUID-based directories
- Without this fix, delivered messages were invisible — server reported "delivered" but `amp-inbox.sh` showed empty inbox

## Root Cause
- Server writes to `~/.agent-messaging/agents/<UUID>/messages/inbox/`
- `amp-init.sh` wrote `"name": "name"` to `.index.json` instead of `"name": "<UUID>"`
- `amp-inbox.sh` resolved via `.index.json` → pointed to wrong (name-based) directory

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (486/486)
- [ ] Manual: re-register an agent, verify `.index.json` has name→UUID mapping
- [ ] Manual: send message via `/api/v1/route`, verify `amp-inbox.sh` sees it

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)