### PR TITLE
fix: sync version references to 0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.26.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.27.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.26.5
+**Current Version:** v0.27.0
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.26.5",
+      "softwareVersion": "0.27.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.26.5",
+      "softwareVersion": "0.27.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.26.5</span>
+                        <span>v0.27.0</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.26.5"
+VERSION="0.27.0"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.26.5",
-  "releaseDate": "2026-03-25",
+  "version": "0.27.0",
+  "releaseDate": "2026-04-13",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

PR #325 bumped `package.json` to 0.27.0 but missed `version.json` and 5 other files. The dashboard footer was still showing v0.26.5.

Fixed: `version.json`, `README.md`, `remote-install.sh`, `docs/index.html`, `docs/ai-index.html`, `docs/BACKLOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)