### PR TITLE
Update AMP protocol version to 0.1.3

### DIFF
--- a/lib/types/amp.ts
+++ b/lib/types/amp.ts
@@ -2,7 +2,7 @@
  * AMP (Agent Messaging Protocol) Types
  *
  * Type definitions for implementing AMP protocol in AI Maestro.
- * Based on the AMP Protocol Specification v0.1.0
+ * Based on the AMP Protocol Specification v0.1.3
  *
  * AI Maestro acts as an AMP PROVIDER for local agents.
  * This enables three deployment scenarios:
@@ -34,7 +34,7 @@ export const AMP_API_KEY_PREFIX = 'amp_live_sk_'
 // Protocol Version
 // ============================================================================
 
-export const AMP_PROTOCOL_VERSION = '0.1.0'
+export const AMP_PROTOCOL_VERSION = '0.1.3'
 
 /**
  * Default provider name (used when organization is not set)

--- a/tests/services/amp-service.test.ts
+++ b/tests/services/amp-service.test.ts
@@ -80,7 +80,7 @@ const {
     getOrganization: vi.fn().mockReturnValue('testorg'),
   },
   mockAmpTypes: {
-    AMP_PROTOCOL_VERSION: '0.1.0',
+    AMP_PROTOCOL_VERSION: '0.1.3',
     getAMPProviderDomain: vi.fn().mockReturnValue('testorg.aimaestro.local'),
   },
 }))
@@ -176,7 +176,7 @@ describe('getHealthStatus', () => {
     expect(result.data?.status).toBe('healthy')
     expect(result.data?.agents_online).toBe(1)
     expect(result.data?.provider).toBe('testorg.aimaestro.local')
-    expect(result.data?.version).toBe('0.1.0')
+    expect(result.data?.version).toBe('0.1.3')
     expect(result.data?.uptime_seconds).toBeGreaterThanOrEqual(0)
   })
 
@@ -207,7 +207,7 @@ describe('getProviderInfo', () => {
 
     expect(result.status).toBe(200)
     expect(result.data?.provider).toBe('testorg.aimaestro.local')
-    expect(result.data?.version).toBe('amp/0.1.0')
+    expect(result.data?.version).toBe('amp/0.1.3')
     expect(result.data?.capabilities).toContain('registration')
     expect(result.data?.capabilities).toContain('local-delivery')
     expect(result.data?.capabilities).toContain('relay-queue')


### PR DESCRIPTION
## Summary
- Updated `AMP_PROTOCOL_VERSION` from `'0.1.0'` to `'0.1.3'` to match current AMP spec
- Updated doc comment referencing spec version
- Updated 3 test assertions in `amp-service.test.ts` to match

## Test plan
- [ ] `npm test` passes with updated version assertions
- [ ] Health endpoint returns version `0.1.3`
- [ ] Provider info endpoint returns `amp/0.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)