### PR TITLE
feat: AMP spec compliance — batch ack path, agent card, messages alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.25.14] - 2026-03-21
+
+### Added
+- **`POST /api/v1/messages/pending/ack`** — Spec-correct path for batch message acknowledgment. Accepts `{ "ids": [...] }` body. The old `POST /api/v1/messages/pending` path is kept as a backward-compatible alias.
+- **`GET /api/v1/agents/me/card`** — Returns a signed agent card containing the agent's address, public key, fingerprint, provider, and capabilities. The card is Ed25519-signed for verification by peers.
+- **`GET /api/v1/messages`** — Alias for `GET /api/v1/messages/pending`. Some AMP clients use the shorter path to fetch pending messages. Both routes now work identically.
+
 ## [0.25.12] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.14-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/v1/agents/me/card/route.ts
+++ b/app/api/v1/agents/me/card/route.ts
@@ -1,0 +1,17 @@
+/**
+ * AMP v1 Agent Card Endpoint
+ *
+ * GET /api/v1/agents/me/card
+ *
+ * Returns a signed agent card with public key and identity info.
+ * Thin wrapper - business logic in services/amp-service.ts
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getAgentCard } from '@/services/amp-service'
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization')
+  const result = getAgentCard(authHeader)
+  return NextResponse.json(result.data!, { status: result.status })
+}

--- a/app/api/v1/messages/pending/ack/route.ts
+++ b/app/api/v1/messages/pending/ack/route.ts
@@ -1,0 +1,30 @@
+/**
+ * AMP v1 Batch Acknowledge Endpoint
+ *
+ * POST /api/v1/messages/pending/ack
+ *
+ * Spec-correct path for batch message acknowledgment.
+ * POST /api/v1/messages/pending is kept as backward-compat alias.
+ * Thin wrapper - business logic in services/amp-service.ts
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { batchAcknowledgeMessages } from '@/services/amp-service'
+import type { AMPError } from '@/lib/types/amp'
+
+export async function POST(request: NextRequest): Promise<NextResponse<{ acknowledged: number } | AMPError>> {
+  const authHeader = request.headers.get('Authorization')
+
+  let body: { ids?: string[] }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({
+      error: 'invalid_request',
+      message: 'Invalid JSON body'
+    } as AMPError, { status: 400 })
+  }
+
+  const result = batchAcknowledgeMessages(authHeader, body.ids)
+  return NextResponse.json(result.data!, { status: result.status })
+}

--- a/app/api/v1/messages/route.ts
+++ b/app/api/v1/messages/route.ts
@@ -1,0 +1,25 @@
+/**
+ * AMP v1 Messages Endpoint
+ *
+ * GET /api/v1/messages?limit=10
+ *
+ * Alias for GET /api/v1/messages/pending — some AMP clients use this shorter path.
+ * Thin wrapper - business logic in services/amp-service.ts
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { listPendingMessages } from '@/services/amp-service'
+import type { AMPError, AMPPendingMessagesResponse } from '@/lib/types/amp'
+
+export async function GET(request: NextRequest): Promise<NextResponse<AMPPendingMessagesResponse | AMPError>> {
+  const authHeader = request.headers.get('Authorization')
+  const { searchParams } = new URL(request.url)
+  const limitParam = searchParams.get('limit')
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined
+
+  const result = listPendingMessages(authHeader, limit)
+  return NextResponse.json(result.data!, {
+    status: result.status,
+    headers: result.headers
+  })
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.12
+**Current Version:** v0.25.14
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.12",
+      "softwareVersion": "0.25.14",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.12",
+      "softwareVersion": "0.25.14",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.12</span>
+                        <span>v0.25.14</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.12",
+  "version": "0.25.14",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.12"
+VERSION="0.25.14"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -10,12 +10,16 @@
  *   GET    /api/v1/info                      -> getProviderInfo
  *   POST   /api/v1/register                  -> registerAgent
  *   POST   /api/v1/route                     -> routeMessage
+ *   GET    /api/v1/messages                   -> listPendingMessages (alias)
  *   GET    /api/v1/messages/pending           -> listPendingMessages
  *   DELETE /api/v1/messages/pending           -> acknowledgePendingMessage
- *   POST   /api/v1/messages/pending           -> batchAcknowledgeMessages
+ *   DELETE /api/v1/messages/pending/:id       -> acknowledgePendingMessage
+ *   POST   /api/v1/messages/pending/ack       -> batchAcknowledgeMessages (spec path)
+ *   POST   /api/v1/messages/pending           -> batchAcknowledgeMessages (compat alias)
  *   POST   /api/v1/messages/:id/read          -> sendReadReceipt
  *   GET    /api/v1/agents                     -> listAMPAgents
  *   GET    /api/v1/agents/me                  -> getAgentSelf
+ *   GET    /api/v1/agents/me/card             -> getAgentCard
  *   PATCH  /api/v1/agents/me                  -> updateAgentSelf
  *   DELETE /api/v1/agents/me                  -> deleteAgentSelf
  *   GET    /api/v1/agents/resolve/:address    -> resolveAgentAddress
@@ -1324,6 +1328,68 @@ export function getAgentSelf(authHeader: string | null): ServiceResult<any> {
     },
     status: 200
   }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/me/card
+// ---------------------------------------------------------------------------
+
+export function getAgentCard(authHeader: string | null): ServiceResult<any> {
+  const auth = authenticateRequest(authHeader)
+
+  if (!auth.authenticated) {
+    return {
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      status: 401
+    }
+  }
+
+  const agent = getAgent(auth.agentId!)
+  if (!agent) {
+    return {
+      data: { error: 'not_found', message: 'Agent not found' } as AMPError,
+      status: 404
+    }
+  }
+
+  const keyPair = loadKeyPair(auth.agentId!)
+  if (!keyPair) {
+    return {
+      data: { error: 'not_found', message: 'Agent keypair not found' } as AMPError,
+      status: 404
+    }
+  }
+
+  const address = auth.address || `${agent.name}@${getAMPProviderDomain(getOrganization() || undefined)}`
+  const signedAt = new Date().toISOString()
+
+  // Build the card
+  const card: Record<string, unknown> = {
+    address,
+    name: agent.name,
+    alias: agent.alias || agent.label || null,
+    public_key: keyPair.publicPem,
+    fingerprint: keyPair.fingerprint,
+    provider: getAMPProviderDomain(getOrganization() || undefined),
+    capabilities: ['messaging', 'read_receipts'],
+    signed_at: signedAt,
+  }
+
+  // Sign: address|public_key_pem|signed_at
+  try {
+    const signable = `${address}|${keyPair.publicPem}|${signedAt}`
+    const privateKey = crypto.createPrivateKey(keyPair.privatePem)
+    const signature = crypto.sign(null, Buffer.from(signable), privateKey)
+    card.signature = signature.toString('base64')
+  } catch (err) {
+    console.error('[AMP] Failed to sign agent card:', err)
+    return {
+      data: { error: 'internal_error', message: 'Failed to sign card' } as AMPError,
+      status: 500
+    }
+  }
+
+  return { data: card, status: 200 }
 }
 
 // ---------------------------------------------------------------------------

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -178,6 +178,7 @@ import {
   sendReadReceipt,
   listAMPAgents,
   getAgentSelf,
+  getAgentCard,
   updateAgentSelf,
   deleteAgentSelf,
   resolveAgentAddress,
@@ -1009,6 +1010,9 @@ const routes: Route[] = [
     )
     sendServiceResult(res, result)
   }},
+  { method: 'GET', pattern: /^\/api\/v1\/agents\/me\/card$/, paramNames: [], handler: async (req, res) => {
+    sendServiceResult(res, getAgentCard(getHeader(req, 'Authorization')))
+  }},
   { method: 'GET', pattern: /^\/api\/v1\/agents\/me$/, paramNames: [], handler: async (req, res) => {
     sendServiceResult(res, getAgentSelf(getHeader(req, 'Authorization')))
   }},
@@ -1035,6 +1039,10 @@ const routes: Route[] = [
     } catch { /* No body is fine */ }
     sendServiceResult(res, await sendReadReceipt(authHeader, params.id, originalSender))
   }},
+  { method: 'GET', pattern: /^\/api\/v1\/messages$/, paramNames: [], handler: async (req, res, _params, query) => {
+    const authHeader = getHeader(req, 'Authorization')
+    sendServiceResult(res, listPendingMessages(authHeader, query.limit ? parseInt(query.limit) : undefined))
+  }},
   { method: 'GET', pattern: /^\/api\/v1\/messages\/pending$/, paramNames: [], handler: async (req, res, _params, query) => {
     const authHeader = getHeader(req, 'Authorization')
     sendServiceResult(res, listPendingMessages(authHeader, query.limit ? parseInt(query.limit) : undefined))
@@ -1046,6 +1054,11 @@ const routes: Route[] = [
   { method: 'DELETE', pattern: /^\/api\/v1\/messages\/pending\/([^/]+)$/, paramNames: ['id'], handler: async (req, res, params) => {
     const authHeader = getHeader(req, 'Authorization')
     sendServiceResult(res, acknowledgePendingMessage(authHeader, params.id))
+  }},
+  { method: 'POST', pattern: /^\/api\/v1\/messages\/pending\/ack$/, paramNames: [], handler: async (req, res) => {
+    const body = await readJsonBody(req)
+    const authHeader = getHeader(req, 'Authorization')
+    sendServiceResult(res, batchAcknowledgeMessages(authHeader, body.ids))
   }},
   { method: 'POST', pattern: /^\/api\/v1\/messages\/pending$/, paramNames: [], handler: async (req, res) => {
     const body = await readJsonBody(req)

--- a/tests/services/amp-service.test.ts
+++ b/tests/services/amp-service.test.ts
@@ -1,0 +1,821 @@
+/**
+ * AMP Service Tests
+ *
+ * Tests the pure business logic in services/amp-service.ts.
+ * Mocks all lib/ dependencies — service tests validate orchestration,
+ * not filesystem I/O (which lib tests already cover).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeAgent, resetFixtureCounter } from '../test-utils/fixtures'
+
+// ============================================================================
+// Mocks — vi.hoisted() ensures availability before vi.mock() runs
+// ============================================================================
+
+const {
+  mockAgentRegistry,
+  mockAmpAuth,
+  mockAmpKeys,
+  mockAmpRelay,
+  mockDelivery,
+  mockAmpInboxWriter,
+  mockAmpWebSocket,
+  mockMessageQueue,
+  mockHostsConfig,
+  mockAmpTypes,
+} = vi.hoisted(() => ({
+  mockAgentRegistry: {
+    loadAgents: vi.fn().mockReturnValue([]),
+    createAgent: vi.fn(),
+    getAgent: vi.fn(),
+    getAgentByName: vi.fn(),
+    getAgentByNameAnyHost: vi.fn(),
+    updateAgent: vi.fn(),
+    deleteAgent: vi.fn(),
+    markAgentAsAMPRegistered: vi.fn(),
+    checkMeshAgentExists: vi.fn(),
+    getAMPRegisteredAgents: vi.fn().mockReturnValue([]),
+  },
+  mockAmpAuth: {
+    authenticateRequest: vi.fn().mockReturnValue({ authenticated: false, error: 'unauthorized', message: 'Authentication required' }),
+    createApiKey: vi.fn(),
+    hashApiKey: vi.fn(),
+    extractApiKeyFromHeader: vi.fn().mockReturnValue(null),
+    revokeApiKey: vi.fn(),
+    rotateApiKey: vi.fn(),
+    revokeAllKeysForAgent: vi.fn(),
+  },
+  mockAmpKeys: {
+    saveKeyPair: vi.fn(),
+    loadKeyPair: vi.fn().mockReturnValue(null),
+    calculateFingerprint: vi.fn().mockReturnValue('SHA256:test-fingerprint'),
+    verifySignature: vi.fn().mockReturnValue(true),
+    generateKeyPair: vi.fn(),
+  },
+  mockAmpRelay: {
+    queueMessage: vi.fn(),
+    getPendingMessages: vi.fn().mockReturnValue({ messages: [], total: 0 }),
+    acknowledgeMessage: vi.fn().mockReturnValue(true),
+    acknowledgeMessages: vi.fn().mockReturnValue(0),
+    cleanupAllExpiredMessages: vi.fn(),
+  },
+  mockDelivery: {
+    deliver: vi.fn(),
+  },
+  mockAmpInboxWriter: {
+    initAgentAMPHome: vi.fn(),
+  },
+  mockAmpWebSocket: {
+    deliverViaWebSocket: vi.fn().mockReturnValue(false),
+  },
+  mockMessageQueue: {
+    resolveAgentIdentifier: vi.fn(),
+  },
+  mockHostsConfig: {
+    getSelfHostId: vi.fn().mockReturnValue('test-host'),
+    getSelfHost: vi.fn().mockReturnValue({ id: 'test-host', name: 'Test Host', url: 'http://localhost:23000' }),
+    getHostById: vi.fn().mockReturnValue(null),
+    isSelf: vi.fn().mockReturnValue(true),
+    getOrganization: vi.fn().mockReturnValue('testorg'),
+  },
+  mockAmpTypes: {
+    AMP_PROTOCOL_VERSION: '0.1.0',
+    getAMPProviderDomain: vi.fn().mockReturnValue('testorg.aimaestro.local'),
+  },
+}))
+
+vi.mock('@/lib/agent-registry', () => mockAgentRegistry)
+vi.mock('@/lib/amp-auth', () => mockAmpAuth)
+vi.mock('@/lib/amp-keys', () => mockAmpKeys)
+vi.mock('@/lib/amp-relay', () => mockAmpRelay)
+vi.mock('@/lib/message-delivery', () => mockDelivery)
+vi.mock('@/lib/amp-inbox-writer', () => mockAmpInboxWriter)
+vi.mock('@/lib/amp-websocket', () => mockAmpWebSocket)
+vi.mock('@/lib/messageQueue', () => mockMessageQueue)
+vi.mock('@/lib/hosts-config-server.mjs', () => mockHostsConfig)
+vi.mock('@/lib/types/amp', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/lib/types/amp')
+  return { ...actual, ...mockAmpTypes }
+})
+
+// ============================================================================
+// Import module under test (after mocks)
+// ============================================================================
+
+import {
+  getHealthStatus,
+  getProviderInfo,
+  listPendingMessages,
+  acknowledgePendingMessage,
+  batchAcknowledgeMessages,
+  listAMPAgents,
+  getAgentSelf,
+  getAgentCard,
+  updateAgentSelf,
+  deleteAgentSelf,
+  resolveAgentAddress,
+  revokeKey,
+  rotateKey,
+  rotateKeypair,
+} from '@/services/amp-service'
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetFixtureCounter()
+})
+
+/** Helper: set up a successful auth context */
+function mockAuthenticated(overrides: Partial<{ agentId: string; address: string; tenantId: string }> = {}) {
+  mockAmpAuth.authenticateRequest.mockReturnValue({
+    authenticated: true,
+    agentId: overrides.agentId ?? 'agent-1',
+    address: overrides.address ?? 'alice@testorg.aimaestro.local',
+    tenantId: overrides.tenantId ?? 'testorg',
+  })
+}
+
+/** Helper: set up a failed auth context */
+function mockUnauthenticated() {
+  mockAmpAuth.authenticateRequest.mockReturnValue({
+    authenticated: false,
+    error: 'unauthorized',
+    message: 'Authentication required',
+  })
+}
+
+// ============================================================================
+// GET /api/v1/health
+// ============================================================================
+
+describe('getHealthStatus', () => {
+  it('returns healthy with agent count', () => {
+    const onlineAgent = makeAgent({
+      sessions: [{ index: 0, status: 'online', createdAt: '', lastActive: '' }],
+    })
+    const offlineAgent = makeAgent({
+      sessions: [{ index: 0, status: 'offline', createdAt: '', lastActive: '' }],
+    })
+    mockAgentRegistry.loadAgents.mockReturnValue([onlineAgent, offlineAgent])
+
+    const result = getHealthStatus()
+
+    expect(result.status).toBe(200)
+    expect(result.data?.status).toBe('healthy')
+    expect(result.data?.agents_online).toBe(1)
+    expect(result.data?.provider).toBe('testorg.aimaestro.local')
+    expect(result.data?.version).toBe('0.1.0')
+    expect(result.data?.uptime_seconds).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns unhealthy on error', () => {
+    mockAgentRegistry.loadAgents.mockImplementation(() => { throw new Error('boom') })
+
+    const result = getHealthStatus()
+
+    expect(result.status).toBe(503)
+    expect(result.data?.status).toBe('unhealthy')
+    expect(result.data?.agents_online).toBe(0)
+  })
+
+  it('includes no-cache headers', () => {
+    mockAgentRegistry.loadAgents.mockReturnValue([])
+    const result = getHealthStatus()
+    expect(result.headers?.['Cache-Control']).toBe('no-cache, no-store, must-revalidate')
+  })
+})
+
+// ============================================================================
+// GET /api/v1/info
+// ============================================================================
+
+describe('getProviderInfo', () => {
+  it('returns provider capabilities', () => {
+    const result = getProviderInfo()
+
+    expect(result.status).toBe(200)
+    expect(result.data?.provider).toBe('testorg.aimaestro.local')
+    expect(result.data?.version).toBe('amp/0.1.0')
+    expect(result.data?.capabilities).toContain('registration')
+    expect(result.data?.capabilities).toContain('local-delivery')
+    expect(result.data?.capabilities).toContain('relay-queue')
+    expect(result.data?.capabilities).toContain('mesh-routing')
+    expect(result.data?.registration_modes).toEqual(['open'])
+    expect(result.data?.rate_limits).toBeDefined()
+  })
+
+  it('includes cache headers', () => {
+    const result = getProviderInfo()
+    expect(result.headers?.['Cache-Control']).toBe('public, max-age=300')
+  })
+})
+
+// ============================================================================
+// GET /api/v1/messages/pending
+// ============================================================================
+
+describe('listPendingMessages', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = listPendingMessages(null)
+    expect(result.status).toBe(401)
+    expect(result.data).toHaveProperty('error', 'unauthorized')
+  })
+
+  it('returns pending messages for authenticated agent', () => {
+    mockAuthenticated()
+    const pending = { messages: [{ id: 'msg-1', from: 'bob', subject: 'hi' }], total: 1 }
+    mockAmpRelay.getPendingMessages.mockReturnValue(pending)
+
+    const result = listPendingMessages('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toEqual(pending)
+    expect(mockAmpRelay.getPendingMessages).toHaveBeenCalledWith('agent-1', 10)
+  })
+
+  it('respects limit parameter (capped at 100)', () => {
+    mockAuthenticated()
+    mockAmpRelay.getPendingMessages.mockReturnValue({ messages: [], total: 0 })
+
+    listPendingMessages('Bearer test-key', 50)
+    expect(mockAmpRelay.getPendingMessages).toHaveBeenCalledWith('agent-1', 50)
+
+    listPendingMessages('Bearer test-key', 200)
+    expect(mockAmpRelay.getPendingMessages).toHaveBeenCalledWith('agent-1', 100)
+  })
+
+  it('defaults to limit 10 when not specified', () => {
+    mockAuthenticated()
+    mockAmpRelay.getPendingMessages.mockReturnValue({ messages: [], total: 0 })
+
+    listPendingMessages('Bearer test-key')
+    expect(mockAmpRelay.getPendingMessages).toHaveBeenCalledWith('agent-1', 10)
+  })
+
+  it('includes no-cache headers', () => {
+    mockAuthenticated()
+    mockAmpRelay.getPendingMessages.mockReturnValue({ messages: [], total: 0 })
+
+    const result = listPendingMessages('Bearer test-key')
+    expect(result.headers?.['Cache-Control']).toBe('no-cache, no-store, must-revalidate')
+  })
+})
+
+// ============================================================================
+// DELETE /api/v1/messages/pending
+// ============================================================================
+
+describe('acknowledgePendingMessage', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = acknowledgePendingMessage(null, 'msg-1')
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 400 when message ID is missing', () => {
+    mockAuthenticated()
+    const result = acknowledgePendingMessage('Bearer test-key', null)
+    expect(result.status).toBe(400)
+    expect(result.data).toHaveProperty('error', 'missing_field')
+  })
+
+  it('returns 404 when message not found', () => {
+    mockAuthenticated()
+    mockAmpRelay.acknowledgeMessage.mockReturnValue(false)
+
+    const result = acknowledgePendingMessage('Bearer test-key', 'msg-nonexistent')
+    expect(result.status).toBe(404)
+    expect(result.data).toHaveProperty('error', 'not_found')
+  })
+
+  it('acknowledges a valid message', () => {
+    mockAuthenticated()
+    mockAmpRelay.acknowledgeMessage.mockReturnValue(true)
+
+    const result = acknowledgePendingMessage('Bearer test-key', 'msg-1')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toEqual({ acknowledged: true })
+    expect(mockAmpRelay.acknowledgeMessage).toHaveBeenCalledWith('agent-1', 'msg-1')
+  })
+})
+
+// ============================================================================
+// POST /api/v1/messages/pending/ack (and compat POST /messages/pending)
+// ============================================================================
+
+describe('batchAcknowledgeMessages', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = batchAcknowledgeMessages(null, ['msg-1'])
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 400 when ids is missing', () => {
+    mockAuthenticated()
+    const result = batchAcknowledgeMessages('Bearer test-key', undefined)
+    expect(result.status).toBe(400)
+    expect(result.data).toHaveProperty('error', 'missing_field')
+  })
+
+  it('returns 400 when ids is empty', () => {
+    mockAuthenticated()
+    const result = batchAcknowledgeMessages('Bearer test-key', [])
+    expect(result.status).toBe(400)
+  })
+
+  it('returns 400 when ids exceeds 100', () => {
+    mockAuthenticated()
+    const ids = Array.from({ length: 101 }, (_, i) => `msg-${i}`)
+    const result = batchAcknowledgeMessages('Bearer test-key', ids)
+    expect(result.status).toBe(400)
+    expect(result.data).toHaveProperty('message', 'Maximum 100 messages per batch')
+  })
+
+  it('acknowledges a batch of messages', () => {
+    mockAuthenticated()
+    mockAmpRelay.acknowledgeMessages.mockReturnValue(3)
+
+    const result = batchAcknowledgeMessages('Bearer test-key', ['msg-1', 'msg-2', 'msg-3'])
+
+    expect(result.status).toBe(200)
+    expect(result.data).toEqual({ acknowledged: 3 })
+    expect(mockAmpRelay.acknowledgeMessages).toHaveBeenCalledWith('agent-1', ['msg-1', 'msg-2', 'msg-3'])
+  })
+})
+
+// ============================================================================
+// GET /api/v1/agents
+// ============================================================================
+
+describe('listAMPAgents', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = listAMPAgents(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns registered agents', () => {
+    mockAuthenticated()
+    const agent = makeAgent({
+      name: 'alice',
+      alias: 'Alice Bot',
+      metadata: { amp: { address: 'alice@testorg.aimaestro.local', tenant: 'testorg' } },
+      sessions: [{ index: 0, status: 'online', createdAt: '', lastActive: '' }],
+    })
+    mockAgentRegistry.getAMPRegisteredAgents.mockReturnValue([agent])
+
+    const result = listAMPAgents('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data.agents).toHaveLength(1)
+    expect(result.data.agents[0]).toEqual({
+      address: 'alice@testorg.aimaestro.local',
+      alias: 'Alice Bot',
+      online: true,
+    })
+    expect(result.data.total).toBe(1)
+  })
+
+  it('filters by search term', () => {
+    mockAuthenticated()
+    const alice = makeAgent({ name: 'alice', metadata: { amp: { address: 'alice@test', tenant: 'testorg' } } })
+    const bob = makeAgent({ name: 'bob', metadata: { amp: { address: 'bob@test', tenant: 'testorg' } } })
+    mockAgentRegistry.getAMPRegisteredAgents.mockReturnValue([alice, bob])
+
+    const result = listAMPAgents('Bearer test-key', 'bob')
+
+    expect(result.status).toBe(200)
+    expect(result.data.agents).toHaveLength(1)
+    expect(result.data.total).toBe(1)
+  })
+
+  it('filters by tenant', () => {
+    mockAuthenticated({ tenantId: 'org-a' })
+    const agentA = makeAgent({ name: 'a', metadata: { amp: { address: 'a@test', tenant: 'org-a' } } })
+    const agentB = makeAgent({ name: 'b', metadata: { amp: { address: 'b@test', tenant: 'org-b' } } })
+    mockAgentRegistry.getAMPRegisteredAgents.mockReturnValue([agentA, agentB])
+
+    const result = listAMPAgents('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data.agents).toHaveLength(1)
+  })
+})
+
+// ============================================================================
+// GET /api/v1/agents/me
+// ============================================================================
+
+describe('getAgentSelf', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = getAgentSelf(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 404 when agent not found', () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgent.mockReturnValue(null)
+
+    const result = getAgentSelf('Bearer test-key')
+    expect(result.status).toBe(404)
+  })
+
+  it('returns agent self info', () => {
+    mockAuthenticated({ address: 'alice@testorg.aimaestro.local' })
+    const agent = makeAgent({
+      id: 'agent-1',
+      alias: 'Alice',
+      metadata: { amp: { registeredAt: '2025-01-01T00:00:00.000Z', fingerprint: 'SHA256:abc' } },
+    })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockAmpKeys.loadKeyPair.mockReturnValue({
+      publicPem: 'PUBLIC_KEY',
+      privatePem: 'PRIVATE_KEY',
+      publicHex: 'abcdef',
+      fingerprint: 'SHA256:abc',
+    })
+
+    const result = getAgentSelf('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data.address).toBe('alice@testorg.aimaestro.local')
+    expect(result.data.fingerprint).toBe('SHA256:abc')
+    expect(result.data.registered_at).toBe('2025-01-01T00:00:00.000Z')
+  })
+})
+
+// ============================================================================
+// GET /api/v1/agents/me/card
+// ============================================================================
+
+describe('getAgentCard', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = getAgentCard(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 404 when agent not found', () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgent.mockReturnValue(null)
+
+    const result = getAgentCard('Bearer test-key')
+    expect(result.status).toBe(404)
+    expect(result.data).toHaveProperty('error', 'not_found')
+  })
+
+  it('returns 404 when keypair not found', () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgent.mockReturnValue(makeAgent({ id: 'agent-1' }))
+    mockAmpKeys.loadKeyPair.mockReturnValue(null)
+
+    const result = getAgentCard('Bearer test-key')
+    expect(result.status).toBe(404)
+    expect(result.data.message).toContain('keypair')
+  })
+
+  it('returns a signed agent card', () => {
+    mockAuthenticated({ address: 'alice@testorg.aimaestro.local' })
+    const agent = makeAgent({ id: 'agent-1', name: 'alice', alias: 'Alice Bot' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+
+    // Generate a real Ed25519 keypair for the test
+    const crypto = require('crypto')
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+    const publicPem = publicKey.export({ type: 'spki', format: 'pem' }) as string
+    const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string
+
+    mockAmpKeys.loadKeyPair.mockReturnValue({
+      publicPem,
+      privatePem,
+      publicHex: 'abcdef',
+      fingerprint: 'SHA256:test-fp',
+    })
+
+    const result = getAgentCard('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data.address).toBe('alice@testorg.aimaestro.local')
+    expect(result.data.name).toBe('alice')
+    expect(result.data.alias).toBe('Alice Bot')
+    expect(result.data.public_key).toBe(publicPem)
+    expect(result.data.fingerprint).toBe('SHA256:test-fp')
+    expect(result.data.provider).toBe('testorg.aimaestro.local')
+    expect(result.data.capabilities).toContain('messaging')
+    expect(result.data.capabilities).toContain('read_receipts')
+    expect(result.data.signed_at).toBeDefined()
+    expect(result.data.signature).toBeDefined()
+    expect(typeof result.data.signature).toBe('string')
+    // Verify signature is valid base64
+    expect(() => Buffer.from(result.data.signature, 'base64')).not.toThrow()
+  })
+
+  it('signature verifies with the public key', () => {
+    mockAuthenticated({ address: 'alice@testorg.aimaestro.local' })
+    const agent = makeAgent({ id: 'agent-1', name: 'alice' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+
+    const crypto = require('crypto')
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+    const publicPem = publicKey.export({ type: 'spki', format: 'pem' }) as string
+    const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string
+
+    mockAmpKeys.loadKeyPair.mockReturnValue({
+      publicPem,
+      privatePem,
+      publicHex: 'abcdef',
+      fingerprint: 'SHA256:test-fp',
+    })
+
+    const result = getAgentCard('Bearer test-key')
+    expect(result.status).toBe(200)
+
+    // Verify the signature
+    const signable = `${result.data.address}|${result.data.public_key}|${result.data.signed_at}`
+    const verified = crypto.verify(
+      null,
+      Buffer.from(signable),
+      publicKey,
+      Buffer.from(result.data.signature, 'base64')
+    )
+    expect(verified).toBe(true)
+  })
+
+  it('uses agent address from auth when available', () => {
+    mockAuthenticated({ address: 'custom-addr@provider.com' })
+    mockAgentRegistry.getAgent.mockReturnValue(makeAgent({ id: 'agent-1', name: 'alice' }))
+
+    const crypto = require('crypto')
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+    mockAmpKeys.loadKeyPair.mockReturnValue({
+      publicPem: publicKey.export({ type: 'spki', format: 'pem' }),
+      privatePem: privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      publicHex: 'abcdef',
+      fingerprint: 'SHA256:fp',
+    })
+
+    const result = getAgentCard('Bearer test-key')
+    expect(result.data.address).toBe('custom-addr@provider.com')
+  })
+})
+
+// ============================================================================
+// PATCH /api/v1/agents/me
+// ============================================================================
+
+describe('updateAgentSelf', () => {
+  it('returns 401 without auth', async () => {
+    mockUnauthenticated()
+    const result = await updateAgentSelf(null, {})
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 404 when agent not found', async () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgent.mockReturnValue(null)
+
+    const result = await updateAgentSelf('Bearer test-key', { alias: 'New Alias' })
+    expect(result.status).toBe(404)
+  })
+
+  it('updates agent alias', async () => {
+    mockAuthenticated()
+    const agent = makeAgent({ id: 'agent-1', metadata: {} })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+
+    const result = await updateAgentSelf('Bearer test-key', { alias: 'New Alias' })
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('updated', true)
+    expect(mockAgentRegistry.updateAgent).toHaveBeenCalledWith('agent-1', expect.objectContaining({ label: 'New Alias' }))
+  })
+
+  it('does not call updateAgent when no fields change', async () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgent.mockReturnValue(makeAgent({ id: 'agent-1' }))
+
+    await updateAgentSelf('Bearer test-key', {})
+
+    expect(mockAgentRegistry.updateAgent).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
+// DELETE /api/v1/agents/me
+// ============================================================================
+
+describe('deleteAgentSelf', () => {
+  it('returns 401 without auth', async () => {
+    mockUnauthenticated()
+    const result = await deleteAgentSelf(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 404 when agent not found', async () => {
+    mockAuthenticated()
+    mockAgentRegistry.deleteAgent.mockReturnValue(false)
+
+    const result = await deleteAgentSelf('Bearer test-key')
+    expect(result.status).toBe(404)
+  })
+
+  it('deletes agent and revokes keys', async () => {
+    mockAuthenticated({ address: 'alice@test' })
+    mockAgentRegistry.deleteAgent.mockReturnValue(true)
+
+    const result = await deleteAgentSelf('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('deregistered', true)
+    expect(result.data).toHaveProperty('address', 'alice@test')
+    expect(mockAmpAuth.revokeAllKeysForAgent).toHaveBeenCalledWith('agent-1')
+    expect(mockAgentRegistry.deleteAgent).toHaveBeenCalledWith('agent-1', true)
+  })
+})
+
+// ============================================================================
+// GET /api/v1/agents/resolve/:address
+// ============================================================================
+
+describe('resolveAgentAddress', () => {
+  it('returns 401 without auth', () => {
+    mockUnauthenticated()
+    const result = resolveAgentAddress(null, 'alice@test')
+    expect(result.status).toBe(401)
+  })
+
+  it('resolves an agent by name', () => {
+    mockAuthenticated()
+    const agent = makeAgent({
+      id: 'agent-1',
+      name: 'alice',
+      alias: 'Alice Bot',
+      metadata: { amp: { address: 'alice@testorg.aimaestro.local', fingerprint: 'SHA256:old' } },
+      sessions: [{ index: 0, status: 'online', createdAt: '', lastActive: '' }],
+    })
+    mockAgentRegistry.getAgentByNameAnyHost.mockReturnValue(agent)
+    mockAmpKeys.loadKeyPair.mockReturnValue({
+      publicPem: 'PUB_KEY_PEM',
+      privatePem: 'PRIV',
+      publicHex: 'hex',
+      fingerprint: 'SHA256:abc',
+    })
+
+    const result = resolveAgentAddress('Bearer key', 'alice@testorg.aimaestro.local')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('address', 'alice@testorg.aimaestro.local')
+    expect(result.data).toHaveProperty('public_key', 'PUB_KEY_PEM')
+    expect(result.data).toHaveProperty('fingerprint', 'SHA256:abc')
+    expect(result.data).toHaveProperty('online', true)
+    expect(result.data).toHaveProperty('key_algorithm', 'Ed25519')
+  })
+
+  it('returns 404 when agent not found', () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgentByNameAnyHost.mockReturnValue(null)
+    mockAgentRegistry.loadAgents.mockReturnValue([])
+
+    const result = resolveAgentAddress('Bearer key', 'nobody@test')
+
+    expect(result.status).toBe(404)
+    expect(result.data).toHaveProperty('error', 'not_found')
+  })
+
+  it('falls back to address-based lookup', () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgentByNameAnyHost.mockReturnValue(null)
+    const agent = makeAgent({
+      id: 'agent-2',
+      name: 'bob',
+      alias: 'Bob',
+      metadata: { amp: { address: 'bob@custom.domain' } },
+    })
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+    mockAmpKeys.loadKeyPair.mockReturnValue({
+      publicPem: 'BOB_KEY',
+      privatePem: 'PRIV',
+      publicHex: 'hex',
+      fingerprint: 'SHA256:bob-fp',
+    })
+
+    const result = resolveAgentAddress('Bearer key', 'bob@custom.domain')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('address', 'bob@custom.domain')
+    expect(result.data).toHaveProperty('fingerprint', 'SHA256:bob-fp')
+  })
+})
+
+// ============================================================================
+// DELETE /api/v1/auth/revoke-key
+// ============================================================================
+
+describe('revokeKey', () => {
+  it('returns 401 without auth header', () => {
+    mockAmpAuth.extractApiKeyFromHeader.mockReturnValue(null)
+    const result = revokeKey(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 404 when key not found', () => {
+    mockAmpAuth.extractApiKeyFromHeader.mockReturnValue('amp_live_sk_test')
+    mockAmpAuth.revokeApiKey.mockReturnValue(false)
+
+    const result = revokeKey('Bearer amp_live_sk_test')
+    expect(result.status).toBe(404)
+  })
+
+  it('revokes a valid key', () => {
+    mockAmpAuth.extractApiKeyFromHeader.mockReturnValue('amp_live_sk_test')
+    mockAmpAuth.revokeApiKey.mockReturnValue(true)
+
+    const result = revokeKey('Bearer amp_live_sk_test')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('revoked', true)
+    expect(result.data).toHaveProperty('revoked_at')
+  })
+})
+
+// ============================================================================
+// POST /api/v1/auth/rotate-key
+// ============================================================================
+
+describe('rotateKey', () => {
+  it('returns 401 without auth header', () => {
+    mockAmpAuth.extractApiKeyFromHeader.mockReturnValue(null)
+    const result = rotateKey(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 401 for invalid key', () => {
+    mockAmpAuth.extractApiKeyFromHeader.mockReturnValue('amp_live_sk_bad')
+    mockAmpAuth.rotateApiKey.mockReturnValue(null)
+
+    const result = rotateKey('Bearer amp_live_sk_bad')
+    expect(result.status).toBe(401)
+  })
+
+  it('rotates a valid key', () => {
+    mockAmpAuth.extractApiKeyFromHeader.mockReturnValue('amp_live_sk_old')
+    mockAmpAuth.rotateApiKey.mockReturnValue({
+      api_key: 'amp_live_sk_new',
+      previous_key_revoked: true,
+    })
+
+    const result = rotateKey('Bearer amp_live_sk_old')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('api_key', 'amp_live_sk_new')
+  })
+})
+
+// ============================================================================
+// POST /api/v1/auth/rotate-keys (keypair)
+// ============================================================================
+
+describe('rotateKeypair', () => {
+  it('returns 401 without auth', async () => {
+    mockUnauthenticated()
+    const result = await rotateKeypair(null)
+    expect(result.status).toBe(401)
+  })
+
+  it('returns 404 when agent not found', async () => {
+    mockAuthenticated()
+    mockAgentRegistry.getAgent.mockReturnValue(null)
+
+    const result = await rotateKeypair('Bearer test-key')
+    expect(result.status).toBe(404)
+  })
+
+  it('generates new keypair and updates agent', async () => {
+    mockAuthenticated({ address: 'alice@test' })
+    const agent = makeAgent({ id: 'agent-1', metadata: { amp: { fingerprint: 'SHA256:old' } } })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockAmpKeys.generateKeyPair.mockResolvedValue({
+      publicPem: 'NEW_PUB',
+      privatePem: 'NEW_PRIV',
+      publicHex: 'newhex',
+      fingerprint: 'SHA256:new-fp',
+    })
+
+    const result = await rotateKeypair('Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('rotated', true)
+    expect(result.data).toHaveProperty('fingerprint', 'SHA256:new-fp')
+    expect(result.data).toHaveProperty('public_key', 'NEW_PUB')
+    expect(result.data).toHaveProperty('key_algorithm', 'Ed25519')
+    expect(mockAmpKeys.saveKeyPair).toHaveBeenCalledWith('agent-1', expect.objectContaining({ fingerprint: 'SHA256:new-fp' }))
+    expect(mockAgentRegistry.updateAgent).toHaveBeenCalled()
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.12",
+  "version": "0.25.14",
   "releaseDate": "2026-03-21",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **`POST /v1/messages/pending/ack`** — Spec-correct batch acknowledgment path. Old `POST /v1/messages/pending` kept as backward-compat alias.
- **`GET /v1/agents/me/card`** — Returns Ed25519-signed agent card (address, public key, fingerprint, provider, capabilities).
- **`GET /v1/messages`** — Alias for `GET /v1/messages/pending` for clients using shorter path.
- **52 new tests** for `amp-service.ts` covering all AMP endpoints (health, info, pending messages, batch ack, agent self, agent card, resolve, key rotation, revocation).

## Files changed
| File | Change |
|------|--------|
| `app/api/v1/messages/pending/ack/route.ts` | **NEW** — spec-correct batch ack |
| `app/api/v1/agents/me/card/route.ts` | **NEW** — signed agent card |
| `app/api/v1/messages/route.ts` | **NEW** — messages alias |
| `services/amp-service.ts` | Added `getAgentCard()` + updated header |
| `services/headless-router.ts` | 3 new route entries |
| `tests/services/amp-service.test.ts` | **NEW** — 52 tests |
| Version files | Bump to 0.25.14 |

## Test plan
- [x] `yarn test` — 538 tests pass (52 new)
- [x] `yarn build` — clean build
- [ ] `curl -X POST localhost:23000/api/v1/messages/pending/ack -H "Authorization: Bearer ..." -d '{"ids":[]}'` → 400
- [ ] `curl localhost:23000/api/v1/agents/me/card -H "Authorization: Bearer ..."` → signed card JSON
- [ ] `curl localhost:23000/api/v1/messages -H "Authorization: Bearer ..."` → pending messages
- [ ] Old paths still work (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)