### PR TITLE
feat: accept client-provided agent_id in AMP registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.25.12] - 2026-03-21
+
+### Added
+- **Client-provided `agent_id` in AMP registration** — `POST /api/v1/register` now accepts an optional `agent_id` field. If a valid UUIDv4 is provided, the server uses it as the agent's canonical identifier instead of generating one. Supports offline-first agent initialization.
+
 ## [0.25.11] - 2026-03-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.11
+**Current Version:** v0.25.12
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.11",
+      "softwareVersion": "0.25.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.11",
+      "softwareVersion": "0.25.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.11</span>
+                        <span>v0.25.12</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -367,8 +367,9 @@ export function createAgent(request: CreateAgentRequest): Agent {
     })
   }
 
-  // Generate ID first so we can use it for gender-matched persona name and avatar
-  const agentId = uuidv4()
+  // Use client-provided ID (offline-first) or generate one
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  const agentId = (request.id && UUID_RE.test(request.id)) ? request.id : uuidv4()
 
   // Get already used labels and avatars on this host
   const { labels: usedLabels, avatars: usedAvatars } = getUsedLabelsAndAvatars(hostId)

--- a/lib/types/amp.ts
+++ b/lib/types/amp.ts
@@ -190,6 +190,9 @@ export interface AMPMessage {
  * POST /v1/register
  */
 export interface AMPRegistrationRequest {
+  /** Client-provided agent UUID (offline-first identity). Server uses this if valid, generates one otherwise. */
+  agent_id?: string
+
   /** Tenant/organization identifier */
   tenant: string
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.11",
+  "version": "0.25.12",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.11"
+VERSION="0.25.12"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -635,6 +635,7 @@ export async function registerAgent(
     } else {
       try {
         agent = createAgent({
+          id: body.agent_id,
           name: normalizedName,
           label: body.alias,
           program: 'Claude Code',

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -436,6 +436,7 @@ export interface AgentSummary {
  * Agent creation request
  */
 export interface CreateAgentRequest {
+  id?: string                   // Client-provided UUID (offline-first). Generated if not provided.
   name: string                  // Agent identity (was alias)
   label?: string                // Optional display override (was displayName)
   avatar?: string

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.11",
+  "version": "0.25.12",
   "releaseDate": "2026-03-21",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- `POST /api/v1/register` now accepts optional `agent_id` field (UUIDv4)
- Server uses client-provided ID as canonical identifier if valid, generates one otherwise
- Backward compatible — existing registrations without `agent_id` work unchanged
- Supports offline-first agent initialization per AMP spec Section 03

## Changes
- `lib/types/amp.ts` — Added `agent_id?: string` to `AMPRegistrationRequest`
- `types/agent.ts` — Added `id?: string` to `CreateAgentRequest`
- `lib/agent-registry.ts` — `createAgent()` uses provided ID if valid UUID, else generates
- `services/amp-service.ts` — Passes `body.agent_id` through to `createAgent()`

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (486/486)
- [ ] Manual: register with `agent_id` in body → verify same UUID used
- [ ] Manual: register without `agent_id` → verify UUID auto-generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)