### PR TITLE
feat: AMP key rotation with proof-of-possession + duplicate key rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.25.15] - 2026-03-23
+
+### Added
+- **Key rotation with proof-of-possession** — `POST /api/v1/auth/rotate-keys` now accepts an optional body with `new_public_key`, `key_algorithm`, and `proof` fields. When provided, the server verifies the proof (new key signed with old private key) before accepting the rotation. Omitting the body falls back to server-side key generation for backward compatibility.
+- **Duplicate public key rejection** — `POST /api/v1/register` now rejects registration when the submitted public key fingerprint is already associated with a different agent (409 `key_already_registered`). Same-agent re-registration with the same key remains allowed.
+
 ## [0.25.14] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.25.14-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.25.15-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/v1/auth/rotate-keys/route.ts
+++ b/app/api/v1/auth/rotate-keys/route.ts
@@ -10,7 +10,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { rotateKeypair } from '@/services/amp-service'
 
 export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null)
   const authHeader = request.headers.get('Authorization')
-  const result = await rotateKeypair(authHeader)
+  const result = await rotateKeypair(body, authHeader)
   return NextResponse.json(result.data!, { status: result.status })
 }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.25.14
+**Current Version:** v0.25.15
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.25.14",
+      "softwareVersion": "0.25.15",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.25.14",
+      "softwareVersion": "0.25.15",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.25.14</span>
+                        <span>v0.25.15</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/types/amp.ts
+++ b/lib/types/amp.ts
@@ -441,6 +441,7 @@ export type AMPErrorCode =
   | 'payload_too_large'     // Message payload exceeds size limit
   | 'missing_header'        // Required HTTP header is missing
   | 'duplicate_message'     // Message ID has already been delivered (replay protection)
+  | 'key_already_registered' // Public key fingerprint is already associated with another agent
 
 /**
  * AMP error response
@@ -500,6 +501,24 @@ export interface AMPKeyRotationResponse {
   api_key: string
   expires_at: string | null
   previous_key_valid_until: string
+}
+
+/**
+ * Keypair rotation request (proof-of-possession)
+ *
+ * POST /v1/auth/rotate-keys
+ * Agent provides new public key + proof (new key signed with old private key).
+ * If body is omitted, server falls back to server-side key generation (backward compat).
+ */
+export interface AMPKeypairRotationRequest {
+  /** PEM-encoded Ed25519 public key */
+  new_public_key: string
+
+  /** Key algorithm — must be 'Ed25519' */
+  key_algorithm: 'Ed25519'
+
+  /** Base64-encoded proof: sign(new_public_key_hex, old_private_key) */
+  proof: string
 }
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.25.14",
+  "version": "0.25.15",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.25.14"
+VERSION="0.25.15"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -58,6 +58,7 @@ import type {
   AMPPayload,
   AMPError,
   AMPNameTakenError,
+  AMPKeypairRotationRequest,
 } from '@/lib/types/amp'
 
 // ---------------------------------------------------------------------------
@@ -608,6 +609,23 @@ export async function registerAgent(
           details: { expected_tenant: configOrg }
         } as AMPError,
         status: 400
+      }
+    }
+
+    // Check if public key fingerprint is already used by a different agent
+    const ampAgents = getAMPRegisteredAgents()
+    const duplicateKeyAgent = ampAgents.find((a: any) =>
+      a.metadata?.amp?.fingerprint === fingerprint &&
+      a.name?.toLowerCase() !== normalizedName
+    )
+    if (duplicateKeyAgent) {
+      return {
+        data: {
+          error: 'key_already_registered',
+          message: 'This public key is already associated with another agent',
+          details: { fingerprint }
+        } as AMPError,
+        status: 409
       }
     }
 
@@ -1613,7 +1631,7 @@ export function rotateKey(authHeader: string | null): ServiceResult<AMPKeyRotati
 // POST /api/v1/auth/rotate-keys
 // ---------------------------------------------------------------------------
 
-export async function rotateKeypair(authHeader: string | null): Promise<ServiceResult<any>> {
+export async function rotateKeypair(body: AMPKeypairRotationRequest | null, authHeader: string | null): Promise<ServiceResult<any>> {
   const auth = authenticateRequest(authHeader)
 
   if (!auth.authenticated) {
@@ -1631,8 +1649,62 @@ export async function rotateKeypair(authHeader: string | null): Promise<ServiceR
     }
   }
 
-  // Generate new keypair and save to disk
-  const newKeyPair = await generateKeyPair()
+  let newKeyPair: { publicPem: string; privatePem: string; publicHex: string; fingerprint: string }
+
+  if (body && body.new_public_key && body.proof) {
+    // ── Proof-of-possession rotation ──────────────────────────────────────
+    if (body.key_algorithm && body.key_algorithm !== 'Ed25519') {
+      return {
+        data: { error: 'invalid_field', message: 'key_algorithm must be Ed25519', field: 'key_algorithm' } as AMPError,
+        status: 400
+      }
+    }
+
+    const newPublicKeyHex = extractPublicKeyHex(body.new_public_key)
+    if (!newPublicKeyHex) {
+      return {
+        data: { error: 'invalid_field', message: 'Invalid new_public_key format. Must be PEM-encoded Ed25519 public key.', field: 'new_public_key' } as AMPError,
+        status: 400
+      }
+    }
+
+    // Load old keypair to verify proof
+    const oldKeyPair = loadKeyPair(auth.agentId!)
+    if (!oldKeyPair) {
+      return {
+        data: { error: 'not_found', message: 'Existing keypair not found for agent' } as AMPError,
+        status: 404
+      }
+    }
+
+    // Verify proof: new_public_key_hex signed with old private key
+    const proofValid = verifySignature(newPublicKeyHex, body.proof, oldKeyPair.publicHex)
+    if (!proofValid) {
+      return {
+        data: { error: 'invalid_signature', message: 'Proof-of-possession verification failed. The proof must be the new public key hex signed with the old private key.' } as AMPError,
+        status: 401
+      }
+    }
+
+    const fingerprint = calculateFingerprint(newPublicKeyHex)
+    newKeyPair = {
+      publicPem: body.new_public_key,
+      privatePem: '',  // Agent holds its own private key — server does not store it
+      publicHex: newPublicKeyHex,
+      fingerprint,
+    }
+  } else if (body && (body.new_public_key || body.proof)) {
+    // Partial body — both fields required
+    const missing = !body.new_public_key ? 'new_public_key' : 'proof'
+    return {
+      data: { error: 'missing_field', message: `Both new_public_key and proof are required for proof-of-possession rotation`, field: missing } as AMPError,
+      status: 400
+    }
+  } else {
+    // ── Legacy: server-side key generation (backward compat) ──────────────
+    newKeyPair = await generateKeyPair()
+  }
+
   saveKeyPair(auth.agentId!, newKeyPair)
 
   // Update agent metadata with new fingerprint

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -1072,7 +1072,8 @@ const routes: Route[] = [
     sendServiceResult(res, rotateKey(getHeader(req, 'Authorization')))
   }},
   { method: 'POST', pattern: /^\/api\/v1\/auth\/rotate-keys$/, paramNames: [], handler: async (req, res) => {
-    sendServiceResult(res, await rotateKeypair(getHeader(req, 'Authorization')))
+    const body = await readJsonBody(req)
+    sendServiceResult(res, await rotateKeypair(body, getHeader(req, 'Authorization')))
   }},
   { method: 'POST', pattern: /^\/api\/v1\/federation\/deliver$/, paramNames: [], handler: async (req, res) => {
     const body = await readJsonBody(req)

--- a/tests/services/amp-service.test.ts
+++ b/tests/services/amp-service.test.ts
@@ -118,7 +118,15 @@ import {
   revokeKey,
   rotateKey,
   rotateKeypair,
+  registerAgent,
 } from '@/services/amp-service'
+
+// ============================================================================
+// Test constants
+// ============================================================================
+
+/** Real Ed25519 PEM for tests (extractPublicKeyHex uses crypto.createPublicKey) */
+const TEST_ED25519_PEM = '-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAI6oyzfEh2pUxQ2+qFoZ2bZZ9q6kDsSbFmAzLVe89qcs=\n-----END PUBLIC KEY-----\n'
 
 // ============================================================================
 // Setup
@@ -785,7 +793,7 @@ describe('rotateKey', () => {
 describe('rotateKeypair', () => {
   it('returns 401 without auth', async () => {
     mockUnauthenticated()
-    const result = await rotateKeypair(null)
+    const result = await rotateKeypair(null, null)
     expect(result.status).toBe(401)
   })
 
@@ -793,11 +801,11 @@ describe('rotateKeypair', () => {
     mockAuthenticated()
     mockAgentRegistry.getAgent.mockReturnValue(null)
 
-    const result = await rotateKeypair('Bearer test-key')
+    const result = await rotateKeypair(null, 'Bearer test-key')
     expect(result.status).toBe(404)
   })
 
-  it('generates new keypair and updates agent', async () => {
+  it('generates new keypair (no body — backward compat)', async () => {
     mockAuthenticated({ address: 'alice@test' })
     const agent = makeAgent({ id: 'agent-1', metadata: { amp: { fingerprint: 'SHA256:old' } } })
     mockAgentRegistry.getAgent.mockReturnValue(agent)
@@ -808,7 +816,7 @@ describe('rotateKeypair', () => {
       fingerprint: 'SHA256:new-fp',
     })
 
-    const result = await rotateKeypair('Bearer test-key')
+    const result = await rotateKeypair(null, 'Bearer test-key')
 
     expect(result.status).toBe(200)
     expect(result.data).toHaveProperty('rotated', true)
@@ -817,5 +825,122 @@ describe('rotateKeypair', () => {
     expect(result.data).toHaveProperty('key_algorithm', 'Ed25519')
     expect(mockAmpKeys.saveKeyPair).toHaveBeenCalledWith('agent-1', expect.objectContaining({ fingerprint: 'SHA256:new-fp' }))
     expect(mockAgentRegistry.updateAgent).toHaveBeenCalled()
+  })
+
+  it('rotates with valid proof-of-possession', async () => {
+    mockAuthenticated({ agentId: 'agent-1', address: 'alice@test' })
+    const agent = makeAgent({ id: 'agent-1', metadata: { amp: { fingerprint: 'SHA256:old' } } })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockAmpKeys.loadKeyPair.mockReturnValue({ publicHex: 'oldhex', privatePem: 'OLD_PRIV', publicPem: 'OLD_PUB', fingerprint: 'SHA256:old' })
+    mockAmpKeys.verifySignature.mockReturnValue(true)
+    mockAmpKeys.calculateFingerprint.mockReturnValue('SHA256:new-pop-fp')
+
+    const body = { new_public_key: TEST_ED25519_PEM, key_algorithm: 'Ed25519' as const, proof: 'base64proof' }
+    const result = await rotateKeypair(body, 'Bearer test-key')
+
+    expect(result.status).toBe(200)
+    expect(result.data).toHaveProperty('rotated', true)
+    expect(result.data).toHaveProperty('fingerprint', 'SHA256:new-pop-fp')
+    expect(mockAmpKeys.verifySignature).toHaveBeenCalled()
+    expect(mockAmpKeys.saveKeyPair).toHaveBeenCalledWith('agent-1', expect.objectContaining({ fingerprint: 'SHA256:new-pop-fp' }))
+  })
+
+  it('returns 401 for invalid proof signature', async () => {
+    mockAuthenticated({ agentId: 'agent-1' })
+    const agent = makeAgent({ id: 'agent-1', metadata: { amp: { fingerprint: 'SHA256:old' } } })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockAmpKeys.loadKeyPair.mockReturnValue({ publicHex: 'oldhex', privatePem: 'OLD_PRIV', publicPem: 'OLD_PUB', fingerprint: 'SHA256:old' })
+    mockAmpKeys.verifySignature.mockReturnValue(false)
+
+    const body = { new_public_key: TEST_ED25519_PEM, key_algorithm: 'Ed25519' as const, proof: 'bad-proof' }
+    const result = await rotateKeypair(body, 'Bearer test-key')
+
+    expect(result.status).toBe(401)
+    expect(result.data).toHaveProperty('error', 'invalid_signature')
+  })
+
+  it('returns 400 when proof provided without new_public_key', async () => {
+    mockAuthenticated({ agentId: 'agent-1' })
+    const agent = makeAgent({ id: 'agent-1', metadata: { amp: {} } })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+
+    const body = { proof: 'base64proof' } as any
+    const result = await rotateKeypair(body, 'Bearer test-key')
+
+    expect(result.status).toBe(400)
+    expect(result.data).toHaveProperty('error', 'missing_field')
+  })
+
+  it('returns 400 when new_public_key provided without proof', async () => {
+    mockAuthenticated({ agentId: 'agent-1' })
+    const agent = makeAgent({ id: 'agent-1', metadata: { amp: {} } })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+
+    const body = { new_public_key: '-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----' } as any
+    const result = await rotateKeypair(body, 'Bearer test-key')
+
+    expect(result.status).toBe(400)
+    expect(result.data).toHaveProperty('error', 'missing_field')
+  })
+})
+
+// ============================================================================
+// POST /api/v1/register — duplicate key rejection
+// ============================================================================
+
+describe('registerAgent — duplicate key rejection', () => {
+  const validRegBody = {
+    tenant: 'testorg',
+    name: 'new-agent',
+    public_key: TEST_ED25519_PEM,
+    key_algorithm: 'Ed25519' as const,
+  }
+
+  /** Set up mocks needed for registerAgent to reach the duplicate-key check */
+  function setupRegisterMocks() {
+    mockAmpKeys.calculateFingerprint.mockReturnValue('SHA256:test-fingerprint')
+    mockHostsConfig.getSelfHost.mockReturnValue({ id: 'test-host', name: 'Test Host', url: 'http://localhost:23000' })
+    mockHostsConfig.getSelfHostId.mockReturnValue('test-host')
+    mockHostsConfig.getOrganization.mockReturnValue('testorg')
+  }
+
+  it('rejects registration when fingerprint already used by different agent', async () => {
+    setupRegisterMocks()
+    const existingAgent = makeAgent({ name: 'other-agent', metadata: { amp: { fingerprint: 'SHA256:test-fingerprint', registeredVia: 'local' } } })
+    mockAgentRegistry.getAMPRegisteredAgents.mockReturnValue([existingAgent])
+    mockAgentRegistry.getAgentByName.mockReturnValue(null)
+
+    const result = await registerAgent(validRegBody, null)
+
+    expect(result.status).toBe(409)
+    expect(result.data).toHaveProperty('error', 'key_already_registered')
+    expect((result.data as any).details).toHaveProperty('fingerprint')
+    // Must NOT reveal the other agent's name (info leakage prevention)
+    expect(JSON.stringify(result.data)).not.toContain('other-agent')
+  })
+
+  it('allows same agent re-registering with same key', async () => {
+    setupRegisterMocks()
+    const existingAgent = makeAgent({ name: 'new-agent', metadata: { amp: { fingerprint: 'SHA256:test-fingerprint', registeredVia: 'local' } } })
+    mockAgentRegistry.getAMPRegisteredAgents.mockReturnValue([existingAgent])
+    mockAgentRegistry.getAgentByName.mockReturnValue(existingAgent)
+    mockAmpAuth.createApiKey.mockReturnValue({ key: 'api-key-123', hash: 'hash-123' })
+
+    const result = await registerAgent(validRegBody, null)
+
+    // Should succeed (re-registration), not 409
+    expect(result.status).not.toBe(409)
+  })
+
+  it('allows registration with unique fingerprint', async () => {
+    setupRegisterMocks()
+    mockAgentRegistry.getAMPRegisteredAgents.mockReturnValue([])
+    mockAgentRegistry.getAgentByName.mockReturnValue(null)
+    mockAgentRegistry.createAgent.mockImplementation((data: any) => ({ ...data, id: 'new-id' }))
+    mockAmpAuth.createApiKey.mockReturnValue({ key: 'api-key-123', hash: 'hash-123' })
+
+    const result = await registerAgent(validRegBody, null)
+
+    expect(result.status).not.toBe(409)
   })
 })

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.14",
-  "releaseDate": "2026-03-21",
+  "version": "0.25.15",
+  "releaseDate": "2026-03-23",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

- **Key rotation with proof-of-possession** — `POST /v1/auth/rotate-keys` now accepts an optional body with `new_public_key`, `key_algorithm`, and `proof` fields. Server verifies the proof (new key hex signed with old private key) before accepting. Omitting body falls back to server-side key generation for backward compatibility.
- **Duplicate public key rejection** — `POST /v1/register` returns 409 `key_already_registered` when the submitted fingerprint is already associated with a different agent. Same-agent re-registration with the same key remains allowed. Does not reveal the other agent's name (info leakage prevention per spec).
- Version bumped to **0.25.15**

## Test plan

- [x] `yarn test` — 545/545 tests pass (8 new tests added)
- [x] `yarn build` — succeeds
- [x] Version bumped via `./scripts/bump-version.sh patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)