### PR TITLE
feat: replace send-keys with additionalContext for inbox notifications

### DIFF
--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -121,44 +121,24 @@ function debugLog(data) {
     fs.appendFileSync(debugFile, line);
 }
 
-// Send message notification to agent via tmux
-async function sendMessageNotification(cwd, messagePrompt) {
+// Check for unread messages using AMP CLI (standalone — no AI Maestro needed)
+async function checkUnreadMessagesStandalone() {
+    const { execSync } = require('child_process');
     try {
-        const agentsResponse = await fetch('http://localhost:23000/api/agents');
-        if (!agentsResponse.ok) return false;
+        const output = execSync('amp-inbox.sh --count 2>/dev/null', {
+            encoding: 'utf8',
+            timeout: 3000,
+            env: { ...process.env, PATH: process.env.PATH }
+        }).trim();
 
-        const agentsData = await agentsResponse.json();
-        const agent = (agentsData.agents || []).find(a => {
-            const agentWd = a.workingDirectory || a.session?.workingDirectory;
-            if (!agentWd) return false;
-            if (agentWd === cwd) return true;
-            if (cwd.startsWith(agentWd + '/')) return true;
-            if (agentWd.startsWith(cwd + '/')) return true;
-            return false;
-        });
+        // amp-inbox.sh --count returns a number
+        const count = parseInt(output, 10);
+        if (isNaN(count) || count === 0) return null;
 
-        if (agent && agent.session?.tmuxSessionName) {
-            // Send via AI Maestro API
-            const response = await fetch(
-                `http://localhost:23000/api/sessions/${encodeURIComponent(agent.session.tmuxSessionName)}/command`,
-                {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        command: messagePrompt,
-                        requireIdle: false,  // Hook context ensures appropriate timing
-                        addNewline: true
-                    })
-                }
-            );
-            const result = await response.json();
-            debugLog({ event: 'message_notification_sent', success: result.success, session: agent.session.tmuxSessionName });
-            return result.success;
-        }
-        return false;
+        return `You have ${count} unread message${count === 1 ? '' : 's'} in your AMP inbox. Check them with: amp-inbox.sh`;
     } catch (err) {
-        debugLog({ event: 'message_notification_error', error: err.message });
-        return false;
+        debugLog({ event: 'standalone_inbox_check_failed', error: err.message });
+        return null;
     }
 }
 
@@ -231,7 +211,8 @@ async function checkUnreadMessages(cwd) {
         }
     } catch (err) {
         debugLog({ event: 'message_check_error', error: err.message });
-        return null;
+        // Fall back to standalone AMP check (works without AI Maestro)
+        return checkUnreadMessagesStandalone();
     }
 }
 
@@ -246,6 +227,9 @@ async function main() {
     const cwd = input.cwd || process.cwd();
     const sessionId = input.session_id;
     const transcriptPath = input.transcript_path;
+
+    // Hook response — may be enriched with additionalContext for inbox notifications
+    let hookResponse = {};
 
     // Handle different hook events
     switch (hookEvent) {
@@ -332,11 +316,16 @@ async function main() {
                     transcriptPath
                 });
 
-                // Check for unread messages and notify the agent
-                const messagePrompt = await checkUnreadMessages(cwd);
-                if (messagePrompt) {
-                    debugLog({ event: 'sending_message_notification', cwd, prompt: messagePrompt, trigger: 'idle_prompt' });
-                    await sendMessageNotification(cwd, messagePrompt);
+                // Check for unread messages and inject as additionalContext
+                const idleMessagePrompt = await checkUnreadMessages(cwd);
+                if (idleMessagePrompt) {
+                    debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'idle_prompt' });
+                    hookResponse = {
+                        hookSpecificOutput: {
+                            hookEventName: 'Notification',
+                            additionalContext: idleMessagePrompt
+                        }
+                    };
                 }
             } else if (notificationType === 'permission_prompt') {
                 // For permission prompts, preserve existing tool info if we have it
@@ -372,7 +361,8 @@ async function main() {
             break;
 
         case 'Stop':
-            // Claude finished responding - clear the waiting state
+            // Claude finished responding - keep this fast (no API calls)
+            // Inbox check happens on idle_prompt notification which fires shortly after
             writeState(cwd, {
                 status: 'idle',
                 message: null,
@@ -391,15 +381,17 @@ async function main() {
                 source: input.source
             });
 
-            // Check for unread messages after a short delay to let session initialize
-            // The delay ensures Claude Code is ready to receive the notification
-            setTimeout(async () => {
-                const messagePrompt = await checkUnreadMessages(cwd);
-                if (messagePrompt) {
-                    debugLog({ event: 'sending_message_notification', cwd, prompt: messagePrompt, trigger: 'session_start' });
-                    await sendMessageNotification(cwd, messagePrompt);
-                }
-            }, 3000);  // 3 second delay for session initialization
+            // Check for unread messages and inject as additionalContext
+            const startMessagePrompt = await checkUnreadMessages(cwd);
+            if (startMessagePrompt) {
+                debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'session_start' });
+                hookResponse = {
+                    hookSpecificOutput: {
+                        hookEventName: 'SessionStart',
+                        additionalContext: startMessagePrompt
+                    }
+                };
+            }
             break;
 
         default:
@@ -409,8 +401,8 @@ async function main() {
             }
     }
 
-    // Output empty JSON to indicate success
-    console.log('{}');
+    // Output hook response (may include additionalContext for inbox notifications)
+    console.log(JSON.stringify(hookResponse));
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- Replace broken tmux `send-keys` notification with Claude Code's native `additionalContext` hook response
- Agents now receive inbox notifications as system reminders injected into their conversation context
- Add standalone fallback using `amp-inbox.sh --count` (works without AI Maestro running)

## Problem
The old `sendMessageNotification()` used tmux `send-keys` to type text into the terminal. This breaks when agents run inside a TUI (Claude Code, Codex, Gemini) — the notification text gets typed into the TUI's input field instead of being processed.

Agents were missing AMP notifications while busy, and users had to manually remind them to check their inboxes. (Issues #321, #322)

## Solution
Claude Code hooks can return `additionalContext` in their JSON stdout, which gets injected as a system reminder. The agent sees "You have N unread messages" naturally in its conversation context and knows to check its inbox.

## Changes
- **Removed:** `sendMessageNotification()` — broken tmux send-keys approach
- **Added:** `checkUnreadMessagesStandalone()` — `amp-inbox.sh --count` fallback
- **Changed:** `idle_prompt` and `SessionStart` return `hookSpecificOutput.additionalContext`
- **Kept fast:** `Stop` handler has zero API calls (inbox check on `idle_prompt` shortly after)

## Safety (600 users)
| Failure | Result | Blocks Claude? |
|---------|--------|---------------|
| AI Maestro API down | Falls back to amp-inbox.sh | No |
| amp-inbox.sh not on PATH | Returns `{}` | No |
| Hook times out (>5s) | Process killed, Claude proceeds | No |
| Invalid JSON output | Claude ignores, proceeds | No |
| No unread messages | Returns `{}` | No |

All existing functionality (chat state, status broadcast, permissions) is unchanged.

## Test plan
- [ ] Verify idle_prompt returns additionalContext when messages exist
- [ ] Verify Stop handler stays fast (no API calls)
- [ ] Verify standalone fallback with AI Maestro stopped
- [ ] Verify no notification when inbox is empty
- [ ] Verify chat interface state writing unaffected

Addresses #321, #322
Plugin submodule PR: 23blocks-OS/ai-maestro-plugins#21

🤖 Generated with [Claude Code](https://claude.com/claude-code)