### PR TITLE
feat: multi-agent hook support (Claude, Codex, Gemini)

### DIFF
--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /**
- * AI Maestro Claude Code Hook
+ * AI Maestro Agent Hook
  *
- * This hook captures Claude Code events and writes state to files
- * that AI Maestro can read to display in the Chat interface.
+ * Universal hook for AI coding agents (Claude Code, Codex CLI, Gemini CLI).
+ * Captures agent events, writes state for the Chat interface, and injects
+ * AMP inbox notifications via each agent's native context injection.
  *
- * Supported events:
- * - Notification (idle_prompt): When Claude is waiting for user input
- * - Stop: When Claude finishes responding
- * - SessionStart: When a session starts/resumes
+ * Supported agents and their event mappings:
+ *   Claude Code: Stop, Notification(idle_prompt), SessionStart
+ *   Codex CLI:   Stop, SessionStart
+ *   Gemini CLI:  AfterAgent, Notification, SessionStart
  *
  * State is written to: ~/.aimaestro/chat-state/<cwd-hash>.json
  */
@@ -121,6 +122,47 @@ function debugLog(data) {
     fs.appendFileSync(debugFile, line);
 }
 
+// Detect which AI agent is calling this hook
+function detectAgent(input) {
+    // Gemini CLI sets GEMINI_SESSION_ID or has gemini-specific fields
+    if (process.env.GEMINI_SESSION_ID || process.env.GEMINI_PROJECT_DIR) return 'gemini';
+    // Codex CLI sets model field with gpt- prefix or has turn_id
+    if (input.model && input.model.startsWith('gpt-')) return 'codex';
+    if (input.turn_id !== undefined) return 'codex';
+    // Default to Claude Code
+    return 'claude';
+}
+
+// Normalize event names across agents to our internal names
+function normalizeEvent(hookEvent, agent) {
+    // Gemini's AfterAgent = Claude/Codex's Stop
+    if (agent === 'gemini' && hookEvent === 'AfterAgent') return 'Stop';
+    return hookEvent;
+}
+
+// Build the context injection response in the correct format for each agent
+function buildContextResponse(agent, hookEvent, message) {
+    if (!message) return {};
+
+    switch (agent) {
+        case 'codex':
+            // Codex CLI uses systemMessage field
+            return { systemMessage: message };
+        case 'gemini':
+            // Gemini CLI uses systemMessage or additionalContext
+            return { systemMessage: message };
+        case 'claude':
+        default:
+            // Claude Code uses hookSpecificOutput.additionalContext
+            return {
+                hookSpecificOutput: {
+                    hookEventName: hookEvent,
+                    additionalContext: message
+                }
+            };
+    }
+}
+
 // Check for unread messages using AMP CLI (standalone — no AI Maestro needed)
 async function checkUnreadMessagesStandalone() {
     const { execSync } = require('child_process');
@@ -223,12 +265,16 @@ async function main() {
     // Log all input for debugging
     debugLog({ event: 'hook_received', input });
 
-    const hookEvent = input.hook_event_name || process.env.CLAUDE_HOOK_EVENT;
-    const cwd = input.cwd || process.cwd();
+    const agent = detectAgent(input);
+    const rawEvent = input.hook_event_name || process.env.CLAUDE_HOOK_EVENT;
+    const hookEvent = normalizeEvent(rawEvent, agent);
+    const cwd = input.cwd || process.env.GEMINI_CWD || process.cwd();
     const sessionId = input.session_id;
     const transcriptPath = input.transcript_path;
 
-    // Hook response — may be enriched with additionalContext for inbox notifications
+    debugLog({ event: 'agent_detected', agent, rawEvent, hookEvent });
+
+    // Hook response — may be enriched with context injection for inbox notifications
     let hookResponse = {};
 
     // Handle different hook events
@@ -316,16 +362,11 @@ async function main() {
                     transcriptPath
                 });
 
-                // Check for unread messages and inject as additionalContext
+                // Check for unread messages and inject as context
                 const idleMessagePrompt = await checkUnreadMessages(cwd);
                 if (idleMessagePrompt) {
-                    debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'idle_prompt' });
-                    hookResponse = {
-                        hookSpecificOutput: {
-                            hookEventName: 'Notification',
-                            additionalContext: idleMessagePrompt
-                        }
-                    };
+                    debugLog({ event: 'injecting_inbox_context', cwd, agent, trigger: 'idle_prompt' });
+                    hookResponse = buildContextResponse(agent, rawEvent, idleMessagePrompt);
                 }
             } else if (notificationType === 'permission_prompt') {
                 // For permission prompts, preserve existing tool info if we have it
@@ -381,16 +422,11 @@ async function main() {
                 source: input.source
             });
 
-            // Check for unread messages and inject as additionalContext
+            // Check for unread messages and inject as context
             const startMessagePrompt = await checkUnreadMessages(cwd);
             if (startMessagePrompt) {
-                debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'session_start' });
-                hookResponse = {
-                    hookSpecificOutput: {
-                        hookEventName: 'SessionStart',
-                        additionalContext: startMessagePrompt
-                    }
-                };
+                debugLog({ event: 'injecting_inbox_context', cwd, agent, trigger: 'session_start' });
+                hookResponse = buildContextResponse(agent, rawEvent, startMessagePrompt);
             }
             break;
 

--- a/scripts/claude-hooks/install-hooks.sh
+++ b/scripts/claude-hooks/install-hooks.sh
@@ -1,30 +1,35 @@
 #!/bin/bash
-# Install AI Maestro Claude Code Hooks
+# Install AI Maestro Agent Hooks
 #
-# This script installs hooks that enable the Chat interface to see
-# when Claude is waiting for input and other session events.
+# This script installs hooks for all detected AI coding agents:
+#   - Claude Code  (~/.claude/settings.json)
+#   - Codex CLI    (~/.codex/hooks.json + config.toml)
+#   - Gemini CLI   (~/.gemini/settings.json)
 #
-# Usage: ./install-hooks.sh
+# Usage: ./install-hooks.sh [-y]
 #
-# The hooks are installed to ~/.claude/settings.json (user-level settings)
+# The same hook script (ai-maestro-hook.cjs) is used for all agents.
+# It auto-detects which agent is calling it and returns the correct response format.
 
 set -e
 
-# Parse arguments (accept -y for non-interactive consistency with other installers)
+NON_INTERACTIVE=false
+
+# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -y|--yes|--non-interactive) shift ;;
+        -y|--yes|--non-interactive) NON_INTERACTIVE=true; shift ;;
         *) shift ;;
     esac
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK_SCRIPT="$SCRIPT_DIR/ai-maestro-hook.cjs"
-CLAUDE_SETTINGS_DIR="$HOME/.claude"
-CLAUDE_SETTINGS_FILE="$CLAUDE_SETTINGS_DIR/settings.json"
 STATE_DIR="$HOME/.aimaestro/chat-state"
+INSTALLED_COUNT=0
 
-echo "Installing AI Maestro Claude Code Hooks..."
+echo "Installing AI Maestro Agent Hooks..."
+echo ""
 
 # Make hook script executable
 chmod +x "$HOOK_SCRIPT"
@@ -32,18 +37,67 @@ chmod +x "$HOOK_SCRIPT"
 # Create state directory
 mkdir -p "$STATE_DIR"
 
-# Create Claude settings directory if needed
-mkdir -p "$CLAUDE_SETTINGS_DIR"
+# --- Helper: merge hooks into a JSON settings file ---
+# Usage: merge_hooks_into_settings <settings_file> <hooks_json>
+merge_hooks_into_settings() {
+    local SETTINGS_FILE="$1"
+    local HOOKS_JSON="$2"
 
-# Read existing settings or create empty object
-if [ -f "$CLAUDE_SETTINGS_FILE" ]; then
-    EXISTING_SETTINGS=$(cat "$CLAUDE_SETTINGS_FILE")
-else
-    EXISTING_SETTINGS='{}'
-fi
+    local EXISTING_SETTINGS='{}'
+    if [ -f "$SETTINGS_FILE" ]; then
+        EXISTING_SETTINGS=$(cat "$SETTINGS_FILE")
+    fi
 
-# Create the hooks configuration
-HOOKS_CONFIG=$(cat << EOF
+    local MERGED_SETTINGS
+    MERGED_SETTINGS=$(node -e "
+const existing = JSON.parse(process.argv[1]);
+const hooks = JSON.parse(process.argv[2]);
+
+if (!existing.hooks) {
+    existing.hooks = {};
+}
+
+for (const [event, configs] of Object.entries(hooks.hooks)) {
+    if (!existing.hooks[event]) {
+        existing.hooks[event] = [];
+    }
+
+    const hasOurHook = existing.hooks[event].some(cfg =>
+        cfg.hooks?.some(h => h.command?.includes('ai-maestro-hook'))
+    );
+
+    if (!hasOurHook) {
+        existing.hooks[event].push(...configs);
+    }
+}
+
+console.log(JSON.stringify(existing, null, 2));
+" "$EXISTING_SETTINGS" "$HOOKS_JSON")
+
+    # Write atomically
+    local TEMP_SETTINGS
+    TEMP_SETTINGS=$(mktemp "${SETTINGS_FILE}.XXXXXX")
+    echo "$MERGED_SETTINGS" > "$TEMP_SETTINGS"
+    if node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$TEMP_SETTINGS" 2>/dev/null; then
+        mv "$TEMP_SETTINGS" "$SETTINGS_FILE"
+    else
+        rm -f "$TEMP_SETTINGS"
+        echo "  ERROR: Merged settings JSON is invalid, keeping original"
+        return 1
+    fi
+}
+
+# ============================================================
+# Claude Code
+# ============================================================
+install_claude_hooks() {
+    local SETTINGS_DIR="$HOME/.claude"
+    local SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+    mkdir -p "$SETTINGS_DIR"
+
+    local HOOKS_CONFIG
+    HOOKS_CONFIG=$(cat << HOOKEOF
 {
   "hooks": {
     "Notification": [
@@ -82,58 +136,168 @@ HOOKS_CONFIG=$(cat << EOF
     ]
   }
 }
-EOF
+HOOKEOF
 )
 
-# Merge hooks into existing settings using Node.js (safe: uses JSON.parse, not eval)
-MERGED_SETTINGS=$(node -e "
-const existing = JSON.parse(process.argv[1]);
-const hooks = JSON.parse(process.argv[2]);
-
-// Merge hooks - add our hooks without removing existing ones
-if (!existing.hooks) {
-    existing.hooks = {};
+    if merge_hooks_into_settings "$SETTINGS_FILE" "$HOOKS_CONFIG"; then
+        echo "  Claude Code: $SETTINGS_FILE"
+        INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
+    fi
 }
 
-for (const [event, configs] of Object.entries(hooks.hooks)) {
-    if (!existing.hooks[event]) {
-        existing.hooks[event] = [];
-    }
+# ============================================================
+# Codex CLI
+# ============================================================
+install_codex_hooks() {
+    local SETTINGS_DIR="$HOME/.codex"
+    local HOOKS_FILE="$SETTINGS_DIR/hooks.json"
+    local CONFIG_FILE="$SETTINGS_DIR/config.toml"
 
-    // Check if our hook already exists
-    const hasOurHook = existing.hooks[event].some(cfg =>
-        cfg.hooks?.some(h => h.command?.includes('ai-maestro-hook'))
-    );
+    mkdir -p "$SETTINGS_DIR"
 
-    if (!hasOurHook) {
-        existing.hooks[event].push(...configs);
-    }
+    # Codex uses hooks.json (same format as Claude but different event set)
+    local HOOKS_CONFIG
+    HOOKS_CONFIG=$(cat << HOOKEOF
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $HOOK_SCRIPT",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $HOOK_SCRIPT",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+HOOKEOF
+)
+
+    if merge_hooks_into_settings "$HOOKS_FILE" "$HOOKS_CONFIG"; then
+        echo "  Codex CLI:   $HOOKS_FILE"
+        INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
+    fi
+
+    # Enable hooks feature in config.toml if not already set
+    if [ -f "$CONFIG_FILE" ]; then
+        if ! grep -q 'codex_hooks' "$CONFIG_FILE" 2>/dev/null; then
+            echo "" >> "$CONFIG_FILE"
+            echo "[features]" >> "$CONFIG_FILE"
+            echo "codex_hooks = true" >> "$CONFIG_FILE"
+            echo "  Codex CLI:   enabled codex_hooks in $CONFIG_FILE"
+        fi
+    else
+        cat > "$CONFIG_FILE" << TOMLEOF
+[features]
+codex_hooks = true
+TOMLEOF
+        echo "  Codex CLI:   created $CONFIG_FILE with codex_hooks enabled"
+    fi
 }
 
-console.log(JSON.stringify(existing, null, 2));
-" "$EXISTING_SETTINGS" "$HOOKS_CONFIG")
+# ============================================================
+# Gemini CLI
+# ============================================================
+install_gemini_hooks() {
+    local SETTINGS_DIR="$HOME/.gemini"
+    local SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 
-# Write merged settings atomically: write to temp file, validate JSON, then move
-TEMP_SETTINGS=$(mktemp "${CLAUDE_SETTINGS_FILE}.XXXXXX")
-echo "$MERGED_SETTINGS" > "$TEMP_SETTINGS"
-# Validate JSON before replacing (uses process.argv to avoid shell injection)
-if node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$TEMP_SETTINGS" 2>/dev/null; then
-    mv "$TEMP_SETTINGS" "$CLAUDE_SETTINGS_FILE"
-else
-    rm -f "$TEMP_SETTINGS"
-    echo "ERROR: Merged settings JSON is invalid, keeping original"
-    exit 1
+    mkdir -p "$SETTINGS_DIR"
+
+    # Gemini uses AfterAgent (equivalent to Stop) and Notification
+    local HOOKS_CONFIG
+    HOOKS_CONFIG=$(cat << HOOKEOF
+{
+  "hooks": {
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $HOOK_SCRIPT",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $HOOK_SCRIPT",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $HOOK_SCRIPT",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+HOOKEOF
+)
+
+    if merge_hooks_into_settings "$SETTINGS_FILE" "$HOOKS_CONFIG"; then
+        echo "  Gemini CLI:  $SETTINGS_FILE"
+        INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
+    fi
+}
+
+# ============================================================
+# Detect and install
+# ============================================================
+
+# Always install Claude Code (it's the primary agent)
+echo "Claude Code:"
+install_claude_hooks
+
+# Detect and install Codex CLI
+if command -v codex &>/dev/null || [ -d "$HOME/.codex" ]; then
+    echo ""
+    echo "Codex CLI (detected):"
+    install_codex_hooks
+fi
+
+# Detect and install Gemini CLI
+if command -v gemini &>/dev/null || [ -d "$HOME/.gemini" ]; then
+    echo ""
+    echo "Gemini CLI (detected):"
+    install_gemini_hooks
 fi
 
 echo ""
-echo "Hooks installed successfully!"
+echo "Hooks installed for $INSTALLED_COUNT agent(s)."
 echo ""
 echo "Configuration:"
-echo "  Hook script: $HOOK_SCRIPT"
-echo "  Settings file: $CLAUDE_SETTINGS_FILE"
+echo "  Hook script:    $HOOK_SCRIPT"
 echo "  State directory: $STATE_DIR"
 echo ""
-echo "The Chat interface will now show when Claude is waiting for input."
+echo "Agents will now receive AMP inbox notifications between turns"
+echo "and the Chat interface will show agent status."
 echo ""
-echo "Note: Existing Claude Code sessions need to be restarted for"
+echo "Note: Existing agent sessions need to be restarted for"
 echo "the hooks to take effect."


### PR DESCRIPTION
## Summary
- Hook script auto-detects which AI agent is calling it and returns the correct response format
- Installer detects installed agents and writes hook configs for Claude Code, Codex CLI, and Gemini CLI
- All three agents now get AMP inbox notifications between turns

## Hook Script Changes
- `detectAgent()`: Gemini (env vars), Codex (model/turn_id fields), Claude (default)
- `normalizeEvent()`: Gemini's `AfterAgent` → `Stop`
- `buildContextResponse()`: `additionalContext` (Claude) vs `systemMessage` (Codex/Gemini)

## Installer Changes
- Auto-detects Claude Code (always), Codex CLI (`codex` command or `~/.codex/`), Gemini CLI (`gemini` command or `~/.gemini/`)
- Writes correct hook config per agent (different event names, file locations)
- Enables `codex_hooks = true` in Codex's `config.toml`
- Shared `merge_hooks_into_settings` helper (DRY)

## Test plan
- [ ] Run installer on machine with only Claude Code
- [ ] Run installer on machine with Claude + Codex
- [ ] Run installer on machine with all three agents
- [ ] Verify Claude hooks still work (regression)
- [ ] Verify Codex Stop event triggers inbox check
- [ ] Verify Gemini AfterAgent triggers inbox check

Plugin submodule PR: 23blocks-OS/ai-maestro-plugins#22

🤖 Generated with [Claude Code](https://claude.com/claude-code)