### PR TITLE
feat: unify API errors to AMP format (#285)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.27.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/_helpers.ts
+++ b/app/api/_helpers.ts
@@ -1,0 +1,34 @@
+/**
+ * API Route Helpers
+ *
+ * Shared utilities for Next.js API route handlers.
+ * Converts ServiceResult<T> to NextResponse with proper error formatting.
+ */
+
+import { NextResponse } from 'next/server'
+import type { ServiceResult } from '@/services/service-errors'
+
+/**
+ * Convert a ServiceResult into a NextResponse.
+ *
+ * result.data contains either the success payload or a ServiceError.
+ * The status code is always taken from result.status.
+ */
+export function toResponse<T>(result: ServiceResult<T>): NextResponse {
+  const opts: ResponseInit & { headers?: Record<string, string> } = {
+    status: result.status,
+  }
+  if (result.headers) {
+    opts.headers = result.headers
+  }
+
+  if (result.data !== undefined) {
+    return NextResponse.json(result.data, opts)
+  }
+
+  // Defensive fallback — should not happen after migration
+  return NextResponse.json(
+    { error: 'internal_error', message: 'Unknown error' },
+    { status: result.status >= 400 ? result.status : 500 }
+  )
+}

--- a/app/api/agents/[id]/amp/addresses/[address]/route.ts
+++ b/app/api/agents/[id]/amp/addresses/[address]/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   getAMPAddress,
   updateAMPAddressOnAgent,
   removeAMPAddressFromAgent,
 } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/amp/addresses/[address]
@@ -16,11 +17,7 @@ export async function GET(
   const { id, address } = await params
 
   const result = getAMPAddress(id, address)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -35,11 +32,7 @@ export async function PATCH(
   const body = await request.json()
 
   const result = updateAMPAddressOnAgent(id, address, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -53,9 +46,5 @@ export async function DELETE(
   const { id, address } = await params
 
   const result = removeAMPAddressFromAgent(id, address)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/amp/addresses/route.ts
+++ b/app/api/agents/[id]/amp/addresses/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listAMPAddresses, addAMPAddressToAgent } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/amp/addresses
@@ -12,11 +13,7 @@ export async function GET(
   const { id } = await params
 
   const result = listAMPAddresses(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -31,9 +28,5 @@ export async function POST(
   const body = await request.json()
 
   const result = addAMPAddressToAgent(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/chat/route.ts
+++ b/app/api/agents/[id]/chat/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getConversationMessages, sendChatMessage } from '@/services/agents-chat-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   request: NextRequest,
@@ -21,10 +22,7 @@ export async function GET(
     const limit = parseInt(searchParams.get('limit') || '100', 10)
 
     const result = await getConversationMessages(agentId, { since, limit })
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Chat API] GET Error:', error)
     return NextResponse.json(
@@ -43,10 +41,7 @@ export async function POST(
     const body = await request.json()
 
     const result = await sendChatMessage(agentId, body.message)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Chat API] POST Error:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/database/route.ts
+++ b/app/api/agents/[id]/database/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getDatabaseInfo, initializeDatabase } from '@/services/agents-graph-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/database
@@ -11,11 +12,7 @@ export async function GET(
 ) {
   const { id: agentId } = await params
   const result = await getDatabaseInfo(agentId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -28,9 +25,5 @@ export async function POST(
 ) {
   const { id: agentId } = await params
   const result = await initializeDatabase(agentId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/docs/route.ts
+++ b/app/api/agents/[id]/docs/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { queryDocs, indexDocs, clearDocs } from '@/services/agents-docs-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   request: NextRequest,
@@ -29,10 +30,7 @@ export async function GET(
       project: searchParams.get('project'),
     })
 
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Docs API] Error:', error)
     return NextResponse.json(
@@ -60,10 +58,7 @@ export async function POST(
     }
 
     const result = await indexDocs(agentId, body)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Docs API] Error:', error)
     return NextResponse.json(
@@ -83,10 +78,7 @@ export async function DELETE(
     const projectPath = searchParams.get('project') || undefined
 
     const result = await clearDocs(agentId, projectPath)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Docs API] Error:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/email/addresses/[address]/route.ts
+++ b/app/api/agents/[id]/email/addresses/[address]/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   getEmailAddressDetail,
   updateEmailAddressOnAgent,
   removeEmailAddressFromAgent,
 } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/email/addresses/[address]
@@ -16,11 +17,7 @@ export async function GET(
   const { id, address } = await params
 
   const result = getEmailAddressDetail(id, address)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -35,11 +32,7 @@ export async function PATCH(
   const body = await request.json()
 
   const result = updateEmailAddressOnAgent(id, address, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -53,9 +46,5 @@ export async function DELETE(
   const { id, address } = await params
 
   const result = removeEmailAddressFromAgent(id, address)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/email/addresses/route.ts
+++ b/app/api/agents/[id]/email/addresses/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listEmailAddresses, addEmailAddressToAgent } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/email/addresses
@@ -12,11 +13,7 @@ export async function GET(
   const { id } = await params
 
   const result = listEmailAddresses(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -31,10 +28,5 @@ export async function POST(
   const body = await request.json()
 
   const result = addEmailAddressToAgent(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  // Handle conflict (409) — service returns data (not error) for conflicts
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/export/route.ts
+++ b/app/api/agents/[id]/export/route.ts
@@ -9,6 +9,8 @@
 
 import { NextResponse } from 'next/server'
 import { exportAgentZip, createTranscriptExportJob } from '@/services/agents-transfer-service'
+import { toResponse } from '@/app/api/_helpers'
+import { isServiceError } from '@/services/service-errors'
 
 export async function GET(
   _request: Request,
@@ -17,8 +19,8 @@ export async function GET(
   try {
     const result = await exportAgentZip(params.id)
 
-    if (result.error || !result.data) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
+    if (!result.data || isServiceError(result.data)) {
+      return toResponse(result)
     }
 
     const { buffer, filename, agentId, agentName } = result.data
@@ -50,11 +52,7 @@ export async function POST(
   try {
     const body = await request.json()
     const result = createTranscriptExportJob(params.id, body)
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Failed to create transcript export job:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/graph/code/route.ts
+++ b/app/api/agents/[id]/graph/code/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { queryCodeGraph, indexCodeGraph, deleteCodeGraph } from '@/services/agents-graph-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/graph/code
@@ -22,10 +23,7 @@ export async function GET(
     depth: parseInt(searchParams.get('depth') || '1', 10),
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -50,11 +48,7 @@ export async function POST(
   }
 
   const result = await indexCodeGraph(agentId, body)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -69,9 +63,5 @@ export async function DELETE(
   const projectPath = request.nextUrl.searchParams.get('project') || ''
 
   const result = await deleteCodeGraph(agentId, projectPath)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/graph/db/route.ts
+++ b/app/api/agents/[id]/graph/db/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { queryDbGraph, indexDbSchema, clearDbGraph } from '@/services/agents-graph-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/graph/db
@@ -19,10 +20,7 @@ export async function GET(
     database: searchParams.get('database'),
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error, ...(result.data || {}) }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -37,11 +35,7 @@ export async function POST(
   const body = await request.json()
 
   const result = await indexDbSchema(agentId, body)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -56,9 +50,5 @@ export async function DELETE(
   const databaseName = request.nextUrl.searchParams.get('database') || ''
 
   const result = await clearDbGraph(agentId, databaseName)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/graph/query/route.ts
+++ b/app/api/agents/[id]/graph/query/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { queryGraph } from '@/services/agents-graph-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/graph/query
@@ -20,8 +21,5 @@ export async function GET(
     to: searchParams.get('to'),
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error, ...(result.data || {}) }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/hibernate/route.ts
+++ b/app/api/agents/[id]/hibernate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { hibernateAgent } from '@/services/agents-core-service'
 import { getAgent } from '@/lib/agent-registry'
 import { isSelf } from '@/lib/hosts-config'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * POST /api/agents/[id]/hibernate
@@ -60,9 +61,5 @@ export async function POST(
   }
 
   const result = await hibernateAgent(id, { sessionIndex })
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/memory/consolidate/route.ts
+++ b/app/api/agents/[id]/memory/consolidate/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   getConsolidationStatus,
   triggerConsolidation,
   manageConsolidation,
 } from '@/services/agents-memory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/memory/consolidate
@@ -15,11 +16,7 @@ export async function GET(
 ) {
   const { id: agentId } = await params
   const result = await getConsolidationStatus(agentId)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -46,13 +43,7 @@ export async function POST(
       : undefined,
   })
 
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, status: 'failed', error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -78,8 +69,5 @@ export async function PATCH(
     dryRun: body.dryRun,
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/memory/long-term/route.ts
+++ b/app/api/agents/[id]/memory/long-term/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   queryLongTermMemories,
   deleteLongTermMemory,
   updateLongTermMemory,
 } from '@/services/agents-memory-service'
 import type { MemoryCategory } from '@/lib/cozo-schema-memory'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/memory/long-term
@@ -40,10 +41,7 @@ export async function GET(
     maxTokens: parseInt(searchParams.get('maxTokens') || '2000'),
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -61,11 +59,7 @@ export async function DELETE(
   const memoryId = request.nextUrl.searchParams.get('id') || ''
 
   const result = await deleteLongTermMemory(agentId, memoryId)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -92,8 +86,5 @@ export async function PATCH(
     context: body.context,
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/memory/route.ts
+++ b/app/api/agents/[id]/memory/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getMemory, initializeMemory } from '@/services/agents-memory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/memory
@@ -11,11 +12,7 @@ export async function GET(
 ) {
   const { id: agentId } = await params
   const result = await getMemory(agentId)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -34,8 +31,5 @@ export async function POST(
     force: body.force,
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/messages/[messageId]/route.ts
+++ b/app/api/agents/[id]/messages/[messageId]/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   getMessage,
   updateMessage,
   deleteMessageById,
   forwardMessage,
 } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/messages/[messageId]
@@ -19,11 +20,7 @@ export async function GET(
   const box = (searchParams.get('box') || 'inbox') as 'inbox' | 'sent'
 
   const result = await getMessage(id, messageId, box)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -38,11 +35,7 @@ export async function PATCH(
   const body = await request.json()
 
   const result = await updateMessage(id, messageId, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -56,11 +49,7 @@ export async function DELETE(
   const { id, messageId } = await params
 
   const result = await deleteMessageById(id, messageId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -75,9 +64,5 @@ export async function POST(
   const body = await request.json()
 
   const result = await forwardMessage(id, messageId, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/messages/route.ts
+++ b/app/api/agents/[id]/messages/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listMessages, sendMessage } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/messages
@@ -20,10 +21,7 @@ export async function GET(
     to: searchParams.get('to') || undefined,
   })
 
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -38,9 +36,5 @@ export async function POST(
   const body = await request.json()
 
   const result = await sendMessage(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/metrics/route.ts
+++ b/app/api/agents/[id]/metrics/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getMetrics, updateMetrics } from '@/services/agents-memory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]/metrics
@@ -11,11 +12,7 @@ export async function GET(
 ) {
   const { id: agentId } = await params
   const result = getMetrics(agentId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -30,9 +27,5 @@ export async function PATCH(
   const body = await request.json()
 
   const result = updateMetrics(agentId, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/playback/route.ts
+++ b/app/api/agents/[id]/playback/route.ts
@@ -9,6 +9,7 @@
 
 import { NextResponse } from 'next/server'
 import { getPlaybackState, controlPlayback } from '@/services/agents-playback-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   request: Request,
@@ -19,10 +20,7 @@ export async function GET(
     const sessionId = searchParams.get('sessionId')
 
     const result = getPlaybackState(params.id, sessionId)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Playback API] Failed to get playback state:', error)
     return NextResponse.json(
@@ -39,10 +37,7 @@ export async function POST(
   try {
     const body = await request.json()
     const result = controlPlayback(params.id, body)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Playback API] Failed to control playback:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/repos/route.ts
+++ b/app/api/agents/[id]/repos/route.ts
@@ -10,6 +10,7 @@
 
 import { NextResponse } from 'next/server'
 import { listRepos, updateRepos, removeRepo } from '@/services/agents-repos-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: Request,
@@ -17,10 +18,7 @@ export async function GET(
 ) {
   try {
     const result = listRepos(params.id)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error getting agent repos:', error)
     return NextResponse.json(
@@ -37,10 +35,7 @@ export async function POST(
   try {
     const body = await request.json()
     const result = updateRepos(params.id, body)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error updating agent repos:', error)
     return NextResponse.json(
@@ -63,10 +58,7 @@ export async function DELETE(
     }
 
     const result = removeRepo(params.id, remoteUrl)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error removing repo:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server'
 import { getAgentById, updateAgentById, deleteAgentById } from '@/services/agents-core-service'
 import type { UpdateAgentRequest } from '@/types/agent'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/[id]
@@ -12,11 +12,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = getAgentById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -30,11 +26,7 @@ export async function PATCH(
   const { id } = await params
   const body: UpdateAgentRequest = await request.json()
   const result = updateAgentById(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -52,9 +44,5 @@ export async function DELETE(
   const hard = hardParam === 'true' || hardParam === '1' || hardParam === 'yes'
 
   const result = deleteAgentById(id, hard)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/search/route.ts
+++ b/app/api/agents/[id]/search/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { searchConversations, ingestConversations } from '@/services/agents-memory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/search
@@ -39,10 +40,7 @@ export async function GET(
     semanticWeight: searchParams.get('semanticWeight') ? parseFloat(searchParams.get('semanticWeight')!) : undefined,
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -65,8 +63,5 @@ export async function POST(
     batchSize: body.batchSize,
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/session/route.ts
+++ b/app/api/agents/[id]/session/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   getAgentSessionStatus,
   linkAgentSession,
   sendAgentSessionCommand,
   unlinkOrDeleteAgentSession,
 } from '@/services/agents-core-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * POST /api/agents/[id]/session
@@ -17,11 +18,7 @@ export async function POST(
   const { id } = await params
   const body = await request.json()
   const result = linkAgentSession(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -41,22 +38,7 @@ export async function PATCH(
     addNewline: body.addNewline,
   })
 
-  if (result.error && result.status !== 409) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-
-  // For 409 (not idle), include data + error together
-  if (result.status === 409) {
-    return NextResponse.json(
-      { success: false, error: result.error, ...result.data },
-      { status: 409 }
-    )
-  }
-
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -69,14 +51,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = await getAgentSessionStatus(id)
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -95,8 +70,5 @@ export async function DELETE(
     deleteAgent: searchParams.get('deleteAgent') === 'true',
   })
 
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/skills/route.ts
+++ b/app/api/agents/[id]/skills/route.ts
@@ -12,6 +12,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getSkillsConfig, updateSkills, addSkill, removeSkill } from '@/services/agents-skills-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: NextRequest,
@@ -20,10 +21,7 @@ export async function GET(
   try {
     const { id } = await params
     const result = getSkillsConfig(id)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error fetching agent skills:', error)
     return NextResponse.json(
@@ -41,10 +39,7 @@ export async function PATCH(
     const { id } = await params
     const body = await request.json()
     const result = await updateSkills(id, body)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error updating agent skills:', error)
     return NextResponse.json(
@@ -62,10 +57,7 @@ export async function POST(
     const { id } = await params
     const body = await request.json()
     const result = addSkill(id, body)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error adding custom skill:', error)
     return NextResponse.json(
@@ -90,10 +82,7 @@ export async function DELETE(
     }
 
     const result = removeSkill(id, skill, type)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error removing skill:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/skills/settings/route.ts
+++ b/app/api/agents/[id]/skills/settings/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getSkillSettings, saveSkillSettings } from '@/services/agents-skills-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: NextRequest,
@@ -17,10 +18,7 @@ export async function GET(
   try {
     const { id: agentId } = await params
     const result = await getSkillSettings(agentId)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Skill Settings API] GET Error:', error)
     return NextResponse.json(
@@ -38,10 +36,7 @@ export async function PUT(
     const { id: agentId } = await params
     const body = await request.json()
     const result = await saveSkillSettings(agentId, body.settings)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Skill Settings API] PUT Error:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/subconscious/route.ts
+++ b/app/api/agents/[id]/subconscious/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getSubconsciousStatus, triggerSubconsciousAction } from '@/services/agents-subconscious-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: NextRequest,
@@ -17,10 +18,7 @@ export async function GET(
   try {
     const { id: agentId } = await params
     const result = await getSubconsciousStatus(agentId)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Agent Subconscious API] Error:', error)
     return NextResponse.json(
@@ -39,10 +37,7 @@ export async function POST(
     const body = await request.json()
 
     const result = await triggerSubconsciousAction(agentId, body.action)
-    if (result.error) {
-      return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Agent Subconscious API] POST Error:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/tracking/route.ts
+++ b/app/api/agents/[id]/tracking/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getTracking, initializeTracking } from '@/services/agents-memory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/:id/tracking
@@ -11,11 +12,7 @@ export async function GET(
 ) {
   const { id: agentId } = await params
   const result = await getTracking(agentId)
-
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -33,8 +30,5 @@ export async function POST(
     addSampleData: body.addSampleData,
   })
 
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/[id]/transfer/route.ts
+++ b/app/api/agents/[id]/transfer/route.ts
@@ -8,6 +8,7 @@
 
 import { NextResponse } from 'next/server'
 import { transferAgent } from '@/services/agents-transfer-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function POST(
   request: Request,
@@ -16,11 +17,7 @@ export async function POST(
   try {
     const body = await request.json()
     const result = await transferAgent(params.id, body)
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Transfer error:', error)
     return NextResponse.json(

--- a/app/api/agents/[id]/wake/route.ts
+++ b/app/api/agents/[id]/wake/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { wakeAgent } from '@/services/agents-core-service'
 import { getAgent } from '@/lib/agent-registry'
 import { isSelf } from '@/lib/hosts-config'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * POST /api/agents/[id]/wake
@@ -73,9 +74,5 @@ export async function POST(
   }
 
   const result = await wakeAgent(id, { startProgram, sessionIndex, program })
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/by-name/[name]/route.ts
+++ b/app/api/agents/by-name/[name]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { lookupAgentByName } from '@/services/agents-core-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/by-name/[name]
@@ -11,9 +12,5 @@ export async function GET(
 ) {
   const { name } = await params
   const result = lookupAgentByName(name)
-
-  if (result.error) {
-    return NextResponse.json(result.data || { exists: false }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/directory/lookup/[name]/route.ts
+++ b/app/api/agents/directory/lookup/[name]/route.ts
@@ -8,8 +8,9 @@
  * Thin wrapper — business logic in services/agents-directory-service.ts
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { lookupAgentByDirectoryName } from '@/services/agents-directory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: NextRequest,
@@ -17,8 +18,5 @@ export async function GET(
 ) {
   const { name } = await params
   const result = lookupAgentByDirectoryName(name)
-  if (result.error) {
-    return NextResponse.json({ found: false }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/directory/route.ts
+++ b/app/api/agents/directory/route.ts
@@ -8,13 +8,11 @@
  * Thin wrapper — business logic in services/agents-directory-service.ts
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getDirectory } from '@/services/agents-directory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(_request: NextRequest) {
   const result = getDirectory()
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/directory/sync/route.ts
+++ b/app/api/agents/directory/sync/route.ts
@@ -7,13 +7,11 @@
  * Thin wrapper — business logic in services/agents-directory-service.ts
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { syncDirectory } from '@/services/agents-directory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function POST(_request: NextRequest) {
   const result = await syncDirectory()
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/docker/create/route.ts
+++ b/app/api/agents/docker/create/route.ts
@@ -8,6 +8,7 @@
 
 import { NextResponse } from 'next/server'
 import { createDockerAgent } from '@/services/agents-docker-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,11 +16,7 @@ export async function POST(request: Request) {
   try {
     const body = await request.json()
     const result = await createDockerAgent(body)
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('[Docker Create] Error:', error)
     return NextResponse.json(

--- a/app/api/agents/email-index/route.ts
+++ b/app/api/agents/email-index/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { queryEmailIndex } from '@/services/agents-messaging-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/agents/email-index
@@ -22,8 +23,5 @@ export async function GET(request: NextRequest) {
     isFederatedSubQuery: request.headers.get('X-Federated-Query') === 'true',
   })
 
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/health/route.ts
+++ b/app/api/agents/health/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { proxyHealthCheck } from '@/services/agents-core-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,12 +10,5 @@ export const dynamic = 'force-dynamic'
 export async function POST(request: Request) {
   const { url } = await request.json()
   const result = await proxyHealthCheck(url)
-
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error, details: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/normalize-hosts/route.ts
+++ b/app/api/agents/normalize-hosts/route.ts
@@ -10,21 +10,15 @@
  * Thin wrapper — business logic in services/agents-directory-service.ts
  */
 
-import { NextResponse } from 'next/server'
 import { diagnoseHosts, normalizeHosts } from '@/services/agents-directory-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET() {
   const result = diagnoseHosts()
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 export async function POST() {
   const result = normalizeHosts()
-  if (result.error) {
-    return NextResponse.json({ success: false, error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/register/route.ts
+++ b/app/api/agents/register/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { registerAgent } from '@/services/agents-core-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,12 +10,5 @@ export const dynamic = 'force-dynamic'
 export async function POST(request: Request) {
   const body = await request.json()
   const result = registerAgent(body)
-
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error, details: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { listAgents, searchAgentsByQuery, createNewAgent } from '@/services/agents-core-service'
+import { toResponse } from '@/app/api/_helpers'
 import type { CreateAgentRequest } from '@/types/agent'
 
 // Force this route to be dynamic (not statically generated at build time)
@@ -19,17 +19,11 @@ export async function GET(request: Request) {
   // If search query provided, return simple search results
   if (query) {
     const result = searchAgentsByQuery(query)
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   }
 
   const result = await listAgents()
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error, agents: [] },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -39,9 +33,5 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const body: CreateAgentRequest = await request.json()
   const result = createNewAgent(body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/agents/startup/route.ts
+++ b/app/api/agents/startup/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { initializeStartup, getStartupInfo } from '@/services/agents-core-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,14 +9,7 @@ export const dynamic = 'force-dynamic'
  */
 export async function POST() {
   const result = await initializeStartup()
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -25,12 +18,5 @@ export async function POST() {
  */
 export async function GET() {
   const result = getStartupInfo()
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/conversations/[file]/messages/route.ts
+++ b/app/api/conversations/[file]/messages/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getConversationMessages } from '@/services/config-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/conversations/:file/messages?agentId=X
@@ -13,13 +14,5 @@ export async function GET(
   const agentId = request.nextUrl.searchParams.get('agentId') || ''
 
   const result = await getConversationMessages(encodedFile, agentId)
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error, ...(result.data || {}) },
-      { status: result.status }
-    )
-  }
-
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/conversations/parse/route.ts
+++ b/app/api/conversations/parse/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { parseConversationFile } from '@/services/config-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * POST /api/conversations/parse
@@ -13,15 +14,7 @@ export async function POST(request: NextRequest) {
     console.log('[Parse Conversation] Request for file:', conversationFile)
 
     const result = parseConversationFile(conversationFile)
-
-    if (result.error) {
-      return NextResponse.json(
-        { success: false, error: result.error },
-        { status: result.status }
-      )
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('[Parse Conversation] Error:', error)
     return NextResponse.json(

--- a/app/api/debug/pty/route.ts
+++ b/app/api/debug/pty/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { getPtyDebugInfo } from '@/services/config-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // Disable Next.js caching for this endpoint
 export const dynamic = 'force-dynamic'
@@ -11,13 +11,5 @@ export const revalidate = 0
  */
 export async function GET() {
   const result = await getPtyDebugInfo()
-
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error },
-      { status: result.status }
-    )
-  }
-
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/domains/[id]/route.ts
+++ b/app/api/domains/[id]/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { getDomainById, updateDomainById, deleteDomainById } from '@/services/domains-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/domains/[id]
@@ -11,11 +11,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = getDomainById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -29,11 +25,7 @@ export async function PATCH(
   const { id } = await params
   const body = await request.json()
   const result = updateDomainById(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -46,9 +38,5 @@ export async function DELETE(
 ) {
   const { id } = await params
   const result = deleteDomainById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/domains/route.ts
+++ b/app/api/domains/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { listAllDomains, createNewDomain } from '@/services/domains-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/domains
@@ -7,11 +7,7 @@ import { listAllDomains, createNewDomain } from '@/services/domains-service'
  */
 export async function GET() {
   const result = listAllDomains()
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -21,9 +17,5 @@ export async function GET() {
 export async function POST(request: Request) {
   const body = await request.json()
   const result = createNewDomain(body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/export/jobs/[jobId]/route.ts
+++ b/app/api/export/jobs/[jobId]/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { getExportJobStatus, deleteExportJob } from '@/services/config-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/export/jobs/[jobId]
@@ -10,17 +10,8 @@ export async function GET(
   { params }: { params: Promise<{ jobId: string }> }
 ) {
   const { jobId } = await params
-
   const result = getExportJobStatus(jobId)
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -32,15 +23,6 @@ export async function DELETE(
   { params }: { params: Promise<{ jobId: string }> }
 ) {
   const { jobId } = await params
-
   const result = deleteExportJob(jobId)
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/help/agent/route.ts
+++ b/app/api/help/agent/route.ts
@@ -6,26 +6,19 @@
  * GET /api/help/agent - Check assistant agent status
  */
 
-import { NextResponse } from 'next/server'
 import {
   createAssistantAgent,
   deleteAssistantAgent,
   getAssistantStatus,
 } from '@/services/help-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * POST - Create or return existing assistant agent
  */
 export async function POST() {
   const result = await createAssistantAgent()
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -33,14 +26,7 @@ export async function POST() {
  */
 export async function DELETE() {
   const result = await deleteAssistantAgent()
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -48,12 +34,5 @@ export async function DELETE() {
  */
 export async function GET() {
   const result = await getAssistantStatus()
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/hosts/[id]/route.ts
+++ b/app/api/hosts/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { updateExistingHost, deleteExistingHost } from '@/services/hosts-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,10 +17,7 @@ export async function PUT(
   const hostData = await request.json()
 
   const result = await updateExistingHost(id, hostData)
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -34,8 +32,5 @@ export async function DELETE(
   const { id } = await params
 
   const result = await deleteExistingHost(id)
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/hosts/health/route.ts
+++ b/app/api/hosts/health/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { checkRemoteHealth } from '@/services/hosts-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,8 +13,5 @@ export async function GET(request: NextRequest) {
   const hostUrl = request.nextUrl.searchParams.get('url') || ''
 
   const result = await checkRemoteHealth(hostUrl)
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/hosts/route.ts
+++ b/app/api/hosts/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listHosts, addNewHost } from '@/services/hosts-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // Force this route to be dynamic (not statically generated at build time)
 export const dynamic = 'force-dynamic'
@@ -11,10 +12,7 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET() {
   const result = await listHosts()
-  if (result.error) {
-    return NextResponse.json({ error: result.error, hosts: [] }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -27,8 +25,5 @@ export async function POST(request: NextRequest) {
   const host = await request.json()
 
   const result = await addNewHost({ host, syncEnabled })
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/hosts/sync/route.ts
+++ b/app/api/hosts/sync/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { triggerMeshSync, getMeshStatus } from '@/services/hosts-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // Force this route to be dynamic
 export const dynamic = 'force-dynamic'
@@ -11,10 +11,7 @@ export const dynamic = 'force-dynamic'
  */
 export async function POST() {
   const result = await triggerMeshSync()
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -24,8 +21,5 @@ export async function POST() {
  */
 export async function GET() {
   const result = await getMeshStatus()
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/marketplace/skills/[id]/route.ts
+++ b/app/api/marketplace/skills/[id]/route.ts
@@ -7,9 +7,9 @@
  * Example: claude-plugins-official:code-review:code-review
  */
 
-import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getMarketplaceSkillById } from '@/services/marketplace-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: NextRequest,
@@ -17,12 +17,5 @@ export async function GET(
 ) {
   const { id } = await params
   const result = await getMarketplaceSkillById(id)
-
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/marketplace/skills/route.ts
+++ b/app/api/marketplace/skills/route.ts
@@ -9,9 +9,9 @@
  * GET /api/marketplace/skills?includeContent=true - Include full SKILL.md content
  */
 
-import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { listMarketplaceSkills } from '@/services/marketplace-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
@@ -24,12 +24,5 @@ export async function GET(request: NextRequest) {
   }
 
   const result = await listMarketplaceSkills(params)
-
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/meetings/[id]/route.ts
+++ b/app/api/meetings/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getMeetingById, updateExistingMeeting, deleteExistingMeeting } from '@/services/messages-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/meetings/[id] - Get a single meeting
 export async function GET(
@@ -8,7 +9,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = getMeetingById(id)
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }
 
 // PATCH /api/meetings/[id] - Update a meeting
@@ -19,7 +20,7 @@ export async function PATCH(
   const { id } = await params
   const body = await request.json()
   const result = updateExistingMeeting(id, body)
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }
 
 // DELETE /api/meetings/[id] - Delete a meeting
@@ -29,5 +30,5 @@ export async function DELETE(
 ) {
   const { id } = await params
   const result = deleteExistingMeeting(id)
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/meetings/route.ts
+++ b/app/api/meetings/route.ts
@@ -1,15 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listMeetings, createNewMeeting } from '@/services/messages-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/meetings - List all meetings (optional ?status=active filter)
 export async function GET(request: NextRequest) {
   const result = listMeetings(request.nextUrl.searchParams.get('status'))
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }
 
 // POST /api/meetings - Create a new meeting
 export async function POST(request: NextRequest) {
   const body = await request.json()
   const result = createNewMeeting(body)
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/messages/forward/route.ts
+++ b/app/api/messages/forward/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { forwardMessage } from '@/services/messages-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function POST(request: NextRequest) {
   const body = await request.json()
   const result = await forwardMessage(body)
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/messages/meeting/route.ts
+++ b/app/api/messages/meeting/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getMeetingMessages } from '@/services/messages-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/messages/meeting?meetingId=<id>&participants=<id1,id2,...>&since=<timestamp>
@@ -11,5 +12,5 @@ export async function GET(request: NextRequest) {
     participants: searchParams.get('participants'),
     since: searchParams.get('since'),
   })
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getMessages, sendMessage, updateMessage, removeMessage } from '@/services/messages-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/messages?agent=<agentId|alias|sessionName>&status=<status>&from=<from>&box=<inbox|sent>
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     from: searchParams.get('from'),
     to: searchParams.get('to'),
   })
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const body = await request.json()
   const result = await sendMessage(body)
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -39,7 +40,7 @@ export async function PATCH(request: NextRequest) {
     searchParams.get('id'),
     searchParams.get('action'),
   )
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -51,5 +52,5 @@ export async function DELETE(request: NextRequest) {
     searchParams.get('agent'),
     searchParams.get('id'),
   )
-  return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/organization/route.ts
+++ b/app/api/organization/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getOrganization, setOrganizationName } from '@/services/config-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/organization
@@ -7,7 +8,7 @@ import { getOrganization, setOrganizationName } from '@/services/config-service'
  */
 export async function GET() {
   const result = getOrganization()
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }
 
 /**
@@ -21,7 +22,7 @@ export async function POST(request: Request) {
     const { organization, setBy } = body
 
     const result = setOrganizationName({ organization, setBy })
-    return NextResponse.json(result.data ?? { error: result.error }, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('[Organization API] Error:', error)
     return NextResponse.json(

--- a/app/api/plugin-builder/build/route.ts
+++ b/app/api/plugin-builder/build/route.ts
@@ -9,19 +9,13 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { buildPlugin } from '@/services/plugin-builder-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
     const result = await buildPlugin(body)
-
-    if (result.error) {
-      return NextResponse.json(
-        { error: result.error },
-        { status: result.status }
-      )
-    }
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch {
     return NextResponse.json(
       { error: 'Invalid request body' },

--- a/app/api/plugin-builder/builds/[id]/route.ts
+++ b/app/api/plugin-builder/builds/[id]/route.ts
@@ -4,23 +4,15 @@
  * GET /api/plugin-builder/builds/:id - Check build status
  */
 
-import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getBuildStatus } from '@/services/plugin-builder-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params
-
   const result = await getBuildStatus(id)
-
-  if (result.error) {
-    return NextResponse.json(
-      { error: result.error },
-      { status: result.status }
-    )
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/plugin-builder/push/route.ts
+++ b/app/api/plugin-builder/push/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { pushToGitHub } from '@/services/plugin-builder-service'
+import { toResponse } from '@/app/api/_helpers'
 import type { PluginPushConfig } from '@/types/plugin-builder'
 
 export async function POST(request: NextRequest) {
@@ -28,14 +29,7 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await pushToGitHub(body)
-
-    if (result.error) {
-      return NextResponse.json(
-        { error: result.error },
-        { status: result.status }
-      )
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error pushing to GitHub:', error)
     return NextResponse.json(

--- a/app/api/plugin-builder/scan-repo/route.ts
+++ b/app/api/plugin-builder/scan-repo/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { scanRepo } from '@/services/plugin-builder-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,14 +21,7 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await scanRepo(body.url, body.ref || 'main')
-
-    if (result.error) {
-      return NextResponse.json(
-        { error: result.error },
-        { status: result.status }
-      )
-    }
-    return NextResponse.json(result.data)
+    return toResponse(result)
   } catch (error) {
     console.error('Error scanning repo:', error)
     return NextResponse.json(

--- a/app/api/sessions/[id]/command/route.ts
+++ b/app/api/sessions/[id]/command/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sendCommand, checkIdleStatus } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * @deprecated Use /api/agents/[id]/session with PATCH method instead.
@@ -28,22 +29,7 @@ export async function POST(
       addNewline: body.addNewline,
     })
 
-    if (result.error && !result.data) {
-      return NextResponse.json(
-        { success: false, error: result.error },
-        { status: result.status }
-      )
-    }
-
-    if (result.error && result.data) {
-      // Session not idle case: has both data and error
-      return NextResponse.json(
-        { ...result.data, error: result.error },
-        { status: result.status }
-      )
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('[Session Command API] Error:', error)
     return NextResponse.json(

--- a/app/api/sessions/[id]/rename/route.ts
+++ b/app/api/sessions/[id]/rename/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { renameSession } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -24,12 +25,7 @@ export async function PATCH(
     ])
 
     const result = await renameSession(oldName, newName)
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('Failed to rename session:', error)
     return NextResponse.json({ error: 'Failed to rename session' }, { status: 500 })

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { deleteSession } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -20,12 +21,7 @@ export async function DELETE(
   try {
     const { id: sessionName } = await params
     const result = await deleteSession(sessionName)
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('Failed to delete session:', error)
     return NextResponse.json({ error: 'Failed to delete session' }, { status: 500 })

--- a/app/api/sessions/activity/update/route.ts
+++ b/app/api/sessions/activity/update/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { broadcastActivityUpdate } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // Disable caching
 export const dynamic = 'force-dynamic'
@@ -13,15 +14,7 @@ export async function POST(request: NextRequest) {
     const { sessionName, status, hookStatus, notificationType } = await request.json()
 
     const result = broadcastActivityUpdate(sessionName, status, hookStatus, notificationType)
-
-    if (result.error) {
-      return NextResponse.json(
-        { success: false, error: result.error },
-        { status: result.status }
-      )
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('[Activity Update API] Error:', error)
     return NextResponse.json(

--- a/app/api/sessions/create/route.ts
+++ b/app/api/sessions/create/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSession } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function POST(request: Request) {
   try {
@@ -16,11 +17,7 @@ export async function POST(request: Request) {
       program: body.program,
     })
 
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('Failed to create session:', error)
     return NextResponse.json({ error: 'Failed to create session' }, { status: 500 })

--- a/app/api/sessions/restore/route.ts
+++ b/app/api/sessions/restore/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { listRestorableSessions, restoreSessions, deletePersistedSession } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/sessions/restore
@@ -24,12 +25,7 @@ export async function POST(request: Request) {
     const { sessionId, all } = await request.json()
 
     const result = await restoreSessions({ sessionId, all })
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-
-    return NextResponse.json({ success: true, ...result.data }, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('Failed to restore sessions:', error)
     return NextResponse.json({ error: 'Failed to restore sessions' }, { status: 500 })
@@ -46,12 +42,7 @@ export async function DELETE(request: Request) {
     const sessionId = searchParams.get('sessionId')
 
     const result = deletePersistedSession(sessionId || '')
-
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status })
-    }
-
-    return NextResponse.json(result.data, { status: result.status })
+    return toResponse(result)
   } catch (error) {
     console.error('Failed to delete persisted session:', error)
     return NextResponse.json({ error: 'Failed to delete session' }, { status: 500 })

--- a/app/api/subconscious/route.ts
+++ b/app/api/subconscious/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { getSubconsciousStatus } from '@/services/config-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // Force dynamic rendering - agent count changes at runtime
 export const dynamic = 'force-dynamic'
@@ -11,13 +11,5 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET() {
   const result = getSubconsciousStatus()
-
-  if (result.error) {
-    return NextResponse.json(
-      { success: false, error: result.error },
-      { status: result.status }
-    )
-  }
-
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/teams/[id]/documents/[docId]/route.ts
+++ b/app/api/teams/[id]/documents/[docId]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getTeamDocument, updateTeamDocument, deleteTeamDocument } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/teams/[id]/documents/[docId] - Get a single document
 export async function GET(
@@ -8,11 +9,7 @@ export async function GET(
 ) {
   const { id, docId } = await params
   const result = getTeamDocument(id, docId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // PUT /api/teams/[id]/documents/[docId] - Update a document
@@ -23,11 +20,7 @@ export async function PUT(
   const { id, docId } = await params
   const body = await request.json()
   const result = updateTeamDocument(id, docId, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // DELETE /api/teams/[id]/documents/[docId] - Delete a document
@@ -37,9 +30,5 @@ export async function DELETE(
 ) {
   const { id, docId } = await params
   const result = deleteTeamDocument(id, docId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/teams/[id]/documents/route.ts
+++ b/app/api/teams/[id]/documents/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listTeamDocuments, createTeamDocument } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/teams/[id]/documents - List all documents for a team
 export async function GET(
@@ -8,11 +9,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = listTeamDocuments(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // POST /api/teams/[id]/documents - Create a new document
@@ -23,9 +20,5 @@ export async function POST(
   const { id } = await params
   const body = await request.json()
   const result = createTeamDocument(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/teams/[id]/route.ts
+++ b/app/api/teams/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getTeamById, updateTeamById, deleteTeamById } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/teams/[id] - Get a single team
 export async function GET(
@@ -8,11 +9,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = getTeamById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // PUT /api/teams/[id] - Update a team
@@ -23,11 +20,7 @@ export async function PUT(
   const { id } = await params
   const body = await request.json()
   const result = updateTeamById(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // DELETE /api/teams/[id] - Delete a team
@@ -37,9 +30,5 @@ export async function DELETE(
 ) {
   const { id } = await params
   const result = deleteTeamById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/teams/[id]/tasks/[taskId]/route.ts
+++ b/app/api/teams/[id]/tasks/[taskId]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { updateTeamTask, deleteTeamTask } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // PUT /api/teams/[id]/tasks/[taskId] - Update a task
 export async function PUT(
@@ -9,11 +10,7 @@ export async function PUT(
   const { id, taskId } = await params
   const body = await request.json()
   const result = updateTeamTask(id, taskId, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // DELETE /api/teams/[id]/tasks/[taskId] - Delete a task
@@ -23,9 +20,5 @@ export async function DELETE(
 ) {
   const { id, taskId } = await params
   const result = deleteTeamTask(id, taskId)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/teams/[id]/tasks/route.ts
+++ b/app/api/teams/[id]/tasks/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listTeamTasks, createTeamTask } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/teams/[id]/tasks - List tasks with resolved dependencies
 export async function GET(
@@ -8,11 +9,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = listTeamTasks(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 // POST /api/teams/[id]/tasks - Create a new task
@@ -23,9 +20,5 @@ export async function POST(
   const { id } = await params
   const body = await request.json()
   const result = createTeamTask(id, body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/teams/notify/route.ts
+++ b/app/api/teams/notify/route.ts
@@ -1,13 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { notifyTeamAgents } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // POST /api/teams/notify - Notify team agents about a meeting
 export async function POST(request: NextRequest) {
   const body = await request.json()
   const result = await notifyTeamAgents(body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -1,19 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listAllTeams, createNewTeam } from '@/services/teams-service'
+import { toResponse } from '@/app/api/_helpers'
 
 // GET /api/teams - List all teams
 export async function GET() {
   const result = listAllTeams()
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }
 
 // POST /api/teams - Create a new team
 export async function POST(request: NextRequest) {
   const body = await request.json()
   const result = createNewTeam(body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -7,14 +7,11 @@
  * No authentication required - used for monitoring and load balancers.
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getHealthStatus } from '@/services/amp-service'
-import type { AMPHealthResponse } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
 
-export async function GET(_request: NextRequest): Promise<NextResponse<AMPHealthResponse>> {
+export async function GET(_request: NextRequest) {
   const result = getHealthStatus()
-  return NextResponse.json(result.data!, {
-    status: result.status,
-    headers: result.headers
-  })
+  return toResponse(result)
 }

--- a/app/api/v1/info/route.ts
+++ b/app/api/v1/info/route.ts
@@ -7,14 +7,11 @@
  * and rate limits. No authentication required.
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { getProviderInfo } from '@/services/amp-service'
-import type { AMPInfoResponse } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
 
-export async function GET(_request: NextRequest): Promise<NextResponse<AMPInfoResponse>> {
+export async function GET(_request: NextRequest) {
   const result = getProviderInfo()
-  return NextResponse.json(result.data!, {
-    status: result.status,
-    headers: result.headers
-  })
+  return toResponse(result)
 }

--- a/app/api/v1/messages/pending/[id]/route.ts
+++ b/app/api/v1/messages/pending/[id]/route.ts
@@ -7,17 +7,17 @@
  * Both are supported for client compatibility.
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { acknowledgePendingMessage } from '@/services/amp-service'
-import type { AMPError } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
 
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-): Promise<NextResponse<{ acknowledged: boolean } | AMPError>> {
+) {
   const authHeader = request.headers.get('Authorization')
   const { id } = await params
 
   const result = acknowledgePendingMessage(authHeader, id)
-  return NextResponse.json(result.data!, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/v1/messages/pending/ack/route.ts
+++ b/app/api/v1/messages/pending/ack/route.ts
@@ -10,9 +10,10 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { batchAcknowledgeMessages } from '@/services/amp-service'
+import { toResponse } from '@/app/api/_helpers'
 import type { AMPError } from '@/lib/types/amp'
 
-export async function POST(request: NextRequest): Promise<NextResponse<{ acknowledged: number } | AMPError>> {
+export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('Authorization')
 
   let body: { ids?: string[] }
@@ -26,5 +27,5 @@ export async function POST(request: NextRequest): Promise<NextResponse<{ acknowl
   }
 
   const result = batchAcknowledgeMessages(authHeader, body.ids)
-  return NextResponse.json(result.data!, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/v1/messages/pending/route.ts
+++ b/app/api/v1/messages/pending/route.ts
@@ -10,31 +10,29 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { listPendingMessages, acknowledgePendingMessage, batchAcknowledgeMessages } from '@/services/amp-service'
-import type { AMPError, AMPPendingMessagesResponse } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
+import type { AMPError } from '@/lib/types/amp'
 
-export async function GET(request: NextRequest): Promise<NextResponse<AMPPendingMessagesResponse | AMPError>> {
+export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('Authorization')
   const { searchParams } = new URL(request.url)
   const limitParam = searchParams.get('limit')
   const limit = limitParam ? parseInt(limitParam, 10) : undefined
 
   const result = listPendingMessages(authHeader, limit)
-  return NextResponse.json(result.data!, {
-    status: result.status,
-    headers: result.headers
-  })
+  return toResponse(result)
 }
 
-export async function DELETE(request: NextRequest): Promise<NextResponse<{ acknowledged: boolean } | AMPError>> {
+export async function DELETE(request: NextRequest) {
   const authHeader = request.headers.get('Authorization')
   const { searchParams } = new URL(request.url)
   const messageId = searchParams.get('id')
 
   const result = acknowledgePendingMessage(authHeader, messageId)
-  return NextResponse.json(result.data!, { status: result.status })
+  return toResponse(result)
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse<{ acknowledged: number } | AMPError>> {
+export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('Authorization')
 
   let body: { ids?: string[] }
@@ -48,5 +46,5 @@ export async function POST(request: NextRequest): Promise<NextResponse<{ acknowl
   }
 
   const result = batchAcknowledgeMessages(authHeader, body.ids)
-  return NextResponse.json(result.data!, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/v1/messages/route.ts
+++ b/app/api/v1/messages/route.ts
@@ -7,19 +7,16 @@
  * Thin wrapper - business logic in services/amp-service.ts
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { listPendingMessages } from '@/services/amp-service'
-import type { AMPError, AMPPendingMessagesResponse } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
 
-export async function GET(request: NextRequest): Promise<NextResponse<AMPPendingMessagesResponse | AMPError>> {
+export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('Authorization')
   const { searchParams } = new URL(request.url)
   const limitParam = searchParams.get('limit')
   const limit = limitParam ? parseInt(limitParam, 10) : undefined
 
   const result = listPendingMessages(authHeader, limit)
-  return NextResponse.json(result.data!, {
-    status: result.status,
-    headers: result.headers
-  })
+  return toResponse(result)
 }

--- a/app/api/v1/register/route.ts
+++ b/app/api/v1/register/route.ts
@@ -7,14 +7,15 @@
  * Thin wrapper - business logic in services/amp-service.ts
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { registerAgent } from '@/services/amp-service'
-import type { AMPRegistrationRequest, AMPRegistrationResponse, AMPError, AMPNameTakenError } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
+import type { AMPRegistrationRequest } from '@/lib/types/amp'
 
-export async function POST(request: NextRequest): Promise<NextResponse<AMPRegistrationResponse | AMPError | AMPNameTakenError>> {
+export async function POST(request: NextRequest) {
   const body = await request.json() as AMPRegistrationRequest
   const authHeader = request.headers.get('Authorization')
 
   const result = await registerAgent(body, authHeader)
-  return NextResponse.json(result.data!, { status: result.status })
+  return toResponse(result)
 }

--- a/app/api/v1/route/route.ts
+++ b/app/api/v1/route/route.ts
@@ -7,11 +7,12 @@
  * Thin wrapper - business logic in services/amp-service.ts
  */
 
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { routeMessage } from '@/services/amp-service'
-import type { AMPRouteRequest, AMPRouteResponse, AMPError } from '@/lib/types/amp'
+import { toResponse } from '@/app/api/_helpers'
+import type { AMPRouteRequest } from '@/lib/types/amp'
 
-export async function POST(request: NextRequest): Promise<NextResponse<AMPRouteResponse | AMPError>> {
+export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('Authorization')
   const forwardedFrom = request.headers.get('X-Forwarded-From')
   const envelopeIdHeader = request.headers.get('X-AMP-Envelope-Id')
@@ -21,8 +22,5 @@ export async function POST(request: NextRequest): Promise<NextResponse<AMPRouteR
   const body = await request.json() as AMPRouteRequest
 
   const result = await routeMessage(body, authHeader, forwardedFrom, envelopeIdHeader, signatureHeader, contentLength)
-  return NextResponse.json(result.data!, {
-    status: result.status,
-    headers: result.headers
-  })
+  return toResponse(result)
 }

--- a/app/api/webhooks/[id]/route.ts
+++ b/app/api/webhooks/[id]/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { getWebhookById, deleteWebhookById } from '@/services/webhooks-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/webhooks/[id]
@@ -11,11 +11,7 @@ export async function GET(
 ) {
   const { id } = await params
   const result = getWebhookById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -28,9 +24,5 @@ export async function DELETE(
 ) {
   const { id } = await params
   const result = deleteWebhookById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/webhooks/[id]/test/route.ts
+++ b/app/api/webhooks/[id]/test/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { testWebhookById } from '@/services/webhooks-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * POST /api/webhooks/[id]/test
@@ -11,9 +11,5 @@ export async function POST(
 ) {
   const { id } = await params
   const result = await testWebhookById(id)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }

--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { listAllWebhooks, createNewWebhook } from '@/services/webhooks-service'
+import { toResponse } from '@/app/api/_helpers'
 
 /**
  * GET /api/webhooks
@@ -7,11 +7,7 @@ import { listAllWebhooks, createNewWebhook } from '@/services/webhooks-service'
  */
 export async function GET() {
   const result = listAllWebhooks()
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data)
+  return toResponse(result)
 }
 
 /**
@@ -21,9 +17,5 @@ export async function GET() {
 export async function POST(request: Request) {
   const body = await request.json()
   const result = createNewWebhook(body)
-
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status })
-  }
-  return NextResponse.json(result.data, { status: result.status })
+  return toResponse(result)
 }

--- a/app/companion/page.tsx
+++ b/app/companion/page.tsx
@@ -1096,7 +1096,7 @@ function CompanionInput({
         textareaRef.current?.focus()
       } else {
         const data = await res.json().catch(() => ({}))
-        console.error('[CompanionInput] Send failed:', data.error || res.statusText)
+        console.error('[CompanionInput] Send failed:', data.message || data.error || res.statusText)
       }
     } catch (err) {
       console.error('[CompanionInput] Send error:', err)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -405,7 +405,7 @@ export default function DashboardPage() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to delete agent')
+        throw new Error(data.message || data.error || 'Failed to delete agent')
       }
 
       // Close profile panel
@@ -446,7 +446,7 @@ export default function DashboardPage() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to create session')
+        throw new Error(data.message || data.error || 'Failed to create session')
       }
 
       setIsProfileOpen(false)
@@ -495,7 +495,7 @@ export default function DashboardPage() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to wake agent')
+        throw new Error(data.message || data.error || 'Failed to wake agent')
       }
 
       refreshAgents()

--- a/components/AgentCreationWizard.tsx
+++ b/components/AgentCreationWizard.tsx
@@ -321,7 +321,7 @@ export default function AgentCreationWizard({ onClose, onComplete, onSwitchToAdv
         })
         if (!response.ok) {
           const data = await response.json()
-          throw new Error(data.error || 'Failed to create Docker agent')
+          throw new Error(data.message || data.error || 'Failed to create Docker agent')
         }
       } else {
         const response = await fetch('/api/sessions/create', {
@@ -338,7 +338,7 @@ export default function AgentCreationWizard({ onClose, onComplete, onSwitchToAdv
         })
         if (!response.ok) {
           const data = await response.json()
-          throw new Error(data.error || 'Failed to create agent')
+          throw new Error(data.message || data.error || 'Failed to create agent')
         }
       }
       setCreationSuccess(true)

--- a/components/AgentGraph.tsx
+++ b/components/AgentGraph.tsx
@@ -169,7 +169,7 @@ export default function AgentGraph({ sessionName, agentId, workingDirectory, hos
       if (data.success) {
         setGraphData(data.result)
       } else {
-        setError(data.error || 'Failed to fetch graph')
+        setError(data.message || data.error || 'Failed to fetch graph')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')
@@ -192,7 +192,7 @@ export default function AgentGraph({ sessionName, agentId, workingDirectory, hos
       if (data.success) {
         setFocusMode({ nodeId, data: data.result })
       } else {
-        setError(data.error || 'Failed to focus on node')
+        setError(data.message || data.error || 'Failed to focus on node')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')
@@ -267,7 +267,7 @@ export default function AgentGraph({ sessionName, agentId, workingDirectory, hos
         // Refresh graph
         await fetchGraphData()
       } else {
-        setError(data.error || 'Failed to index project')
+        setError(data.message || data.error || 'Failed to index project')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -511,7 +511,7 @@ export default function AgentList({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to hibernate agent')
+        throw new Error(data.message || data.error || 'Failed to hibernate agent')
       }
 
       // Refresh the agent list to show updated status
@@ -558,7 +558,7 @@ export default function AgentList({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to wake agent')
+        throw new Error(data.message || data.error || 'Failed to wake agent')
       }
 
       // Close dialog and refresh the agent list
@@ -650,7 +650,7 @@ export default function AgentList({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to move agent')
+        throw new Error(data.message || data.error || 'Failed to move agent')
       }
 
       // Refresh the agent list to show updated position
@@ -679,7 +679,7 @@ export default function AgentList({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to create agent')
+        throw new Error(data.message || data.error || 'Failed to create agent')
       }
 
       return true // Success - modal will handle showing celebration
@@ -2080,7 +2080,7 @@ function CreateAgentAdvancedModal({
 
         if (!response.ok) {
           const data = await response.json()
-          throw new Error(data.error || 'Failed to create Docker agent')
+          throw new Error(data.message || data.error || 'Failed to create Docker agent')
         }
 
         setCreationSuccess(true)

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -92,7 +92,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       const data = await response.json()
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to fetch messages')
+        throw new Error(data.message || data.error || 'Failed to fetch messages')
       }
 
       if (data.success) {
@@ -194,7 +194,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       const data = await response.json()
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to send message')
+        throw new Error(data.message || data.error || 'Failed to send message')
       }
 
       // Clear pending message after a delay (it was sent successfully)

--- a/components/ConversationDetailPanel.tsx
+++ b/components/ConversationDetailPanel.tsx
@@ -94,12 +94,12 @@ export default function ConversationDetailPanel({ conversationFile, projectPath,
 
       if (!response.ok) {
         console.error('[ConversationDetail] API error:', response.status, data)
-        throw new Error(data.error || `Failed to load conversation (${response.status})`)
+        throw new Error(data.message || data.error || `Failed to load conversation (${response.status})`)
       }
 
       if (!data.success) {
         console.error('[ConversationDetail] API returned success=false:', data)
-        throw new Error(data.error || 'Failed to parse conversation')
+        throw new Error(data.message || data.error || 'Failed to parse conversation')
       }
 
       console.log('[ConversationDetail] API returned', data.messages?.length, 'messages')

--- a/components/DocumentationPanel.tsx
+++ b/components/DocumentationPanel.tsx
@@ -188,7 +188,7 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
         await fetchStats()
         await fetchDocuments()
       } else {
-        setError(data.error || 'Failed to index documentation')
+        setError(data.message || data.error || 'Failed to index documentation')
       }
     } catch (err: any) {
       console.error('[DocumentationPanel] Indexing error:', err)
@@ -225,7 +225,7 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
         setSearchResults(data.result || [])
         setActiveView('search')
       } else {
-        setError(data.error || 'Search failed')
+        setError(data.message || data.error || 'Search failed')
       }
     } catch (err) {
       setError('Failed to search documentation')

--- a/components/GraphVisualization.tsx
+++ b/components/GraphVisualization.tsx
@@ -97,7 +97,7 @@ export function GraphVisualization({ agentId, graphType, onNodeSelect }: GraphVi
       const data = await response.json()
 
       if (!data.success) {
-        throw new Error(data.error || 'Failed to fetch graph data')
+        throw new Error(data.message || data.error || 'Failed to fetch graph data')
       }
 
       setGraphData(data.result)

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -105,7 +105,7 @@ export default function HelpPanel({ isOpen, onClose }: HelpPanelProps) {
         }
       } else {
         setAgentStatus('error')
-        setAgentError(data.error || 'Failed to create assistant')
+        setAgentError(data.message || data.error || 'Failed to create assistant')
       }
     } catch (err) {
       setAgentStatus('error')

--- a/components/HostsSettings.tsx
+++ b/components/HostsSettings.tsx
@@ -73,7 +73,7 @@ export default function HostsSettings() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to add host')
+        throw new Error(data.message || data.error || 'Failed to add host')
       }
 
       await fetchHosts()
@@ -94,7 +94,7 @@ export default function HostsSettings() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to update host')
+        throw new Error(data.message || data.error || 'Failed to update host')
       }
 
       await fetchHosts()
@@ -115,7 +115,7 @@ export default function HostsSettings() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to delete host')
+        throw new Error(data.message || data.error || 'Failed to delete host')
       }
 
       await fetchHosts()

--- a/components/ImportAgentDialog.tsx
+++ b/components/ImportAgentDialog.tsx
@@ -113,7 +113,7 @@ export default function ImportAgentDialog({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Import failed')
+        throw new Error(data.message || data.error || 'Import failed')
       }
 
       const data: AgentImportResult = await response.json()

--- a/components/MemoryViewer.tsx
+++ b/components/MemoryViewer.tsx
@@ -181,7 +181,7 @@ export default function MemoryViewer({ agentId, hostUrl = '', isActive = false }
         success: data.success,
         memoriesCreated: data.memories_created,
         memoriesReinforced: data.memories_reinforced,
-        error: data.error
+        error: data.message || data.error
       })
 
       if (data.success) {

--- a/components/MigrationBanner.tsx
+++ b/components/MigrationBanner.tsx
@@ -57,7 +57,7 @@ export default function MigrationBanner() {
           window.location.reload()
         }, 2000)
       } else {
-        setError(data.error || 'Migration failed')
+        setError(data.message || data.error || 'Migration failed')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Migration failed')

--- a/components/MobileWorkTree.tsx
+++ b/components/MobileWorkTree.tsx
@@ -192,7 +192,7 @@ export default function MobileWorkTree({
       console.log('[MobileWorkTree] Memory API response:', data)
 
       if (!data.success) {
-        throw new Error(data.error || 'Failed to fetch memory')
+        throw new Error(data.message || data.error || 'Failed to fetch memory')
       }
 
       // Transform data to match component interface (same as desktop WorkTree)

--- a/components/OrganizationSetup.tsx
+++ b/components/OrganizationSetup.tsx
@@ -117,7 +117,7 @@ export default function OrganizationSetup({ onComplete, onSkip }: OrganizationSe
       const data = await response.json()
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to set organization')
+        throw new Error(data.message || data.error || 'Failed to set organization')
       }
 
       onComplete()
@@ -215,7 +215,7 @@ export default function OrganizationSetup({ onComplete, onSkip }: OrganizationSe
 
       if (!orgResponse.ok) {
         const data = await orgResponse.json()
-        throw new Error(data.error || 'Failed to adopt organization')
+        throw new Error(data.message || data.error || 'Failed to adopt organization')
       }
 
       // 2. Add the remote host to our hosts list

--- a/components/TransferAgentDialog.tsx
+++ b/components/TransferAgentDialog.tsx
@@ -153,8 +153,8 @@ export default function TransferAgentDialog({
                 const data = JSON.parse(line.slice(6))
                 if (data.status) setStatus(data.status as TransferStatus)
                 if (data.progress) setProgress(data.progress)
-                if (data.error) {
-                  setError(data.error)
+                if (data.error || data.message) {
+                  setError(data.message || data.error)
                   setStatus('error')
                 }
                 if (data.result) {
@@ -177,7 +177,7 @@ export default function TransferAgentDialog({
         const data = await response.json()
 
         if (!response.ok) {
-          throw new Error(data.error || 'Transfer failed')
+          throw new Error(data.message || data.error || 'Transfer failed')
         }
 
         // Transition to arriving

--- a/components/WorkTree.tsx
+++ b/components/WorkTree.tsx
@@ -155,7 +155,7 @@ export default function WorkTree({ sessionName, agentId, agentAlias, hostId, isA
         data = await response.json()
 
         if (!data.success) {
-          throw new Error(data.error || 'Failed to fetch memory after initialization')
+          throw new Error(data.message || data.error || 'Failed to fetch memory after initialization')
         }
       }
 

--- a/components/onboarding/FirstAgentWizard.tsx
+++ b/components/onboarding/FirstAgentWizard.tsx
@@ -83,7 +83,7 @@ export default function FirstAgentWizard({ onComplete, onCancel }: FirstAgentWiz
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to create agent')
+        throw new Error(data.message || data.error || 'Failed to create agent')
       }
 
       // Animate completion

--- a/components/plugin-builder/BuildAction.tsx
+++ b/components/plugin-builder/BuildAction.tsx
@@ -65,7 +65,7 @@ export default function BuildAction({ config, disabled, disabledReason }: BuildA
 
       if (!res.ok) {
         const data = await res.json()
-        setError(data.error || 'Build failed')
+        setError(data.message || data.error || 'Build failed')
         setBuilding(false)
         return
       }
@@ -140,7 +140,7 @@ export default function BuildAction({ config, disabled, disabledReason }: BuildA
       const data = await res.json()
       setPushResult({
         ok: res.ok,
-        message: res.ok ? (data.message || 'Pushed successfully') : (data.error || 'Push failed'),
+        message: res.ok ? (data.message || 'Pushed successfully') : (data.message || data.error || 'Push failed'),
       })
     } catch {
       setPushResult({ ok: false, message: 'Failed to connect to server' })

--- a/components/plugin-builder/RepoScanner.tsx
+++ b/components/plugin-builder/RepoScanner.tsx
@@ -40,7 +40,7 @@ export default function RepoScanner({ onSkillsFound, onAddSkill, selectedSkillKe
 
       if (!res.ok) {
         const data = await res.json()
-        if (!signal.aborted) setError(data.error || 'Failed to scan repository')
+        if (!signal.aborted) setError(data.message || data.error || 'Failed to scan repository')
         return
       }
 

--- a/components/settings/HostsSection.tsx
+++ b/components/settings/HostsSection.tsx
@@ -200,7 +200,7 @@ export default function HostsSection() {
       const data = await response.json()
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to add host')
+        throw new Error(data.message || data.error || 'Failed to add host')
       }
 
       await fetchHosts()
@@ -224,7 +224,7 @@ export default function HostsSection() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to update host')
+        throw new Error(data.message || data.error || 'Failed to update host')
       }
 
       await fetchHosts()
@@ -245,7 +245,7 @@ export default function HostsSection() {
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to delete host')
+        throw new Error(data.message || data.error || 'Failed to delete host')
       }
 
       await fetchHosts()

--- a/components/settings/WebhooksSection.tsx
+++ b/components/settings/WebhooksSection.tsx
@@ -129,7 +129,7 @@ export default function WebhooksSection() {
       setTestResult({
         id,
         success: data.success,
-        message: data.success ? 'Webhook delivered successfully' : (data.error || 'Delivery failed'),
+        message: data.success ? 'Webhook delivered successfully' : (data.message || data.error || 'Delivery failed'),
       })
     } catch (err) {
       setTestResult({

--- a/components/team-meeting/MeetingSidebar.tsx
+++ b/components/team-meeting/MeetingSidebar.tsx
@@ -52,7 +52,7 @@ export default function MeetingSidebar({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to hibernate agent')
+        throw new Error(data.message || data.error || 'Failed to hibernate agent')
       }
     } catch (error) {
       console.error('Failed to hibernate agent:', error)
@@ -91,7 +91,7 @@ export default function MeetingSidebar({
 
       if (!response.ok) {
         const data = await response.json()
-        throw new Error(data.error || 'Failed to wake agent')
+        throw new Error(data.message || data.error || 'Failed to wake agent')
       }
 
       setWakeDialogAgent(null)

--- a/components/zoom/AgentProfileTab.tsx
+++ b/components/zoom/AgentProfileTab.tsx
@@ -876,7 +876,7 @@ export default function AgentProfileTab({ agent: initialAgent, hostUrl, onClose 
           })
           if (!response.ok) {
             const data = await response.json()
-            throw new Error(data.error || 'Failed to delete agent')
+            throw new Error(data.message || data.error || 'Failed to delete agent')
           }
           onClose?.()
         }}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.27.0
+**Current Version:** v0.29.0
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.27.0",
+      "softwareVersion": "0.29.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.27.0",
+      "softwareVersion": "0.29.0",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -448,7 +448,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.27.0</span>
+                        <span>v0.29.0</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/types/amp.ts
+++ b/lib/types/amp.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AMPAgentIdentity, AMPExternalRegistration } from '@/types/agent'
+import type { ServiceErrorCode, ServiceError } from '@/services/service-errors'
 
 // Re-export for convenience
 export type { AMPAgentIdentity, AMPExternalRegistration }
@@ -421,9 +422,9 @@ export interface AMPInfoResponse {
 // ============================================================================
 
 /**
- * AMP error codes
+ * AMP error codes — subset of ServiceErrorCode covering the 18 AMP protocol codes.
  */
-export type AMPErrorCode =
+export type AMPErrorCode = Extract<ServiceErrorCode,
   | 'invalid_request'
   | 'missing_field'
   | 'invalid_field'
@@ -436,29 +437,27 @@ export type AMPErrorCode =
   | 'invalid_signature'
   | 'agent_not_found'
   | 'tenant_access_denied'
-  | 'organization_not_set'  // Phase 2: Organization required for AMP registration
-  | 'external_provider'     // Recipient is on external provider — client must send directly
-  | 'payload_too_large'     // Message payload exceeds size limit
-  | 'missing_header'        // Required HTTP header is missing
-  | 'duplicate_message'     // Message ID has already been delivered (replay protection)
-  | 'key_already_registered' // Public key fingerprint is already associated with another agent
+  | 'organization_not_set'
+  | 'external_provider'
+  | 'payload_too_large'
+  | 'missing_header'
+  | 'duplicate_message'
+  | 'key_already_registered'
+>
 
 /**
- * AMP error response
+ * AMP error response — extends ServiceError with constrained error code.
  */
-export interface AMPError {
+export interface AMPError extends ServiceError {
   error: AMPErrorCode
-  message: string
-  field?: string
-  details?: Record<string, unknown>
 }
 
 /**
- * Name taken error with suggestions
+ * Name taken error with suggestions (in details.suggestions)
  */
 export interface AMPNameTakenError extends AMPError {
   error: 'name_taken'
-  suggestions: string[]
+  details: { suggestions: string[] }
 }
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.27.0",
+  "version": "0.29.0",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.27.0"
+VERSION="0.29.0"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/agents-chat-service.ts
+++ b/services/agents-chat-service.ts
@@ -11,14 +11,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as crypto from 'crypto'
 import os from 'os'
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, notFound, invalidRequest, missingField } from '@/services/service-errors'
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -37,7 +30,7 @@ export async function getConversationMessages(
 ): Promise<ServiceResult<Record<string, unknown>>> {
   const agent = getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   const { since, limit = 100 } = options
@@ -47,7 +40,7 @@ export async function getConversationMessages(
                      agent.preferences?.defaultWorkingDirectory
 
   if (!workingDir) {
-    return { error: 'Agent has no working directory configured', status: 400 }
+    return invalidRequest('Agent has no working directory configured')
   }
 
   // Find the Claude conversation directory for this project
@@ -244,22 +237,22 @@ export async function sendChatMessage(
   message: string
 ): Promise<ServiceResult<Record<string, unknown>>> {
   if (!message || typeof message !== 'string') {
-    return { error: 'Message is required', status: 400 }
+    return missingField('message')
   }
 
   const agent = getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   const sessionName = agent.name || agent.alias
   if (!sessionName) {
-    return { error: 'Agent has no session name', status: 400 }
+    return invalidRequest('Agent has no session name')
   }
 
   const hasOnlineSession = agent.sessions?.some(s => s.status === 'online')
   if (!hasOnlineSession) {
-    return { error: 'Agent session is not online', status: 400 }
+    return invalidRequest('Agent session is not online')
   }
 
   const runtime = getRuntime()

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -63,16 +63,7 @@ import { initializeAllAgents, getStartupStatus } from '@/lib/agent-startup'
 import { sessionActivity } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
 import type { Host } from '@/types/host'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number // HTTP-like status code for the route to use
-}
+import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed, gone, timeout } from '@/services/service-errors'
 
 interface DiscoveredSession {
   name: string
@@ -585,7 +576,7 @@ export async function listAgents(): Promise<ServiceResult<{
     }
   } catch (error) {
     console.error('[Agents] Failed to fetch agents:', error)
-    return { error: 'Failed to fetch agents', status: 500 }
+    return operationFailed('fetch agents', (error as Error).message)
   }
 }
 
@@ -607,9 +598,8 @@ export function createNewAgent(body: CreateAgentRequest): ServiceResult<{ agent:
     const agent = createAgent(body)
     return { data: { agent }, status: 201 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to create agent'
     console.error('Failed to create agent:', error)
-    return { error: message, status: 400 }
+    return invalidRequest((error as Error).message || 'Failed to create agent')
   }
 }
 
@@ -621,12 +611,12 @@ export function getAgentById(id: string): ServiceResult<{ agent: Agent }> {
   try {
     const agent = getAgent(id)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', id)
     }
     return { data: { agent }, status: 200 }
   } catch (error) {
     console.error('Failed to get agent:', error)
-    return { error: 'Failed to get agent', status: 500 }
+    return operationFailed('get agent', (error as Error).message)
   }
 }
 
@@ -639,22 +629,21 @@ export function updateAgentById(id: string, body: UpdateAgentRequest): ServiceRe
     // Check if agent exists and is not soft-deleted
     const existing = getAgent(id, true) // include deleted to distinguish 404 vs 410
     if (!existing) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', id)
     }
     if (existing.deletedAt) {
-      return { error: 'Cannot update a deleted agent', status: 410 }
+      return gone('Agent')
     }
 
     const agent = updateAgent(id, body)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', id)
     }
 
     return { data: { agent }, status: 200 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to update agent'
     console.error('Failed to update agent:', error)
-    return { error: message, status: 400 }
+    return invalidRequest((error as Error).message || 'Failed to update agent')
   }
 }
 
@@ -666,22 +655,21 @@ export function deleteAgentById(id: string, hard: boolean): ServiceResult<{ succ
   try {
     const agent = getAgent(id, true) // include deleted to distinguish 404 vs 410
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', id)
     }
     if (agent.deletedAt && !hard) {
-      // Return 410 with extra context: already deleted
-      return { error: 'Agent already deleted', status: 410 }
+      return gone('Agent')
     }
 
     const success = deleteAgent(id, hard)
     if (!success) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', id)
     }
 
     return { data: { success: true, hard }, status: 200 }
   } catch (error) {
     console.error('Failed to delete agent:', error)
-    return { error: 'Failed to delete agent', status: 500 }
+    return operationFailed('delete agent', (error as Error).message)
   }
 }
 
@@ -706,7 +694,7 @@ export function registerAgent(body: RegisterAgentParams): ServiceResult<{
       const { sessionName, workingDirectory } = body
 
       if (!sessionName) {
-        return { error: 'Missing required field: sessionName', status: 400 }
+        return missingField('sessionName')
       }
 
       agentId = sessionName.replace(/[^a-zA-Z0-9_-]/g, '-')
@@ -747,7 +735,7 @@ export function registerAgent(body: RegisterAgentParams): ServiceResult<{
     } else {
       // Full agent config format (cloud agents)
       if (!body.id || !body.deployment?.cloud?.websocketUrl) {
-        return { error: 'Missing required fields: id and websocketUrl', status: 400 }
+        return missingField('id and websocketUrl')
       }
 
       agentId = body.id
@@ -776,10 +764,7 @@ export function registerAgent(body: RegisterAgentParams): ServiceResult<{
     }
   } catch (error) {
     console.error('Failed to register agent:', error)
-    return {
-      error: `Failed to register agent: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      status: 500,
-    }
+    return operationFailed('register agent', (error as Error).message)
   }
 }
 
@@ -825,7 +810,7 @@ export function lookupAgentByName(name: string): ServiceResult<{
     }
   } catch (error) {
     console.error('[Agent Lookup] Error:', error)
-    return { data: { exists: false }, status: 500 }
+    return operationFailed('lookup agent', error instanceof Error ? error.message : 'Internal server error')
   }
 }
 
@@ -1007,7 +992,7 @@ export async function getAgentSessionStatus(agentId: string): Promise<ServiceRes
   try {
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const sessionName = agent.name || agent.alias
@@ -1047,10 +1032,7 @@ export async function getAgentSessionStatus(agentId: string): Promise<ServiceRes
     }
   } catch (error) {
     console.error('[Agent Session] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get session status', (error as Error).message)
   }
 }
 
@@ -1063,19 +1045,18 @@ export function linkAgentSession(agentId: string, params: LinkSessionParams): Se
     const { sessionName, workingDirectory } = params
 
     if (!sessionName) {
-      return { error: 'sessionName is required', status: 400 }
+      return missingField('sessionName')
     }
 
     const success = linkSession(agentId, sessionName, workingDirectory || process.cwd())
     if (!success) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to link session'
     console.error('Failed to link session:', error)
-    return { error: message, status: 400 }
+    return invalidRequest((error as Error).message || 'Failed to link session')
   }
 }
 
@@ -1101,23 +1082,23 @@ export async function sendAgentSessionCommand(
     const { command, requireIdle = true, addNewline = true } = params
 
     if (!command || typeof command !== 'string') {
-      return { error: 'Command is required', status: 400 }
+      return missingField('command')
     }
 
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const sessionName = agent.name || agent.alias
     if (!sessionName) {
-      return { error: 'Agent has no name configured', status: 400 }
+      return invalidField('name', 'Agent has no name configured')
     }
 
     const runtime = getRuntime()
     const exists = await runtime.sessionExists(sessionName)
     if (!exists) {
-      return { error: 'Tmux session not found', status: 404 }
+      return notFound('Tmux session', sessionName)
     }
 
     if (requireIdle && !isSessionIdle(sessionName)) {
@@ -1130,7 +1111,6 @@ export async function sendAgentSessionCommand(
           timeSinceActivity,
           idleThreshold: IDLE_THRESHOLD_MS,
         },
-        error: 'Session is not idle',
         status: 409,
       }
     }
@@ -1154,10 +1134,7 @@ export async function sendAgentSessionCommand(
     }
   } catch (error) {
     console.error('[Agent Session Command] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('send session command', (error as Error).message)
   }
 }
 
@@ -1180,7 +1157,7 @@ export async function unlinkOrDeleteAgentSession(
 
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const runtime = getRuntime()
@@ -1199,7 +1176,7 @@ export async function unlinkOrDeleteAgentSession(
       // Hard delete with backup
       const success = deleteAgent(agentId, true)
       if (!success) {
-        return { error: 'Failed to delete agent', status: 500 }
+        return operationFailed('delete agent')
       }
 
       return {
@@ -1224,7 +1201,7 @@ export async function unlinkOrDeleteAgentSession(
 
     const success = unlinkSession(agentId)
     if (!success) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     return {
@@ -1238,7 +1215,7 @@ export async function unlinkOrDeleteAgentSession(
     }
   } catch (error) {
     console.error('Failed to unlink/delete session:', error)
-    return { error: 'Failed to unlink session', status: 500 }
+    return operationFailed('unlink session', (error as Error).message)
   }
 }
 
@@ -1264,18 +1241,15 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
     // Check including soft-deleted to give a better error message (410 Gone vs 404)
     const agent = getAgent(agentId, true)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
     if (agent.deletedAt) {
-      return {
-        error: `Agent was deleted on ${new Date(agent.deletedAt).toLocaleDateString()}. Restore from backup or create a new agent.`,
-        status: 410
-      }
+      return gone('Agent')
     }
 
     const agentName = agent.name || agent.alias
     if (!agentName) {
-      return { error: 'Agent has no name configured', status: 400 }
+      return invalidField('name', 'Agent has no name configured')
     }
 
     const workingDirectory = agent.workingDirectory ||
@@ -1309,7 +1283,7 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
       await runtime.createSession(sessionName, workingDirectory)
     } catch (error) {
       console.error(`[Wake] Failed to create tmux session:`, error)
-      return { error: 'Failed to create tmux session', status: 500 }
+      return operationFailed('create tmux session', (error as Error).message)
     }
 
     // Persist session metadata
@@ -1383,10 +1357,7 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
     }
   } catch (error) {
     console.error('[Wake] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Failed to wake agent',
-      status: 500,
-    }
+    return operationFailed('wake agent', (error as Error).message)
   }
 }
 
@@ -1408,12 +1379,12 @@ export async function hibernateAgent(agentId: string, params: HibernateAgentPara
 
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const agentName = agent.name || agent.alias
     if (!agentName) {
-      return { error: 'Agent has no name configured', status: 400 }
+      return invalidField('name', 'Agent has no name configured')
     }
 
     const runtime = getRuntime()
@@ -1477,10 +1448,7 @@ export async function hibernateAgent(agentId: string, params: HibernateAgentPara
     }
   } catch (error) {
     console.error('[Hibernate] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Failed to hibernate agent',
-      status: 500,
-    }
+    return operationFailed('hibernate agent', (error as Error).message)
   }
 }
 
@@ -1510,10 +1478,7 @@ export async function initializeStartup(): Promise<ServiceResult<{
     }
   } catch (error) {
     console.error('[Startup] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('initialize startup', (error as Error).message)
   }
 }
 
@@ -1527,10 +1492,7 @@ export function getStartupInfo(): ServiceResult<any> {
     return { data: { success: true, ...status }, status: 200 }
   } catch (error) {
     console.error('[Startup] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get startup info', (error as Error).message)
   }
 }
 
@@ -1541,7 +1503,7 @@ export function getStartupInfo(): ServiceResult<any> {
 export async function proxyHealthCheck(url: string): Promise<ServiceResult<any>> {
   try {
     if (!url || typeof url !== 'string') {
-      return { error: 'URL is required', status: 400 }
+      return missingField('url')
     }
 
     const controller = new AbortController()
@@ -1554,18 +1516,15 @@ export async function proxyHealthCheck(url: string): Promise<ServiceResult<any>>
     clearTimeout(timeoutId)
 
     if (!response.ok) {
-      return { error: `Agent returned HTTP ${response.status}`, status: response.status }
+      return operationFailed('health check', `Agent returned HTTP ${response.status}`)
     }
 
     const data = await response.json()
     return { data, status: 200 }
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      return { error: 'Timeout connecting to agent', status: 504 }
+      return timeout('Timeout connecting to agent')
     }
-    return {
-      error: `Failed to connect to agent: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      status: 500,
-    }
+    return operationFailed('connect to agent', (error as Error).message)
   }
 }

--- a/services/agents-directory-service.ts
+++ b/services/agents-directory-service.ts
@@ -14,7 +14,7 @@
  *   POST   /api/agents/normalize-hosts              -> normalizeHosts
  */
 
-import type { ServiceResult } from '@/services/agents-core-service'
+import { type ServiceResult, operationFailed } from '@/services/service-errors'
 import {
   rebuildLocalDirectory,
   getLocalEntriesForSync,
@@ -39,10 +39,7 @@ export function getDirectory(): ServiceResult<any> {
     return { data: { success: true, entries, stats }, status: 200 }
   } catch (error) {
     console.error('[Agent Directory Service] getDirectory error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Internal server error',
-      status: 500,
-    }
+    return operationFailed('get directory', error instanceof Error ? error.message : 'Internal server error')
   }
 }
 
@@ -77,7 +74,7 @@ export function lookupAgentByDirectoryName(name: string): ServiceResult<any> {
     }
   } catch (error) {
     console.error('[Agent Directory Service] lookupAgentByDirectoryName error:', error)
-    return { data: { found: false }, status: 500 }
+    return operationFailed('lookup agent', error instanceof Error ? error.message : 'Internal server error')
   }
 }
 
@@ -104,10 +101,7 @@ export async function syncDirectory(): Promise<ServiceResult<any>> {
     }
   } catch (error) {
     console.error('[Agent Directory Service] syncDirectory error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Internal server error',
-      status: 500,
-    }
+    return operationFailed('directory operation', error instanceof Error ? error.message : 'Internal server error')
   }
 }
 
@@ -130,10 +124,7 @@ export function diagnoseHosts(): ServiceResult<any> {
     }
   } catch (error) {
     console.error('[Agent Directory Service] diagnoseHosts error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Internal server error',
-      status: 500,
-    }
+    return operationFailed('directory operation', error instanceof Error ? error.message : 'Internal server error')
   }
 }
 
@@ -156,9 +147,6 @@ export function normalizeHosts(): ServiceResult<any> {
     }
   } catch (error) {
     console.error('[Agent Directory Service] normalizeHosts error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Internal server error',
-      status: 500,
-    }
+    return operationFailed('directory operation', error instanceof Error ? error.message : 'Internal server error')
   }
 }

--- a/services/agents-docker-service.ts
+++ b/services/agents-docker-service.ts
@@ -9,16 +9,9 @@ import { exec } from 'child_process'
 import { promisify } from 'util'
 import { createAgent, loadAgents, saveAgents } from '@/lib/agent-registry'
 import { getHosts, isSelf } from '@/lib/hosts-config'
+import { type ServiceResult, missingField, operationFailed, invalidRequest, serviceError } from '@/services/service-errors'
 
 const execAsync = promisify(exec)
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
 
 export interface DockerCreateRequest {
   name: string
@@ -44,7 +37,7 @@ export interface DockerCreateRequest {
  */
 export async function createDockerAgent(body: DockerCreateRequest): Promise<ServiceResult<Record<string, unknown>>> {
   if (!body.name?.trim()) {
-    return { error: 'Agent name is required', status: 400 }
+    return missingField('name')
   }
 
   const name = body.name.trim().toLowerCase()
@@ -64,10 +57,7 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
         const data = await resp.json()
         return { data, status: resp.status }
       } catch (err) {
-        return {
-          error: `Failed to reach remote host: ${err instanceof Error ? err.message : 'Unknown error'}`,
-          status: 502
-        }
+        return operationFailed('reach remote host', err instanceof Error ? err.message : 'Unknown error')
       }
     }
   }
@@ -76,7 +66,7 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
   try {
     await execAsync("docker version --format '{{.Server.Version}}'", { timeout: 5000 })
   } catch {
-    return { error: 'Docker is not available on this host', status: 400 }
+    return invalidRequest('Docker is not available on this host')
   }
 
   // Find an available port in 23001-23100 range
@@ -103,7 +93,7 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
   }
 
   if (!port) {
-    return { error: 'No available ports in range 23001-23100', status: 503 }
+    return serviceError('operation_failed', 'No available ports in range 23001-23100', 503)
   }
 
   // Build the AI_TOOL environment variable
@@ -152,7 +142,7 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
     containerId = stdout.trim().slice(0, 12)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error'
-    return { error: `Failed to start container: ${message}`, status: 500 }
+    return operationFailed('start container', message)
   }
 
   // Register in agent registry

--- a/services/agents-docs-service.ts
+++ b/services/agents-docs-service.ts
@@ -18,14 +18,7 @@ import {
   findDocsByType,
   getDocumentWithSections,
 } from '@/lib/rag/doc-indexer'
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, invalidRequest, notFound, missingField } from '@/services/service-errors'
 
 export interface DocsQueryOptions {
   action: string
@@ -72,7 +65,7 @@ export async function queryDocs(
 
     case 'search': {
       if (!q && !keyword) {
-        return { error: 'search requires "q" (semantic) or "keyword" (lexical) parameter', status: 400 }
+        return invalidRequest('search requires "q" (semantic) or "keyword" (lexical) parameter')
       }
 
       // Trigger delta indexing in background
@@ -90,7 +83,7 @@ export async function queryDocs(
 
     case 'find-by-type': {
       if (!docType) {
-        return { error: 'find-by-type requires "type" parameter', status: 400 }
+        return missingField('type')
       }
       result = await findDocsByType(agentDb, docType, project || undefined)
       break
@@ -98,7 +91,7 @@ export async function queryDocs(
 
     case 'get-doc': {
       if (!docId) {
-        return { error: 'get-doc requires "docId" parameter', status: 400 }
+        return missingField('docId')
       }
       result = await getDocumentWithSections(agentDb, docId)
       break
@@ -134,7 +127,7 @@ export async function queryDocs(
     }
 
     default:
-      return { error: `Unknown action: ${action}`, status: 400 }
+      return invalidRequest(`Unknown action: ${action}`)
   }
 
   return {
@@ -161,7 +154,7 @@ export async function indexDocs(
   if (!projectPath) {
     const registryAgent = getAgentFromRegistry(agentId)
     if (!registryAgent) {
-      return { error: `Agent not found in registry: ${agentId}`, status: 404 }
+      return notFound('Agent', agentId)
     }
 
     projectPath = registryAgent.workingDirectory ||
@@ -169,7 +162,7 @@ export async function indexDocs(
                   registryAgent.preferences?.defaultWorkingDirectory
 
     if (!projectPath) {
-      return { error: 'No projectPath provided and agent has no configured working directory', status: 400 }
+      return missingField('projectPath')
     }
 
     console.log(`[Docs Service] Auto-detected projectPath from registry: ${projectPath}`)

--- a/services/agents-graph-service.ts
+++ b/services/agents-graph-service.ts
@@ -39,16 +39,7 @@ import {
   initializeFileMetadata,
   getProjectFileMetadata,
 } from '@/lib/rag/code-indexer'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, missingField, notFound, invalidRequest, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -102,10 +93,7 @@ export async function getDatabaseInfo(agentId: string): Promise<ServiceResult<an
     }
   } catch (error) {
     console.error('[Graph Service] getDatabaseInfo Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('get database info', (error as Error).message)
   }
 }
 
@@ -142,10 +130,7 @@ export async function initializeDatabase(agentId: string): Promise<ServiceResult
     }
   } catch (error) {
     console.error('[Graph Service] initializeDatabase Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('initialize database', (error as Error).message)
   }
 }
 
@@ -206,7 +191,7 @@ export async function queryDbGraph(
 
       case 'columns': {
         if (!name) {
-          return { error: 'columns requires "name" parameter (table name)', status: 400 }
+          return missingField('name')
         }
         result = await findColumnsInTable(agentDb, name)
         break
@@ -214,7 +199,7 @@ export async function queryDbGraph(
 
       case 'fk': {
         if (!name) {
-          return { error: 'fk requires "name" parameter (table name)', status: 400 }
+          return missingField('name')
         }
         result = await findForeignKeysFromTable(agentDb, name)
         break
@@ -222,7 +207,7 @@ export async function queryDbGraph(
 
       case 'dependents': {
         if (!name) {
-          return { error: 'dependents requires "name" parameter (table name)', status: 400 }
+          return missingField('name')
         }
         result = await findTableDependents(agentDb, name)
         break
@@ -230,7 +215,7 @@ export async function queryDbGraph(
 
       case 'impact': {
         if (!name || !column) {
-          return { error: 'impact requires "name" (table) and "column" parameters', status: 400 }
+          return missingField('name and column')
         }
         result = await analyzeColumnTypeChange(agentDb, name, column)
         break
@@ -266,7 +251,7 @@ export async function queryDbGraph(
       }
 
       default:
-        return { error: `Unknown action: ${action}`, status: 400 }
+        return invalidRequest(`Unknown action: ${action}`)
     }
 
     return {
@@ -275,10 +260,7 @@ export async function queryDbGraph(
     }
   } catch (error) {
     console.error('[Graph Service] queryDbGraph Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('query database graph', (error as Error).message)
   }
 }
 
@@ -290,7 +272,7 @@ export async function indexDbSchema(
     const { connectionString, clear = true } = body
 
     if (!connectionString) {
-      return { error: 'Missing required parameter: connectionString', status: 400 }
+      return missingField('connectionString')
     }
 
     console.log(`[Graph Service] Indexing database schema for agent ${agentId}`)
@@ -316,10 +298,7 @@ export async function indexDbSchema(
     }
   } catch (error) {
     console.error('[Graph Service] indexDbSchema Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('index database schema', (error as Error).message)
   }
 }
 
@@ -329,7 +308,7 @@ export async function clearDbGraph(
 ): Promise<ServiceResult<any>> {
   try {
     if (!databaseName) {
-      return { error: 'Missing required parameter: database', status: 400 }
+      return missingField('database')
     }
 
     console.log(`[Graph Service] Clearing database schema graph for agent ${agentId}: ${databaseName}`)
@@ -345,10 +324,7 @@ export async function clearDbGraph(
     }
   } catch (error) {
     console.error('[Graph Service] clearDbGraph Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('clear database graph', (error as Error).message)
   }
 }
 
@@ -379,7 +355,7 @@ export async function queryGraph(
     switch (queryType) {
       case 'find-callers': {
         if (!name) {
-          return { error: 'find-callers requires "name" parameter', status: 400 }
+          return missingField('name')
         }
 
         const callersResult = await agentDb.run(`
@@ -401,7 +377,7 @@ export async function queryGraph(
 
       case 'find-callees': {
         if (!name) {
-          return { error: 'find-callees requires "name" parameter', status: 400 }
+          return missingField('name')
         }
 
         const calleesResult = await agentDb.run(`
@@ -423,7 +399,7 @@ export async function queryGraph(
 
       case 'find-related': {
         if (!name) {
-          return { error: 'find-related requires "name" parameter', status: 400 }
+          return missingField('name')
         }
 
         const related: any = {
@@ -540,7 +516,7 @@ export async function queryGraph(
 
       case 'find-by-type': {
         if (!type) {
-          return { error: 'find-by-type requires "type" parameter', status: 400 }
+          return missingField('type')
         }
 
         try {
@@ -569,7 +545,7 @@ export async function queryGraph(
 
       case 'find-associations': {
         if (!name) {
-          return { error: 'find-associations requires "name" parameter', status: 400 }
+          return missingField('name')
         }
 
         try {
@@ -607,7 +583,7 @@ export async function queryGraph(
 
       case 'find-serializers': {
         if (!name) {
-          return { error: 'find-serializers requires "name" parameter', status: 400 }
+          return missingField('name')
         }
 
         try {
@@ -638,7 +614,7 @@ export async function queryGraph(
 
       case 'find-path': {
         if (!from || !to) {
-          return { error: 'find-path requires "from" and "to" parameters', status: 400 }
+          return missingField('from and to')
         }
 
         try {
@@ -687,7 +663,7 @@ export async function queryGraph(
 
       case 'describe': {
         if (!name) {
-          return { error: 'describe requires "name" parameter', status: 400 }
+          return missingField('name')
         }
 
         const description: any = { name, found: false }
@@ -821,16 +797,7 @@ export async function queryGraph(
       }
 
       default:
-        return {
-          error: `Unknown query type: ${queryType}`,
-          data: {
-            available_queries: [
-              'find-callers', 'find-callees', 'find-related', 'find-by-type',
-              'find-associations', 'find-serializers', 'find-path', 'describe',
-            ],
-          },
-          status: 400
-        }
+        return invalidRequest(`Unknown query type: ${queryType}`)
     }
 
     return {
@@ -839,10 +806,7 @@ export async function queryGraph(
     }
   } catch (error) {
     console.error('[Graph Service] queryGraph Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('query graph', (error as Error).message)
   }
 }
 
@@ -933,7 +897,7 @@ export async function queryCodeGraph(
 
       case 'call-chain': {
         if (!from || !to) {
-          return { error: 'call-chain requires "from" and "to" parameters', status: 400 }
+          return missingField('from and to')
         }
         result = await findCallChain(agentDb, from, to)
         break
@@ -941,7 +905,7 @@ export async function queryCodeGraph(
 
       case 'dependencies': {
         if (!name) {
-          return { error: 'dependencies requires "name" parameter', status: 400 }
+          return missingField('name')
         }
         result = await getFunctionDependencies(agentDb, name)
         break
@@ -1021,7 +985,7 @@ export async function queryCodeGraph(
 
       case 'focus': {
         if (!nodeId) {
-          return { error: 'focus requires "nodeId" parameter', status: 400 }
+          return missingField('nodeId')
         }
 
         console.log(`[Graph Service] Focus on node: ${nodeId}, depth: ${depth}`)
@@ -1133,7 +1097,7 @@ export async function queryCodeGraph(
       }
 
       default:
-        return { error: `Unknown action: ${action}`, status: 400 }
+        return invalidRequest(`Unknown action: ${action}`)
     }
 
     return {
@@ -1142,10 +1106,7 @@ export async function queryCodeGraph(
     }
   } catch (error) {
     console.error('[Graph Service] queryCodeGraph Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('query code graph', (error as Error).message)
   }
 }
 
@@ -1167,7 +1128,7 @@ export async function indexCodeGraph(
     if (!projectPath) {
       const registryAgent = getAgentFromRegistry(agentId)
       if (!registryAgent) {
-        return { error: `Agent not found in registry: ${agentId}`, status: 404 }
+        return notFound('Agent', agentId)
       }
 
       projectPath = registryAgent.workingDirectory ||
@@ -1175,7 +1136,7 @@ export async function indexCodeGraph(
                     registryAgent.preferences?.defaultWorkingDirectory
 
       if (!projectPath) {
-        return { error: 'No projectPath provided and agent has no configured working directory', status: 400 }
+        return missingField('projectPath')
       }
 
       console.log(`[Graph Service] Auto-detected projectPath from registry: ${projectPath}`)
@@ -1264,10 +1225,7 @@ export async function indexCodeGraph(
     }
   } catch (error) {
     console.error('[Graph Service] indexCodeGraph Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('index code graph', (error as Error).message)
   }
 }
 
@@ -1277,7 +1235,7 @@ export async function deleteCodeGraph(
 ): Promise<ServiceResult<any>> {
   try {
     if (!projectPath) {
-      return { error: 'Missing required parameter: project', status: 400 }
+      return missingField('project')
     }
 
     console.log(`[Graph Service] Clearing code graph for agent ${agentId}: ${projectPath}`)
@@ -1293,9 +1251,6 @@ export async function deleteCodeGraph(
     }
   } catch (error) {
     console.error('[Graph Service] deleteCodeGraph Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('clear code graph', (error as Error).message)
   }
 }

--- a/services/agents-memory-service.ts
+++ b/services/agents-memory-service.ts
@@ -70,16 +70,7 @@ import type { MemoryCategory } from '@/lib/cozo-schema-memory'
 import { escapeForCozo } from '@/lib/cozo-utils'
 import { embedTexts } from '@/lib/rag/embeddings'
 import type { UpdateAgentMetricsRequest } from '@/types/agent'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, accessDenied, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -250,10 +241,7 @@ export async function getMemory(agentId: string): Promise<ServiceResult<any>> {
     }
   } catch (error) {
     console.error('[Memory Service] getMemory Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('get memory', (error as Error).message)
   }
 }
 
@@ -454,10 +442,7 @@ export async function initializeMemory(
     }
   } catch (error) {
     console.error('[Memory Service] initializeMemory Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('initialize memory', (error as Error).message)
   }
 }
 
@@ -522,10 +507,7 @@ export async function getConsolidationStatus(agentId: string): Promise<ServiceRe
     }
   } catch (error) {
     console.error('[Memory Service] getConsolidationStatus Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('get consolidation status', (error as Error).message)
   }
 }
 
@@ -577,10 +559,7 @@ export async function triggerConsolidation(
     }
   } catch (error) {
     console.error('[Memory Service] triggerConsolidation Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('trigger consolidation', (error as Error).message)
   }
 }
 
@@ -617,17 +596,11 @@ export async function manageConsolidation(
       }
 
       default:
-        return {
-          error: `Unknown action: ${body.action}`,
-          status: 400
-        }
+        return invalidRequest(`Unknown action: ${body.action}`)
     }
   } catch (error) {
     console.error('[Memory Service] manageConsolidation Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('manage consolidation', (error as Error).message)
   }
 }
 
@@ -717,7 +690,7 @@ export async function queryLongTermMemories(
     if (memoryId) {
       const memory = await getMemoryById(agentDb, memoryId)
       if (!memory) {
-        return { error: 'Memory not found', status: 404 }
+        return notFound('Memory', memoryId)
       }
       return { data: { success: true, agent_id: agentId, memory }, status: 200 }
     }
@@ -750,17 +723,14 @@ export async function queryLongTermMemories(
     return { data: { success: true, agent_id: agentId, memories, count: memories.length }, status: 200 }
   } catch (error) {
     console.error('[Memory Service] queryLongTermMemories Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('query long-term memories', (error as Error).message)
   }
 }
 
 export async function deleteLongTermMemory(agentId: string, memoryId: string): Promise<ServiceResult<any>> {
   try {
     if (!memoryId) {
-      return { error: 'Memory ID is required', status: 400 }
+      return missingField('memoryId')
     }
 
     const agent = await agentRegistry.getAgent(agentId)
@@ -768,11 +738,11 @@ export async function deleteLongTermMemory(agentId: string, memoryId: string): P
 
     const memory = await getMemoryById(agentDb, memoryId)
     if (!memory) {
-      return { error: 'Memory not found', status: 404 }
+      return notFound('Memory', memoryId)
     }
 
     if (memory.agent_id !== agentId) {
-      return { error: 'Memory does not belong to this agent', status: 403 }
+      return accessDenied('Memory does not belong to this agent')
     }
 
     await agentDb.run(`?[memory_id] <- [['${memoryId}']] :delete memories`)
@@ -793,10 +763,7 @@ export async function deleteLongTermMemory(agentId: string, memoryId: string): P
     return { data: { success: true, deleted: memoryId }, status: 200 }
   } catch (error) {
     console.error('[Memory Service] deleteLongTermMemory Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('delete long-term memory', (error as Error).message)
   }
 }
 
@@ -808,11 +775,11 @@ export async function updateLongTermMemory(
     const { id: memoryId, content, category, context } = body
 
     if (!memoryId) {
-      return { error: 'Memory ID is required', status: 400 }
+      return missingField('id')
     }
 
     if (!content && !category && context === undefined) {
-      return { error: 'At least one field (content, category, context) must be provided', status: 400 }
+      return invalidRequest('At least one field (content, category, context) must be provided')
     }
 
     const agent = await agentRegistry.getAgent(agentId)
@@ -820,11 +787,11 @@ export async function updateLongTermMemory(
 
     const memory = await getMemoryById(agentDb, memoryId)
     if (!memory) {
-      return { error: 'Memory not found', status: 404 }
+      return notFound('Memory', memoryId)
     }
 
     if (memory.agent_id !== agentId) {
-      return { error: 'Memory does not belong to this agent', status: 403 }
+      return accessDenied('Memory does not belong to this agent')
     }
 
     const newContent = content || memory.content
@@ -865,10 +832,7 @@ export async function updateLongTermMemory(
     return { data: { success: true, memory: updatedMemory }, status: 200 }
   } catch (error) {
     console.error('[Memory Service] updateLongTermMemory Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('update long-term memory', (error as Error).message)
   }
 }
 
@@ -900,11 +864,11 @@ export async function searchConversations(
     } = params
 
     if (!query) {
-      return { error: 'Missing required parameter: q (query)', status: 400 }
+      return missingField('q')
     }
 
     if (!['hybrid', 'semantic', 'term', 'symbol'].includes(mode)) {
-      return { error: 'Invalid mode. Must be: hybrid, semantic, term, or symbol', status: 400 }
+      return invalidField('mode', 'Mode must be: hybrid, semantic, term, or symbol')
     }
 
     // Trigger delta indexing before search
@@ -942,10 +906,7 @@ export async function searchConversations(
     }
   } catch (error) {
     console.error('[Memory Service] searchConversations Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('search conversations', (error as Error).message)
   }
 }
 
@@ -957,7 +918,7 @@ export async function ingestConversations(
     const { conversationFiles, batchSize = 10 } = body
 
     if (!conversationFiles || !Array.isArray(conversationFiles)) {
-      return { error: 'Missing or invalid conversationFiles array', status: 400 }
+      return invalidField('conversationFiles', 'conversationFiles must be an array')
     }
 
     const agent = await agentRegistry.getAgent(agentId)
@@ -978,10 +939,7 @@ export async function ingestConversations(
     }
   } catch (error) {
     console.error('[Memory Service] ingestConversations Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('ingest conversations', (error as Error).message)
   }
 }
 
@@ -1022,10 +980,7 @@ export async function getTracking(agentId: string): Promise<ServiceResult<any>> 
     }
   } catch (error) {
     console.error('[Memory Service] getTracking Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('get tracking', (error as Error).message)
   }
 }
 
@@ -1092,10 +1047,7 @@ export async function initializeTracking(
     }
   } catch (error) {
     console.error('[Memory Service] initializeTracking Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500
-    }
+    return operationFailed('initialize tracking', (error as Error).message)
   }
 }
 
@@ -1107,12 +1059,12 @@ export function getMetrics(agentId: string): ServiceResult<any> {
   try {
     const agent = getAgentFromFileRegistry(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
     return { data: { metrics: agent.metrics || {} }, status: 200 }
   } catch (error) {
     console.error('Failed to get agent metrics:', error)
-    return { error: 'Failed to get agent metrics', status: 500 }
+    return operationFailed('get agent metrics', (error as Error).message)
   }
 }
 
@@ -1126,7 +1078,7 @@ export function updateMetrics(
     if (action === 'increment' && metric) {
       const success = incrementAgentMetric(agentId, metric as any, amount || 1)
       if (!success) {
-        return { error: 'Agent not found', status: 404 }
+        return notFound('Agent', agentId)
       }
       const agent = getAgentFromFileRegistry(agentId)
       return { data: { metrics: agent?.metrics }, status: 200 }
@@ -1134,13 +1086,12 @@ export function updateMetrics(
 
     const agent = updateAgentMetrics(agentId, metrics as UpdateAgentMetricsRequest)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     return { data: { metrics: agent.metrics }, status: 200 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to update metrics'
     console.error('Failed to update agent metrics:', error)
-    return { error: message, status: 400 }
+    return invalidRequest((error as Error).message)
   }
 }

--- a/services/agents-messaging-service.ts
+++ b/services/agents-messaging-service.ts
@@ -55,16 +55,7 @@ import { emitEmailChanged } from '@/lib/webhook-service'
 import { getHosts, getSelfHostId, isSelf } from '@/lib/hosts-config'
 import { getPublicUrl } from '@/lib/host-sync'
 import type { AddAMPAddressRequest, AddEmailAddressRequest, EmailConflictError, EmailIndexResponse, FederatedEmailIndexResponse } from '@/types/agent'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -216,9 +207,8 @@ export async function listMessages(
       return { data: { messages }, status: 200 }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to list messages'
     console.error('Failed to list messages:', error)
-    return { error: message, status: 500 }
+    return operationFailed('list messages', (error as Error).message)
   }
 }
 
@@ -230,7 +220,7 @@ export async function sendMessage(
     const { to, subject, content, priority, inReplyTo } = body
 
     if (!to || !subject || !content) {
-      return { error: 'Missing required fields: to, subject, content', status: 400 }
+      return invalidRequest('Missing required fields: to, subject, content')
     }
 
     const result = await sendFromUI({
@@ -244,9 +234,8 @@ export async function sendMessage(
 
     return { data: { message: result.message, notified: result.notified }, status: 201 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to send message'
     console.error('Failed to send message:', error)
-    return { error: message, status: 500 }
+    return operationFailed('send message', (error as Error).message)
   }
 }
 
@@ -263,14 +252,13 @@ export async function getMessage(
     const msg = await getAgentMessage(agentId, messageId, box)
 
     if (!msg) {
-      return { error: 'Message not found', status: 404 }
+      return notFound('Message', messageId)
     }
 
     return { data: { message: msg }, status: 200 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to get message'
     console.error('Failed to get message:', error)
-    return { error: message, status: 500 }
+    return operationFailed('get message', (error as Error).message)
   }
 }
 
@@ -285,22 +273,21 @@ export async function updateMessage(
     if (action === 'read') {
       const success = await markAgentMessageAsRead(agentId, messageId)
       if (!success) {
-        return { error: 'Message not found', status: 404 }
+        return notFound('Message', messageId)
       }
       return { data: { success: true }, status: 200 }
     } else if (action === 'archive') {
       const success = await archiveAgentMessage(agentId, messageId)
       if (!success) {
-        return { error: 'Message not found', status: 404 }
+        return notFound('Message', messageId)
       }
       return { data: { success: true }, status: 200 }
     } else {
-      return { error: 'Invalid action', status: 400 }
+      return invalidRequest('Invalid action')
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to update message'
     console.error('Failed to update message:', error)
-    return { error: message, status: 500 }
+    return operationFailed('update message', (error as Error).message)
   }
 }
 
@@ -312,14 +299,13 @@ export async function deleteMessageById(
     const success = await deleteAgentMessage(agentId, messageId)
 
     if (!success) {
-      return { error: 'Message not found', status: 404 }
+      return notFound('Message', messageId)
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to delete message'
     console.error('Failed to delete message:', error)
-    return { error: message, status: 500 }
+    return operationFailed('delete message', (error as Error).message)
   }
 }
 
@@ -332,7 +318,7 @@ export async function forwardMessage(
     const { to, note } = body
 
     if (!to) {
-      return { error: 'Missing required field: to', status: 400 }
+      return missingField('to')
     }
 
     const result = await forwardFromUI({
@@ -344,9 +330,8 @@ export async function forwardMessage(
 
     return { data: { message: result.message }, status: 201 }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to forward message'
     console.error('Failed to forward message:', error)
-    return { error: message, status: 500 }
+    return operationFailed('forward message', (error as Error).message)
   }
 }
 
@@ -358,7 +343,7 @@ export function listAMPAddresses(agentId: string): ServiceResult<any> {
   try {
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const addresses = getAgentAMPAddresses(agentId)
@@ -369,7 +354,7 @@ export function listAMPAddresses(agentId: string): ServiceResult<any> {
     }
   } catch (error) {
     console.error('Failed to get AMP addresses:', error)
-    return { error: 'Failed to get AMP addresses', status: 500 }
+    return operationFailed('get AMP addresses', (error as Error).message)
   }
 }
 
@@ -379,13 +364,13 @@ export function addAMPAddressToAgent(
 ): ServiceResult<any> {
   try {
     if (!body.address) {
-      return { error: 'AMP address is required', status: 400 }
+      return missingField('address')
     }
     if (!body.provider) {
-      return { error: 'Provider is required', status: 400 }
+      return missingField('provider')
     }
     if (!body.type || !['local', 'cloud'].includes(body.type)) {
-      return { error: 'Type must be "local" or "cloud"', status: 400 }
+      return invalidField('type', 'Type must be "local" or "cloud"')
     }
 
     const agent = addAMPAddress(agentId, {
@@ -405,17 +390,17 @@ export function addAMPAddressToAgent(
       status: 201
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to add AMP address'
+    const message = (error as Error).message || 'Failed to add AMP address'
 
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('Agent', agentId)
     }
     if (message.includes('Invalid AMP') || message.includes('Maximum of 10') || message.includes('already claimed')) {
-      return { error: message, status: 400 }
+      return invalidRequest(message)
     }
 
     console.error('Failed to add AMP address:', error)
-    return { error: message, status: 500 }
+    return operationFailed('add AMP address', message)
   }
 }
 
@@ -427,7 +412,7 @@ export function getAMPAddress(agentId: string, address: string): ServiceResult<a
   try {
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const ampAddress = decodeURIComponent(address).toLowerCase()
@@ -435,7 +420,7 @@ export function getAMPAddress(agentId: string, address: string): ServiceResult<a
     const found = addresses.find(a => a.address.toLowerCase() === ampAddress)
 
     if (!found) {
-      return { error: 'AMP address not found', status: 404 }
+      return notFound('AMP address', ampAddress)
     }
 
     return {
@@ -444,7 +429,7 @@ export function getAMPAddress(agentId: string, address: string): ServiceResult<a
     }
   } catch (error) {
     console.error('Failed to get AMP address:', error)
-    return { error: 'Failed to get AMP address', status: 500 }
+    return operationFailed('get AMP address', (error as Error).message)
   }
 }
 
@@ -469,12 +454,12 @@ export function updateAMPAddressOnAgent(
       status: 200
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to update AMP address'
+    const message = (error as Error).message || 'Failed to update AMP address'
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('AMP address', address)
     }
     console.error('Failed to update AMP address:', error)
-    return { error: message, status: 500 }
+    return operationFailed('update AMP address', message)
   }
 }
 
@@ -490,12 +475,12 @@ export function removeAMPAddressFromAgent(agentId: string, address: string): Ser
       status: 200
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to remove AMP address'
+    const message = (error as Error).message || 'Failed to remove AMP address'
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('AMP address', address)
     }
     console.error('Failed to remove AMP address:', error)
-    return { error: message, status: 500 }
+    return operationFailed('remove AMP address', message)
   }
 }
 
@@ -507,7 +492,7 @@ export function listEmailAddresses(agentId: string): ServiceResult<any> {
   try {
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const addresses = getAgentEmailAddresses(agentId)
@@ -518,7 +503,7 @@ export function listEmailAddresses(agentId: string): ServiceResult<any> {
     }
   } catch (error) {
     console.error('Failed to get email addresses:', error)
-    return { error: 'Failed to get email addresses', status: 500 }
+    return operationFailed('get email addresses', (error as Error).message)
   }
 }
 
@@ -528,7 +513,7 @@ export function addEmailAddressToAgent(
 ): ServiceResult<any> {
   try {
     if (!body.address) {
-      return { error: 'Email address is required', status: 400 }
+      return missingField('address')
     }
 
     const agent = addEmailAddress(agentId, {
@@ -561,17 +546,17 @@ export function addEmailAddressToAgent(
       return { data: error, status: 409 }
     }
 
-    const message = error instanceof Error ? error.message : 'Failed to add email address'
+    const message = (error as Error).message || 'Failed to add email address'
 
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('Agent', agentId)
     }
     if (message.includes('Invalid email') || message.includes('Maximum of 10') || message.includes('already exists')) {
-      return { error: message, status: 400 }
+      return invalidRequest(message)
     }
 
     console.error('Failed to add email address:', error)
-    return { error: message, status: 500 }
+    return operationFailed('add email address', message)
   }
 }
 
@@ -583,7 +568,7 @@ export function getEmailAddressDetail(agentId: string, address: string): Service
   try {
     const agent = getAgent(agentId)
     if (!agent) {
-      return { error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentId)
     }
 
     const email = decodeURIComponent(address).toLowerCase()
@@ -591,7 +576,7 @@ export function getEmailAddressDetail(agentId: string, address: string): Service
     const found = addresses.find(a => a.address.toLowerCase() === email)
 
     if (!found) {
-      return { error: 'Email address not found', status: 404 }
+      return notFound('Email address', email)
     }
 
     return {
@@ -600,7 +585,7 @@ export function getEmailAddressDetail(agentId: string, address: string): Service
     }
   } catch (error) {
     console.error('Failed to get email address:', error)
-    return { error: 'Failed to get email address', status: 500 }
+    return operationFailed('get email address', (error as Error).message)
   }
 }
 
@@ -625,12 +610,12 @@ export function updateEmailAddressOnAgent(
       status: 200
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to update email address'
+    const message = (error as Error).message || 'Failed to update email address'
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('Email address', address)
     }
     console.error('Failed to update email address:', error)
-    return { error: message, status: 500 }
+    return operationFailed('update email address', message)
   }
 }
 
@@ -657,12 +642,12 @@ export function removeEmailAddressFromAgent(agentId: string, address: string): S
       status: 200
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to remove email address'
+    const message = (error as Error).message || 'Failed to remove email address'
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('Email address', address)
     }
     console.error('Failed to remove email address:', error)
-    return { error: message, status: 500 }
+    return operationFailed('remove email address', message)
   }
 }
 
@@ -727,7 +712,7 @@ export async function queryEmailIndex(
     if (agentIdQuery) {
       const agent = getAgent(agentIdQuery)
       if (!agent) {
-        return { error: 'Agent not found', status: 404 }
+        return notFound('Agent', agentIdQuery)
       }
 
       const addresses = getAgentEmailAddresses(agentIdQuery)
@@ -761,6 +746,6 @@ export async function queryEmailIndex(
     return { data: enrichedIndex, status: 200 }
   } catch (error) {
     console.error('Failed to get email index:', error)
-    return { error: 'Failed to get email index', status: 500 }
+    return operationFailed('get email index', (error as Error).message)
   }
 }

--- a/services/agents-playback-service.ts
+++ b/services/agents-playback-service.ts
@@ -7,14 +7,7 @@
 
 import { getAgent, getAgentByAlias, getAgentByName } from '@/lib/agent-registry'
 import type { Agent } from '@/types/agent'
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, notFound, missingField, invalidField } from '@/services/service-errors'
 
 interface PlaybackState {
   agentId: string
@@ -44,7 +37,7 @@ export function getPlaybackState(
 ): ServiceResult<Record<string, unknown>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   console.log(
@@ -82,26 +75,26 @@ export function controlPlayback(
 ): ServiceResult<Record<string, unknown>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   const { action, sessionId, value } = body
 
   if (!action) {
-    return { error: 'Missing required parameter: action', status: 400 }
+    return missingField('action')
   }
 
   const validActions = ['play', 'pause', 'seek', 'setSpeed', 'reset']
   if (!validActions.includes(action)) {
-    return { error: `Invalid action. Must be one of: ${validActions.join(', ')}`, status: 400 }
+    return invalidField('action', `Must be one of: ${validActions.join(', ')}`)
   }
 
   if ((action === 'seek' || action === 'setSpeed') && (value === undefined || isNaN(value))) {
-    return { error: `Action '${action}' requires a numeric value parameter`, status: 400 }
+    return invalidField('value', `Action '${action}' requires a numeric value parameter`)
   }
 
   if (sessionId && !agent.sessions?.some(s => s.index === parseInt(sessionId))) {
-    return { error: 'Session not found for this agent', status: 404 }
+    return notFound('Session', sessionId)
   }
 
   console.log(

--- a/services/agents-repos-service.ts
+++ b/services/agents-repos-service.ts
@@ -10,14 +10,7 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import type { Agent, Repository } from '@/types/agent'
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, notFound, missingField, invalidRequest } from '@/services/service-errors'
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -93,7 +86,7 @@ function getAgentWorkingDir(agent: Agent): string | undefined {
 export function listRepos(agentIdOrName: string): ServiceResult<Record<string, unknown>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   const configuredRepos = agent.tools.repositories || []
@@ -134,7 +127,7 @@ export function updateRepos(
 ): ServiceResult<Record<string, unknown>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   if (body.detectFromWorkingDir) {
@@ -164,11 +157,11 @@ export function updateRepos(
       }
     }
 
-    return { error: 'No git repository found in working directory', status: 400 }
+    return invalidRequest('No git repository found in working directory')
   }
 
   if (!body.repositories || !Array.isArray(body.repositories)) {
-    return { error: 'repositories array required', status: 400 }
+    return missingField('repositories')
   }
 
   const agents = loadAgents()
@@ -189,19 +182,19 @@ export function updateRepos(
  */
 export function removeRepo(agentIdOrName: string, remoteUrl: string): ServiceResult<Record<string, unknown>> {
   if (!remoteUrl) {
-    return { error: 'url parameter required', status: 400 }
+    return missingField('url')
   }
 
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   const repos = agent.tools.repositories || []
   const filteredRepos = repos.filter(r => r.remoteUrl !== remoteUrl)
 
   if (filteredRepos.length === repos.length) {
-    return { error: 'Repository not found', status: 404 }
+    return notFound('Repository')
   }
 
   const agents = loadAgents()

--- a/services/agents-skills-service.ts
+++ b/services/agents-skills-service.ts
@@ -18,14 +18,7 @@ import { getSkillById } from '@/lib/marketplace-skills'
 import { agentRegistry } from '@/lib/agent'
 import fs from 'fs/promises'
 import path from 'path'
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, missingField, notFound, invalidField, operationFailed } from '@/services/service-errors'
 
 // ── Public Functions ────────────────────────────────────────────────────────
 
@@ -35,7 +28,7 @@ export interface ServiceResult<T> {
 export function getSkillsConfig(agentId: string): ServiceResult<Record<string, unknown>> {
   const skills = getAgentSkills(agentId)
   if (!skills) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
   return { data: skills as unknown as Record<string, unknown>, status: 200 }
 }
@@ -49,7 +42,7 @@ export async function updateSkills(
 ): Promise<ServiceResult<Record<string, unknown>>> {
   const agent = getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   // Handle skill additions
@@ -65,7 +58,7 @@ export async function updateSkills(
     for (const skillId of body.add) {
       const skill = await getSkillById(skillId, false)
       if (!skill) {
-        return { error: `Skill not found: ${skillId}`, status: 400 }
+        return notFound('Skill', skillId)
       }
       skillsToAdd.push({
         id: skill.id,
@@ -78,7 +71,7 @@ export async function updateSkills(
 
     const result = addMarketplaceSkills(agentId, skillsToAdd)
     if (!result) {
-      return { error: 'Failed to add skills', status: 500 }
+      return operationFailed('add skills')
     }
   }
 
@@ -86,7 +79,7 @@ export async function updateSkills(
   if (body.remove && Array.isArray(body.remove) && body.remove.length > 0) {
     const result = removeMarketplaceSkills(agentId, body.remove)
     if (!result) {
-      return { error: 'Failed to remove skills', status: 500 }
+      return operationFailed('remove skills')
     }
   }
 
@@ -94,7 +87,7 @@ export async function updateSkills(
   if (body.aiMaestro) {
     const result = updateAiMaestroSkills(agentId, body.aiMaestro)
     if (!result) {
-      return { error: 'Failed to update AI Maestro skills', status: 500 }
+      return operationFailed('update AI Maestro skills')
     }
   }
 
@@ -114,19 +107,19 @@ export function addSkill(
 ): ServiceResult<Record<string, unknown>> {
   const agent = getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   if (!body.name || typeof body.name !== 'string') {
-    return { error: 'Missing required field: name', status: 400 }
+    return missingField('name')
   }
 
   if (!body.content || typeof body.content !== 'string') {
-    return { error: 'Missing required field: content', status: 400 }
+    return missingField('content')
   }
 
   if (!/^[a-zA-Z0-9_-]+$/.test(body.name)) {
-    return { error: 'Invalid skill name. Use only alphanumeric characters, hyphens, and underscores.', status: 400 }
+    return invalidField('name', 'Invalid skill name. Use only alphanumeric characters, hyphens, and underscores.')
   }
 
   const result = addCustomSkill(agentId, {
@@ -136,7 +129,7 @@ export function addSkill(
   })
 
   if (!result) {
-    return { error: 'Failed to add custom skill', status: 500 }
+    return operationFailed('add custom skill')
   }
 
   const updatedSkills = getAgentSkills(agentId)
@@ -156,7 +149,7 @@ export function removeSkill(
 ): ServiceResult<Record<string, unknown>> {
   const agent = getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   const isMarketplaceSkill = type === 'marketplace' || (type === 'auto' && skillId.includes(':'))
@@ -169,7 +162,7 @@ export function removeSkill(
   }
 
   if (!result) {
-    return { error: 'Failed to remove skill', status: 500 }
+    return operationFailed('remove skill')
   }
 
   const updatedSkills = getAgentSkills(agentId)
@@ -185,7 +178,7 @@ export function removeSkill(
 export async function getSkillSettings(agentId: string): Promise<ServiceResult<Record<string, unknown>>> {
   const agent = await agentRegistry.getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   const homeDir = process.env.HOME || process.env.USERPROFILE || ''
@@ -208,12 +201,12 @@ export async function saveSkillSettings(
   settings: Record<string, unknown>
 ): Promise<ServiceResult<Record<string, unknown>>> {
   if (!settings) {
-    return { error: 'Settings are required', status: 400 }
+    return missingField('settings')
   }
 
   const agent = await agentRegistry.getAgent(agentId)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentId)
   }
 
   const homeDir = process.env.HOME || process.env.USERPROFILE || ''

--- a/services/agents-subconscious-service.ts
+++ b/services/agents-subconscious-service.ts
@@ -6,14 +6,7 @@
  */
 
 import { agentRegistry } from '@/lib/agent'
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
+import { type ServiceResult, notInitialized, invalidRequest } from '@/services/service-errors'
 
 // ── Public Functions ────────────────────────────────────────────────────────
 
@@ -76,7 +69,7 @@ export async function triggerSubconsciousAction(
   const subconscious = agent.getSubconscious()
 
   if (!subconscious) {
-    return { error: 'Subconscious not initialized', status: 400 }
+    return notInitialized('Subconscious')
   }
 
   switch (action) {
@@ -106,6 +99,6 @@ export async function triggerSubconsciousAction(
     }
 
     default:
-      return { error: `Unknown action: ${action}`, status: 400 }
+      return invalidRequest(`Unknown action: ${action}`)
   }
 }

--- a/services/agents-transfer-service.ts
+++ b/services/agents-transfer-service.ts
@@ -18,6 +18,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { execSync } from 'child_process'
 import type { Agent, Repository } from '@/types/agent'
 import type { AgentExportManifest, AgentImportOptions, AgentImportResult, PortableRepository, RepositoryImportResult } from '@/types/portable'
+import { type ServiceResult, notFound, missingField, invalidField, invalidRequest, operationFailed } from '@/services/service-errors'
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -25,14 +26,6 @@ const VERSION_FILE = path.join(process.cwd(), 'version.json')
 const AIMAESTRO_DIR = path.join(os.homedir(), '.aimaestro')
 const AGENTS_DIR = path.join(AIMAESTRO_DIR, 'agents')
 const MESSAGES_DIR = path.join(AIMAESTRO_DIR, 'messages')
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
 
 export interface TransferRequest {
   targetHostId: string
@@ -294,12 +287,12 @@ function resolveAgent(idOrName: string): Agent | null {
 export async function exportAgentZip(agentIdOrName: string): Promise<ServiceResult<ExportZipResult>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   const agentName = agent.name || agent.alias
   if (!agentName) {
-    return { error: 'Agent has no name configured', status: 400 }
+    return invalidRequest('Agent has no name configured')
   }
 
   // Paths to agent data
@@ -511,29 +504,29 @@ export function createTranscriptExportJob(
 ): ServiceResult<Record<string, unknown>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   const { format, sessionId, startDate, endDate } = body
 
   if (!format) {
-    return { error: 'Missing required parameter: format', status: 400 }
+    return missingField('format')
   }
 
   if (!['json', 'markdown', 'plaintext'].includes(format)) {
-    return { error: 'Invalid format. Must be: json, markdown, or plaintext', status: 400 }
+    return invalidField('format', 'Invalid format. Must be: json, markdown, or plaintext')
   }
 
   if (startDate && isNaN(Date.parse(startDate))) {
-    return { error: 'Invalid startDate format. Must be ISO 8601 timestamp', status: 400 }
+    return invalidField('startDate', 'Invalid startDate format. Must be ISO 8601 timestamp')
   }
 
   if (endDate && isNaN(Date.parse(endDate))) {
-    return { error: 'Invalid endDate format. Must be ISO 8601 timestamp', status: 400 }
+    return invalidField('endDate', 'Invalid endDate format. Must be ISO 8601 timestamp')
   }
 
   if (sessionId && !agent.sessions?.some(s => s.index === parseInt(sessionId))) {
-    return { error: 'Session not found for this agent', status: 404 }
+    return notFound('Session')
   }
 
   console.log(
@@ -600,7 +593,7 @@ export async function importAgent(
     // Read manifest
     const manifestPath = path.join(tempDir, 'manifest.json')
     if (!fs.existsSync(manifestPath)) {
-      return { error: 'Invalid agent export: missing manifest.json', status: 400 }
+      return invalidRequest('Invalid agent export: missing manifest.json')
     }
 
     const manifest: AgentExportManifest = JSON.parse(
@@ -615,7 +608,7 @@ export async function importAgent(
     // Read registry
     const registryPath = path.join(tempDir, 'registry.json')
     if (!fs.existsSync(registryPath)) {
-      return { error: 'Invalid agent export: missing registry.json', status: 400 }
+      return invalidRequest('Invalid agent export: missing registry.json')
     }
 
     const importedAgent: Agent = JSON.parse(
@@ -624,7 +617,7 @@ export async function importAgent(
 
     const importedAgentName = importedAgent.name || importedAgent.alias
     if (!importedAgentName) {
-      return { error: 'Invalid agent export: agent has no name', status: 400 }
+      return invalidRequest('Invalid agent export: agent has no name')
     }
 
     // Check for name conflict
@@ -984,13 +977,13 @@ export async function transferAgent(
 ): Promise<ServiceResult<TransferResult>> {
   const agent = resolveAgent(agentIdOrName)
   if (!agent) {
-    return { error: 'Agent not found', status: 404 }
+    return notFound('Agent', agentIdOrName)
   }
 
   const { targetHostUrl, mode, newAlias, cloneRepositories } = body
 
   if (!targetHostUrl) {
-    return { error: 'Target host URL required', status: 400 }
+    return missingField('targetHostUrl')
   }
 
   let normalizedUrl = targetHostUrl.trim()
@@ -1005,7 +998,7 @@ export async function transferAgent(
 
   if (!exportResponse.ok) {
     const errorText = await exportResponse.text()
-    return { error: `Failed to export agent: ${errorText}`, status: 500 }
+    return operationFailed('export agent', errorText)
   }
 
   const exportBuffer = Buffer.from(await exportResponse.arrayBuffer())
@@ -1038,7 +1031,7 @@ export async function transferAgent(
     } catch {
       errorMessage = errorText || errorMessage
     }
-    return { error: errorMessage, status: 500 }
+    return operationFailed('import on target host', errorMessage)
   }
 
   const importResult = await importResponse.json()

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -56,21 +56,9 @@ import type {
   AMPKeyRotationResponse,
   AMPEnvelope,
   AMPPayload,
-  AMPError,
-  AMPNameTakenError,
   AMPKeypairRotationRequest,
 } from '@/lib/types/amp'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-  headers?: Record<string, string>
-}
+import { type ServiceResult } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Module-level state (shared across requests, lives in the service)
@@ -509,7 +497,7 @@ export function getProviderInfo(): ServiceResult<AMPInfoResponse> {
 export async function registerAgent(
   body: AMPRegistrationRequest,
   authHeader: string | null
-): Promise<ServiceResult<AMPRegistrationResponse | AMPError | AMPNameTakenError>> {
+): Promise<ServiceResult<AMPRegistrationResponse>> {
   try {
     // Check for User Key authentication (D5)
     let userKeyInfo: { ownerId: string; tenantId: string } | null = null
@@ -517,7 +505,7 @@ export async function registerAgent(
       userKeyInfo = decodeUserKey(authHeader.substring(7))
       if (!userKeyInfo) {
         return {
-          data: { error: 'unauthorized', message: 'Invalid User Key format' } as AMPError,
+          data: { error: 'unauthorized', message: 'Invalid User Key format' },
           status: 401
         }
       }
@@ -529,28 +517,28 @@ export async function registerAgent(
     // Validate required fields
     if (!body.tenant || typeof body.tenant !== 'string') {
       return {
-        data: { error: 'missing_field', message: 'tenant is required (or provide a User Key via Authorization header)', field: 'tenant' } as AMPError,
+        data: { error: 'missing_field', message: 'tenant is required (or provide a User Key via Authorization header)', field: 'tenant' },
         status: 400
       }
     }
 
     if (!body.name || typeof body.name !== 'string') {
       return {
-        data: { error: 'missing_field', message: 'name is required', field: 'name' } as AMPError,
+        data: { error: 'missing_field', message: 'name is required', field: 'name' },
         status: 400
       }
     }
 
     if (!body.public_key || typeof body.public_key !== 'string') {
       return {
-        data: { error: 'missing_field', message: 'public_key is required', field: 'public_key' } as AMPError,
+        data: { error: 'missing_field', message: 'public_key is required', field: 'public_key' },
         status: 400
       }
     }
 
     if (!body.key_algorithm || body.key_algorithm !== 'Ed25519') {
       return {
-        data: { error: 'invalid_field', message: 'key_algorithm must be "Ed25519"', field: 'key_algorithm' } as AMPError,
+        data: { error: 'invalid_field', message: 'key_algorithm must be "Ed25519"', field: 'key_algorithm' },
         status: 400
       }
     }
@@ -561,7 +549,7 @@ export async function registerAgent(
     // Validate name format
     if (!isValidAgentName(normalizedName)) {
       return {
-        data: { error: 'invalid_field', message: 'name must be 1-63 characters, alphanumeric and hyphens only, cannot start or end with hyphen', field: 'name' } as AMPError,
+        data: { error: 'invalid_field', message: 'name must be 1-63 characters, alphanumeric and hyphens only, cannot start or end with hyphen', field: 'name' },
         status: 400
       }
     }
@@ -570,7 +558,7 @@ export async function registerAgent(
     const publicKeyHex = extractPublicKeyHex(body.public_key)
     if (!publicKeyHex) {
       return {
-        data: { error: 'invalid_field', message: 'Invalid public key format. Must be PEM-encoded Ed25519 public key.', field: 'public_key' } as AMPError,
+        data: { error: 'invalid_field', message: 'Invalid public key format. Must be PEM-encoded Ed25519 public key.', field: 'public_key' },
         status: 400
       }
     }
@@ -592,8 +580,8 @@ export async function registerAgent(
           error: 'organization_not_set',
           message: 'Organization must be configured before registering agents. Please complete the AI Maestro setup first.',
           field: 'organization',
-          setup_url: '/setup'
-        } as AMPError & { setup_url: string },
+          details: { setup_url: '/setup' }
+        },
         status: 400
       }
     }
@@ -607,7 +595,7 @@ export async function registerAgent(
           message: `This AI Maestro instance is configured for organization '${configOrg}'. Cannot register under '${body.tenant}'.`,
           field: 'tenant',
           details: { expected_tenant: configOrg }
-        } as AMPError,
+        },
         status: 400
       }
     }
@@ -624,7 +612,7 @@ export async function registerAgent(
           error: 'key_already_registered',
           message: 'This public key is already associated with another agent',
           details: { fingerprint }
-        } as AMPError,
+        },
         status: 409
       }
     }
@@ -645,8 +633,8 @@ export async function registerAgent(
             data: {
               error: 'name_taken',
               message: `Agent name '${normalizedName}' is already registered`,
-              suggestions: generateNameSuggestions(normalizedName)
-            } as AMPNameTakenError,
+              details: { suggestions: generateNameSuggestions(normalizedName) }
+            },
             status: 409
           }
         }
@@ -680,7 +668,7 @@ export async function registerAgent(
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : 'Failed to create agent'
         return {
-          data: { error: 'internal_error', message: errorMessage } as AMPError,
+          data: { error: 'internal_error', message: errorMessage },
           status: 500
         }
       }
@@ -754,7 +742,7 @@ export async function registerAgent(
   } catch (error) {
     console.error('[AMP Register] Error:', error)
     return {
-      data: { error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' } as AMPError,
+      data: { error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' },
       status: 500
     }
   }
@@ -771,7 +759,7 @@ export async function routeMessage(
   envelopeIdHeader: string | null,
   signatureHeader: string | null,
   contentLength: string | null
-): Promise<ServiceResult<AMPRouteResponse | AMPError>> {
+): Promise<ServiceResult<AMPRouteResponse>> {
   try {
     // ── Authentication ─────────────────────────────────────────────────
     let auth = authenticateRequest(authHeader)
@@ -791,7 +779,7 @@ export async function routeMessage(
 
     if (!auth.authenticated) {
       return {
-        data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+        data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
         status: 401
       }
     }
@@ -807,7 +795,7 @@ export async function routeMessage(
 
     if (!rateLimit.allowed) {
       return {
-        data: { error: 'rate_limited', message: `Rate limit exceeded: ${ROUTE_RATE_LIMIT_MAX} requests per minute` } as AMPError,
+        data: { error: 'rate_limited', message: `Rate limit exceeded: ${ROUTE_RATE_LIMIT_MAX} requests per minute` },
         status: 429,
         headers: rateLimitHeaders
       }
@@ -816,7 +804,7 @@ export async function routeMessage(
     // ── Payload Size Limit (S10) ──────────────────────────────────────
     if (contentLength && parseInt(contentLength, 10) > MAX_PAYLOAD_SIZE) {
       return {
-        data: { error: 'payload_too_large', message: `Payload exceeds maximum size of ${MAX_PAYLOAD_SIZE} bytes` } as AMPError,
+        data: { error: 'payload_too_large', message: `Payload exceeds maximum size of ${MAX_PAYLOAD_SIZE} bytes` },
         status: 413
       }
     }
@@ -824,25 +812,25 @@ export async function routeMessage(
     // ── Body Validation ────────────────────────────────────────────────
     if (!body.to || typeof body.to !== 'string') {
       return {
-        data: { error: 'missing_field', message: 'to address is required', field: 'to' } as AMPError,
+        data: { error: 'missing_field', message: 'to address is required', field: 'to' },
         status: 400
       }
     }
     if (!body.subject || typeof body.subject !== 'string') {
       return {
-        data: { error: 'missing_field', message: 'subject is required', field: 'subject' } as AMPError,
+        data: { error: 'missing_field', message: 'subject is required', field: 'subject' },
         status: 400
       }
     }
     if (!body.payload || typeof body.payload !== 'object') {
       return {
-        data: { error: 'missing_field', message: 'payload is required', field: 'payload' } as AMPError,
+        data: { error: 'missing_field', message: 'payload is required', field: 'payload' },
         status: 400
       }
     }
     if (!body.payload.type || !body.payload.message) {
       return {
-        data: { error: 'invalid_field', message: 'payload must have type and message fields', field: 'payload' } as AMPError,
+        data: { error: 'invalid_field', message: 'payload must have type and message fields', field: 'payload' },
         status: 400
       }
     }
@@ -853,7 +841,7 @@ export async function routeMessage(
 
     if (!senderAgent && !isMeshForwarded) {
       return {
-        data: { error: 'internal_error', message: 'Sender agent not found in registry' } as AMPError,
+        data: { error: 'internal_error', message: 'Sender agent not found in registry' },
         status: 500
       }
     }
@@ -945,7 +933,7 @@ export async function routeMessage(
         data: {
           error: 'external_provider',
           message: `Recipient is on external provider "${recipientParsed?.provider}". Send directly to that provider using its route_url from your registration.`
-        } as AMPError,
+        },
         status: 422
       }
     }
@@ -1002,7 +990,7 @@ export async function routeMessage(
         if (!resolvedAgentId) {
           console.error(`[AMP Route] Host '${resolvedHostId}' not in config and no UUID for ${recipientName} -- cannot queue`)
           return {
-            data: { error: 'not_found', message: `Recipient '${recipientName}' not found and target host '${resolvedHostId}' is not configured` } as AMPError,
+            data: { error: 'not_found', message: `Recipient '${recipientName}' not found and target host '${resolvedHostId}' is not configured` },
             status: 404
           }
         }
@@ -1032,7 +1020,7 @@ export async function routeMessage(
       console.error(`[AMP Route] Mesh delivery to ${resolvedHostId} failed: ${fwd.error}`)
       if (!resolvedAgentId) {
         return {
-          data: { error: 'internal_error', message: `Mesh delivery to ${resolvedHostId} failed and no UUID to queue: ${fwd.error}` } as AMPError,
+          data: { error: 'internal_error', message: `Mesh delivery to ${resolvedHostId} failed and no UUID to queue: ${fwd.error}` },
           status: 502
         }
       }
@@ -1053,7 +1041,7 @@ export async function routeMessage(
     if (!localAgent) {
       if (!resolvedAgentId) {
         return {
-          data: { error: 'not_found', message: `Recipient '${recipientName}' not found on any host` } as AMPError,
+          data: { error: 'not_found', message: `Recipient '${recipientName}' not found on any host` },
           status: 404
         }
       }
@@ -1094,7 +1082,7 @@ export async function routeMessage(
   } catch (error) {
     console.error('[AMP Route] Error:', error)
     return {
-      data: { error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' } as AMPError,
+      data: { error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' },
       status: 500
     }
   }
@@ -1107,7 +1095,7 @@ export async function routeMessage(
 export function listPendingMessages(
   authHeader: string | null,
   limit?: number
-): ServiceResult<AMPPendingMessagesResponse | AMPError> {
+): ServiceResult<AMPPendingMessagesResponse> {
   // Lazy cleanup of expired relay messages
   lazyCleanup()
 
@@ -1115,7 +1103,7 @@ export function listPendingMessages(
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1137,19 +1125,19 @@ export function listPendingMessages(
 export function acknowledgePendingMessage(
   authHeader: string | null,
   messageId: string | null
-): ServiceResult<{ acknowledged: boolean } | AMPError> {
+): ServiceResult<{ acknowledged: boolean }> {
   const auth = authenticateRequest(authHeader)
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
 
   if (!messageId) {
     return {
-      data: { error: 'missing_field', message: 'Message ID required (use DELETE /pending/:id or DELETE /pending?id=<messageId>)', field: 'id' } as AMPError,
+      data: { error: 'missing_field', message: 'Message ID required (use DELETE /pending/:id or DELETE /pending?id=<messageId>)', field: 'id' },
       status: 400
     }
   }
@@ -1158,7 +1146,7 @@ export function acknowledgePendingMessage(
 
   if (!acknowledged) {
     return {
-      data: { error: 'not_found', message: `Message ${messageId} not found in pending queue` } as AMPError,
+      data: { error: 'not_found', message: `Message ${messageId} not found in pending queue` },
       status: 404
     }
   }
@@ -1173,26 +1161,26 @@ export function acknowledgePendingMessage(
 export function batchAcknowledgeMessages(
   authHeader: string | null,
   ids: string[] | undefined
-): ServiceResult<{ acknowledged: number } | AMPError> {
+): ServiceResult<{ acknowledged: number }> {
   const auth = authenticateRequest(authHeader)
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
 
   if (!ids || !Array.isArray(ids) || ids.length === 0) {
     return {
-      data: { error: 'missing_field', message: 'ids array required', field: 'ids' } as AMPError,
+      data: { error: 'missing_field', message: 'ids array required', field: 'ids' },
       status: 400
     }
   }
 
   if (ids.length > 100) {
     return {
-      data: { error: 'invalid_request', message: 'Maximum 100 messages per batch' } as AMPError,
+      data: { error: 'invalid_request', message: 'Maximum 100 messages per batch' },
       status: 400
     }
   }
@@ -1215,7 +1203,7 @@ export async function sendReadReceipt(
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1274,7 +1262,7 @@ export function listAMPAgents(
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1320,7 +1308,7 @@ export function getAgentSelf(authHeader: string | null): ServiceResult<any> {
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1328,7 +1316,7 @@ export function getAgentSelf(authHeader: string | null): ServiceResult<any> {
   const agent = getAgent(auth.agentId!)
   if (!agent) {
     return {
-      data: { error: 'not_found', message: 'Agent not found' } as AMPError,
+      data: { error: 'not_found', message: 'Agent not found' },
       status: 404
     }
   }
@@ -1357,7 +1345,7 @@ export function getAgentCard(authHeader: string | null): ServiceResult<any> {
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1365,7 +1353,7 @@ export function getAgentCard(authHeader: string | null): ServiceResult<any> {
   const agent = getAgent(auth.agentId!)
   if (!agent) {
     return {
-      data: { error: 'not_found', message: 'Agent not found' } as AMPError,
+      data: { error: 'not_found', message: 'Agent not found' },
       status: 404
     }
   }
@@ -1373,7 +1361,7 @@ export function getAgentCard(authHeader: string | null): ServiceResult<any> {
   const keyPair = loadKeyPair(auth.agentId!)
   if (!keyPair) {
     return {
-      data: { error: 'not_found', message: 'Agent keypair not found' } as AMPError,
+      data: { error: 'not_found', message: 'Agent keypair not found' },
       status: 404
     }
   }
@@ -1402,7 +1390,7 @@ export function getAgentCard(authHeader: string | null): ServiceResult<any> {
   } catch (err) {
     console.error('[AMP] Failed to sign agent card:', err)
     return {
-      data: { error: 'internal_error', message: 'Failed to sign card' } as AMPError,
+      data: { error: 'internal_error', message: 'Failed to sign card' },
       status: 500
     }
   }
@@ -1422,7 +1410,7 @@ export async function updateAgentSelf(
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1430,7 +1418,7 @@ export async function updateAgentSelf(
   const agent = getAgent(auth.agentId!)
   if (!agent) {
     return {
-      data: { error: 'not_found', message: 'Agent not found' } as AMPError,
+      data: { error: 'not_found', message: 'Agent not found' },
       status: 404
     }
   }
@@ -1473,7 +1461,7 @@ export async function deleteAgentSelf(authHeader: string | null): Promise<Servic
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1485,7 +1473,7 @@ export async function deleteAgentSelf(authHeader: string | null): Promise<Servic
   const deleted = deleteAgent(auth.agentId!, true)
   if (!deleted) {
     return {
-      data: { error: 'not_found', message: 'Agent not found' } as AMPError,
+      data: { error: 'not_found', message: 'Agent not found' },
       status: 404
     }
   }
@@ -1507,12 +1495,12 @@ export async function deleteAgentSelf(authHeader: string | null): Promise<Servic
 export function resolveAgentAddress(
   authHeader: string | null,
   address: string
-): ServiceResult<AMPAgentResolveResponse | AMPError> {
+): ServiceResult<AMPAgentResolveResponse> {
   const auth = authenticateRequest(authHeader)
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1534,7 +1522,7 @@ export function resolveAgentAddress(
     )
     if (!byAddress) {
       return {
-        data: { error: 'not_found', message: `Agent not found: ${decodedAddress}` } as AMPError,
+        data: { error: 'not_found', message: `Agent not found: ${decodedAddress}` },
         status: 404
       }
     }
@@ -1578,7 +1566,7 @@ export function revokeKey(authHeader: string | null): ServiceResult<any> {
 
   if (!apiKey) {
     return {
-      data: { error: 'unauthorized', message: 'Missing or invalid Authorization header' } as AMPError,
+      data: { error: 'unauthorized', message: 'Missing or invalid Authorization header' },
       status: 401
     }
   }
@@ -1587,7 +1575,7 @@ export function revokeKey(authHeader: string | null): ServiceResult<any> {
 
   if (!revoked) {
     return {
-      data: { error: 'not_found', message: 'API key not found' } as AMPError,
+      data: { error: 'not_found', message: 'API key not found' },
       status: 404
     }
   }
@@ -1602,12 +1590,12 @@ export function revokeKey(authHeader: string | null): ServiceResult<any> {
 // POST /api/v1/auth/rotate-key
 // ---------------------------------------------------------------------------
 
-export function rotateKey(authHeader: string | null): ServiceResult<AMPKeyRotationResponse | AMPError> {
+export function rotateKey(authHeader: string | null): ServiceResult<AMPKeyRotationResponse> {
   const apiKey = extractApiKeyFromHeader(authHeader)
 
   if (!apiKey) {
     return {
-      data: { error: 'unauthorized', message: 'Missing or invalid Authorization header' } as AMPError,
+      data: { error: 'unauthorized', message: 'Missing or invalid Authorization header' },
       status: 401
     }
   }
@@ -1616,7 +1604,7 @@ export function rotateKey(authHeader: string | null): ServiceResult<AMPKeyRotati
 
   if (!result) {
     return {
-      data: { error: 'unauthorized', message: 'Invalid or expired API key' } as AMPError,
+      data: { error: 'unauthorized', message: 'Invalid or expired API key' },
       status: 401
     }
   }
@@ -1636,7 +1624,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
 
   if (!auth.authenticated) {
     return {
-      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' } as AMPError,
+      data: { error: auth.error || 'unauthorized', message: auth.message || 'Authentication required' },
       status: 401
     }
   }
@@ -1644,7 +1632,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
   const agent = getAgent(auth.agentId!)
   if (!agent) {
     return {
-      data: { error: 'not_found', message: 'Agent not found' } as AMPError,
+      data: { error: 'not_found', message: 'Agent not found' },
       status: 404
     }
   }
@@ -1655,7 +1643,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
     // ── Proof-of-possession rotation ──────────────────────────────────────
     if (body.key_algorithm && body.key_algorithm !== 'Ed25519') {
       return {
-        data: { error: 'invalid_field', message: 'key_algorithm must be Ed25519', field: 'key_algorithm' } as AMPError,
+        data: { error: 'invalid_field', message: 'key_algorithm must be Ed25519', field: 'key_algorithm' },
         status: 400
       }
     }
@@ -1663,7 +1651,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
     const newPublicKeyHex = extractPublicKeyHex(body.new_public_key)
     if (!newPublicKeyHex) {
       return {
-        data: { error: 'invalid_field', message: 'Invalid new_public_key format. Must be PEM-encoded Ed25519 public key.', field: 'new_public_key' } as AMPError,
+        data: { error: 'invalid_field', message: 'Invalid new_public_key format. Must be PEM-encoded Ed25519 public key.', field: 'new_public_key' },
         status: 400
       }
     }
@@ -1672,7 +1660,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
     const oldKeyPair = loadKeyPair(auth.agentId!)
     if (!oldKeyPair) {
       return {
-        data: { error: 'not_found', message: 'Existing keypair not found for agent' } as AMPError,
+        data: { error: 'not_found', message: 'Existing keypair not found for agent' },
         status: 404
       }
     }
@@ -1681,7 +1669,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
     const proofValid = verifySignature(newPublicKeyHex, body.proof, oldKeyPair.publicHex)
     if (!proofValid) {
       return {
-        data: { error: 'invalid_signature', message: 'Proof-of-possession verification failed. The proof must be the new public key hex signed with the old private key.' } as AMPError,
+        data: { error: 'invalid_signature', message: 'Proof-of-possession verification failed. The proof must be the new public key hex signed with the old private key.' },
         status: 401
       }
     }
@@ -1697,7 +1685,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
     // Partial body — both fields required
     const missing = !body.new_public_key ? 'new_public_key' : 'proof'
     return {
-      data: { error: 'missing_field', message: `Both new_public_key and proof are required for proof-of-possession rotation`, field: missing } as AMPError,
+      data: { error: 'missing_field', message: `Both new_public_key and proof are required for proof-of-possession rotation`, field: missing },
       status: 400
     }
   } else {
@@ -1741,7 +1729,7 @@ export async function deliverFederated(
     // ── Provider Identity ───────────────────────────────────────────────
     if (!providerName) {
       return {
-        data: { error: 'missing_header', message: 'X-AMP-Provider header is required' } as AMPError,
+        data: { error: 'missing_header', message: 'X-AMP-Provider header is required' },
         status: 400
       }
     }
@@ -1750,7 +1738,7 @@ export async function deliverFederated(
     const rateLimit = checkFederationRateLimit(providerName)
     if (!rateLimit.allowed) {
       return {
-        data: { error: 'rate_limited', message: 'Federation rate limit exceeded' } as AMPError,
+        data: { error: 'rate_limited', message: 'Federation rate limit exceeded' },
         status: 429,
         headers: { 'Retry-After': '60' }
       }
@@ -1761,7 +1749,7 @@ export async function deliverFederated(
 
     if (!envelope || !payload) {
       return {
-        data: { error: 'invalid_request', message: 'envelope and payload are required' } as AMPError,
+        data: { error: 'invalid_request', message: 'envelope and payload are required' },
         status: 400
       }
     }
@@ -1769,7 +1757,7 @@ export async function deliverFederated(
     // ── Replay Protection ───────────────────────────────────────────────
     if (!trackMessageId(envelope.id)) {
       return {
-        data: { error: 'duplicate_message', message: `Message ${envelope.id} has already been delivered` } as AMPError,
+        data: { error: 'duplicate_message', message: `Message ${envelope.id} has already been delivered` },
         status: 409
       }
     }
@@ -1813,7 +1801,7 @@ export async function deliverFederated(
         }
       }
       return {
-        data: { error: 'not_found', message: `Recipient '${recipientName}' not found on any host` } as AMPError,
+        data: { error: 'not_found', message: `Recipient '${recipientName}' not found on any host` },
         status: 404
       }
     }
@@ -1845,7 +1833,7 @@ export async function deliverFederated(
   } catch (error) {
     console.error('[Federation] Error:', error)
     return {
-      data: { error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' } as AMPError,
+      data: { error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' },
       status: 500
     }
   }

--- a/services/config-service.ts
+++ b/services/config-service.ts
@@ -35,18 +35,9 @@ import type {
   MemoryRunResult,
   MessageCheckResult,
 } from '@/types/subconscious'
+import { type ServiceResult, missingField, notFound, operationFailed } from '@/services/service-errors'
 
 const execAsync = promisify(exec)
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number // HTTP-like status code for the route to use
-}
 
 // -- Config types --
 
@@ -478,10 +469,7 @@ export function getSubconsciousStatus(): ServiceResult<any> {
     }
   } catch (error) {
     console.error('[Subconscious API] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get subconscious status', (error as Error).message)
   }
 }
 
@@ -560,10 +548,7 @@ export async function getPtyDebugInfo(): Promise<ServiceResult<PtyDebugInfo>> {
     }
   } catch (error) {
     console.error('[Debug PTY] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get PTY debug info', (error as Error).message)
   }
 }
 
@@ -603,18 +588,12 @@ export async function getDockerInfo(): Promise<ServiceResult<DockerInfo>> {
 export function parseConversationFile(conversationFile: string): ServiceResult<ParsedConversation> {
   if (!conversationFile) {
     console.error('[Parse Conversation] Missing conversationFile parameter')
-    return {
-      error: 'conversationFile is required',
-      status: 400,
-    }
+    return missingField('conversationFile')
   }
 
   if (!fs.existsSync(conversationFile)) {
     console.error('[Parse Conversation] File not found:', conversationFile)
-    return {
-      error: `Conversation file not found: ${conversationFile}`,
-      status: 404,
-    }
+    return notFound('Conversation file', conversationFile)
   }
 
   try {
@@ -738,10 +717,7 @@ export function parseConversationFile(conversationFile: string): ServiceResult<P
     }
   } catch (error) {
     console.error('[Parse Conversation] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('parse conversation file', (error as Error).message)
   }
 }
 
@@ -757,10 +733,7 @@ export async function getConversationMessages(
   agentId: string
 ): Promise<ServiceResult<ConversationMessages | { error: string; fallback_to_parse: boolean; conversation_file: string }>> {
   if (!agentId) {
-    return {
-      error: 'agentId query parameter is required',
-      status: 400,
-    }
+    return missingField('agentId')
   }
 
   try {
@@ -812,10 +785,7 @@ export async function getConversationMessages(
     }
   } catch (error) {
     console.error('[Messages API] Error:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get conversation messages', (error as Error).message)
   }
 }
 
@@ -832,10 +802,7 @@ export function getExportJobStatus(jobId: string): ServiceResult<{
   message: string
 }> {
   if (!jobId || typeof jobId !== 'string') {
-    return {
-      error: 'Invalid job ID',
-      status: 400,
-    }
+    return missingField('jobId')
   }
 
   console.log(`[Export Jobs API] Get status: Job=${jobId}`)
@@ -876,10 +843,7 @@ export function deleteExportJob(jobId: string): ServiceResult<{
   message: string
 }> {
   if (!jobId || typeof jobId !== 'string') {
-    return {
-      error: 'Invalid job ID',
-      status: 400,
-    }
+    return missingField('jobId')
   }
 
   console.log(`[Export Jobs API] Delete job: Job=${jobId}`)

--- a/services/diagnostics-service.ts
+++ b/services/diagnostics-service.ts
@@ -24,18 +24,13 @@ import path from 'path'
 import os from 'os'
 import { getHosts, isSelf } from '@/lib/hosts-config'
 import { loadAgents } from '@/lib/agent-registry'
+import { type ServiceResult } from '@/services/service-errors'
 
 const execAsync = promisify(exec)
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number
-}
 
 export type DiagnosticStatus = 'pass' | 'fail' | 'warn'
 

--- a/services/domains-service.ts
+++ b/services/domains-service.ts
@@ -15,16 +15,11 @@
 
 import { listDomains, createDomain, getDomain, updateDomain, deleteDomain } from '@/lib/domain-service'
 import type { CreateDomainRequest } from '@/types/agent'
+import { type ServiceResult, missingField, notFound, alreadyExists, invalidField, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
 
 export interface UpdateDomainParams {
   description?: string
@@ -44,7 +39,7 @@ export function listAllDomains(): ServiceResult<{ domains: any[] }> {
     return { data: { domains }, status: 200 }
   } catch (error) {
     console.error('Failed to list domains:', error)
-    return { error: 'Failed to list domains', status: 500 }
+    return operationFailed('list domains')
   }
 }
 
@@ -54,7 +49,7 @@ export function listAllDomains(): ServiceResult<{ domains: any[] }> {
 export function createNewDomain(body: CreateDomainRequest): ServiceResult<{ domain: any }> {
   // Validate required fields
   if (!body.domain) {
-    return { error: 'Domain is required', status: 400 }
+    return missingField('domain')
   }
 
   try {
@@ -64,15 +59,15 @@ export function createNewDomain(body: CreateDomainRequest): ServiceResult<{ doma
     const message = error instanceof Error ? error.message : 'Failed to create domain'
 
     if (message.includes('already exists')) {
-      return { error: message, status: 409 }
+      return alreadyExists('Domain', body.domain)
     }
 
     if (message.includes('Invalid domain')) {
-      return { error: message, status: 400 }
+      return invalidField('domain', message)
     }
 
     console.error('Failed to create domain:', error)
-    return { error: message, status: 500 }
+    return operationFailed('create domain', message)
   }
 }
 
@@ -84,13 +79,13 @@ export function getDomainById(id: string): ServiceResult<{ domain: any }> {
     const domain = getDomain(id)
 
     if (!domain) {
-      return { error: 'Domain not found', status: 404 }
+      return notFound('Domain', id)
     }
 
     return { data: { domain }, status: 200 }
   } catch (error) {
     console.error('Failed to get domain:', error)
-    return { error: 'Failed to get domain', status: 500 }
+    return operationFailed('get domain')
   }
 }
 
@@ -105,13 +100,13 @@ export function updateDomainById(id: string, params: UpdateDomainParams): Servic
     })
 
     if (!domain) {
-      return { error: 'Domain not found', status: 404 }
+      return notFound('Domain', id)
     }
 
     return { data: { domain }, status: 200 }
   } catch (error) {
     console.error('Failed to update domain:', error)
-    return { error: 'Failed to update domain', status: 500 }
+    return operationFailed('update domain')
   }
 }
 
@@ -123,12 +118,12 @@ export function deleteDomainById(id: string): ServiceResult<{ success: boolean }
     const success = deleteDomain(id)
 
     if (!success) {
-      return { error: 'Domain not found', status: 404 }
+      return notFound('Domain', id)
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
     console.error('Failed to delete domain:', error)
-    return { error: 'Failed to delete domain', status: 500 }
+    return operationFailed('delete domain')
   }
 }

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -315,10 +315,11 @@ function sendBinary(res: ServerResponse, statusCode: number, buffer: Buffer | Ui
 }
 
 function sendServiceResult(res: ServerResponse, result: any) {
-  if (result.error && !result.data) {
-    sendJson(res, result.status || 500, { error: result.error }, result.headers)
-  } else {
+  if (result.data !== undefined) {
     sendJson(res, result.status || 200, result.data, result.headers)
+  } else {
+    const fallbackStatus = (result.status && result.status >= 400) ? result.status : 500
+    sendJson(res, fallbackStatus, { error: 'internal_error', message: 'Unknown error' }, result.headers)
   }
 }
 
@@ -820,8 +821,8 @@ const routes: Route[] = [
   { method: 'GET', pattern: /^\/api\/agents\/([^/]+)\/export$/, paramNames: ['id'], handler: async (_req, res, params) => {
     try {
       const result = await exportAgentZip(params.id)
-      if (result.error || !result.data) {
-        sendJson(res, result.status, { error: result.error })
+      if (!result.data || 'error' in result.data) {
+        sendServiceResult(res, result)
         return
       }
       const { buffer, filename, agentId, agentName } = result.data
@@ -910,25 +911,25 @@ const routes: Route[] = [
   // Metadata (uses agents-core-service getAgentById/updateAgentById)
   { method: 'GET', pattern: /^\/api\/agents\/([^/]+)\/metadata$/, paramNames: ['id'], handler: async (_req, res, params) => {
     const result = getAgentById(params.id)
-    if (result.error) {
-      sendJson(res, result.status, { error: result.error })
+    if (!result.data || 'error' in result.data) {
+      sendServiceResult(res, result)
     } else {
-      sendJson(res, 200, { metadata: result.data?.agent?.metadata || {} })
+      sendJson(res, 200, { metadata: result.data.agent?.metadata || {} })
     }
   }},
   { method: 'PATCH', pattern: /^\/api\/agents\/([^/]+)\/metadata$/, paramNames: ['id'], handler: async (req, res, params) => {
     const metadata = await readJsonBody(req)
     const result = updateAgentById(params.id, { metadata })
-    if (result.error) {
-      sendJson(res, result.status, { error: result.error })
+    if (!result.data || 'error' in result.data) {
+      sendServiceResult(res, result)
     } else {
-      sendJson(res, 200, { metadata: result.data?.agent?.metadata })
+      sendJson(res, 200, { metadata: result.data.agent?.metadata })
     }
   }},
   { method: 'DELETE', pattern: /^\/api\/agents\/([^/]+)\/metadata$/, paramNames: ['id'], handler: async (_req, res, params) => {
     const result = updateAgentById(params.id, { metadata: {} })
-    if (result.error) {
-      sendJson(res, result.status, { error: result.error })
+    if (!result.data || 'error' in result.data) {
+      sendServiceResult(res, result)
     } else {
       sendJson(res, 200, { success: true })
     }

--- a/services/help-service.ts
+++ b/services/help-service.ts
@@ -17,16 +17,7 @@ import { tmpdir } from 'os'
 import { getAgentByName, createAgent, deleteAgent } from '@/lib/agent-registry'
 import { parseNameForDisplay } from '@/types/agent'
 import { getRuntime } from '@/lib/agent-runtime'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
+import { type ServiceResult, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -175,17 +166,7 @@ export async function createAssistantAgent(): Promise<ServiceResult<{
     }
   } catch (error) {
     console.error('[Help Agent] Failed to create assistant:', error)
-    return {
-      data: {
-        success: false,
-        agentId: '',
-        name: ASSISTANT_NAME,
-        status: 'error',
-        created: false,
-      },
-      error: error instanceof Error ? error.message : 'Failed to create assistant',
-      status: 500,
-    }
+    return operationFailed('create assistant', (error as Error).message)
   }
 }
 
@@ -210,10 +191,7 @@ export async function deleteAssistantAgent(): Promise<ServiceResult<{ success: b
     return { data: { success: true }, status: 200 }
   } catch (error) {
     console.error('[Help Agent] Failed to delete assistant:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Failed to delete assistant',
-      status: 500,
-    }
+    return operationFailed('delete assistant', (error as Error).message)
   }
 }
 
@@ -252,9 +230,6 @@ export async function getAssistantStatus(): Promise<ServiceResult<{
       status: 200,
     }
   } catch (error) {
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get assistant status', (error as Error).message)
   }
 }

--- a/services/hosts-service.ts
+++ b/services/hosts-service.ts
@@ -49,18 +49,9 @@ import type {
   HostIdentity,
   HostIdentityResponse,
 } from '@/types/host-sync'
+import { type ServiceResult, missingField, invalidField, notFound, operationFailed, invalidRequest } from '@/services/service-errors'
 
 const execAsync = promisify(exec)
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -325,7 +316,7 @@ export async function listHosts(): Promise<ServiceResult<{ hosts: any[] }>> {
     return { data: { hosts: hostsWithSelf }, status: 200 }
   } catch (error) {
     console.error('[Hosts API] Failed to fetch hosts:', error)
-    return { error: 'Failed to fetch hosts', status: 500 }
+    return operationFailed('fetch hosts')
   }
 }
 
@@ -344,19 +335,19 @@ export async function addNewHost(params: AddHostParams): Promise<ServiceResult<a
 
     // Validate required fields
     if (!host.id || !host.name || !host.url || !host.type) {
-      return { error: 'Missing required fields: id, name, url, type', status: 400 }
+      return invalidRequest('Missing required fields: id, name, url, type')
     }
 
     // Validate ID format (alphanumeric, dash, underscore)
     if (!/^[a-zA-Z0-9_-]+$/.test(host.id)) {
-      return { error: 'Host ID can only contain letters, numbers, dashes, and underscores', status: 400 }
+      return invalidField('id', 'Host ID can only contain letters, numbers, dashes, and underscores')
     }
 
     // Validate URL format
     try {
       new URL(host.url)
     } catch {
-      return { error: 'Invalid URL format', status: 400 }
+      return invalidField('url', 'Invalid URL format')
     }
 
     // Use sync-enabled add for remote hosts, regular add for local
@@ -381,7 +372,7 @@ export async function addNewHost(params: AddHostParams): Promise<ServiceResult<a
       // Legacy: local-only add (for local host or when sync disabled)
       const result = addHost(host)
       if (!result.success) {
-        return { error: result.error, status: 400 }
+        return invalidRequest(result.error || 'Failed to add host')
       }
 
       return {
@@ -395,7 +386,7 @@ export async function addNewHost(params: AddHostParams): Promise<ServiceResult<a
     }
   } catch (error) {
     console.error('[Hosts API] Failed to add host:', error)
-    return { error: 'Failed to add host', status: 500 }
+    return operationFailed('add host')
   }
 }
 
@@ -413,19 +404,21 @@ export async function updateExistingHost(
       try {
         new URL(hostData.url)
       } catch {
-        return { error: 'Invalid URL format', status: 400 }
+        return invalidField('url', 'Invalid URL format')
       }
     }
 
     const result = updateHost(id, hostData)
     if (!result.success) {
-      return { error: result.error, status: result.error?.includes('not found') ? 404 : 400 }
+      return result.error?.includes('not found')
+        ? notFound('Host', id)
+        : invalidRequest(result.error || 'Failed to update host')
     }
 
     return { data: { success: true, host: result.host }, status: 200 }
   } catch (error) {
     console.error(`[Hosts API] Failed to update host:`, error)
-    return { error: 'Failed to update host', status: 500 }
+    return operationFailed('update host')
   }
 }
 
@@ -437,13 +430,15 @@ export async function deleteExistingHost(id: string): Promise<ServiceResult<{ su
   try {
     const result = deleteHost(id)
     if (!result.success) {
-      return { error: result.error, status: result.error?.includes('not found') ? 404 : 400 }
+      return result.error?.includes('not found')
+        ? notFound('Host', id)
+        : invalidRequest(result.error || 'Failed to delete host')
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
     console.error(`[Hosts API] Failed to delete host:`, error)
-    return { error: 'Failed to delete host', status: 500 }
+    return operationFailed('delete host')
   }
 }
 
@@ -488,7 +483,7 @@ export function getHostIdentity(): ServiceResult<HostIdentityResponse> {
 export async function checkRemoteHealth(hostUrl: string): Promise<ServiceResult<any>> {
   try {
     if (!hostUrl) {
-      return { error: 'url query parameter is required', status: 400 }
+      return missingField('url')
     }
 
     // Validate URL format
@@ -496,7 +491,7 @@ export async function checkRemoteHealth(hostUrl: string): Promise<ServiceResult<
     try {
       parsedUrl = new URL(hostUrl)
     } catch {
-      return { error: 'Invalid URL format', status: 400 }
+      return invalidField('url', 'Invalid URL format')
     }
 
     // Make health check request using fetch
@@ -589,10 +584,7 @@ export async function triggerMeshSync(): Promise<ServiceResult<any>> {
     }
   } catch (error) {
     console.error('[Mesh Sync] Error during manual sync:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('mesh sync', (error as Error).message)
   }
 }
 
@@ -663,10 +655,7 @@ export async function getMeshStatus(): Promise<ServiceResult<any>> {
     }
   } catch (error) {
     console.error('[Mesh Status] Error getting mesh status:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      status: 500,
-    }
+    return operationFailed('get mesh status', (error as Error).message)
   }
 }
 

--- a/services/marketplace-service.ts
+++ b/services/marketplace-service.ts
@@ -16,16 +16,7 @@ import {
   getSkillById,
 } from '@/lib/marketplace-skills'
 import type { SkillSearchParams } from '@/types/marketplace'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
+import { type ServiceResult, operationFailed, invalidFormat, notFound } from '@/services/service-errors'
 
 // ===========================================================================
 // PUBLIC API -- called by API routes
@@ -59,10 +50,7 @@ export async function listMarketplaceSkills(params: SkillSearchParams): Promise<
     return { data: result, status: 200 }
   } catch (error) {
     console.error('Error fetching marketplace skills:', error)
-    return {
-      error: 'Failed to fetch marketplace skills',
-      status: 500,
-    }
+    return operationFailed('fetch marketplace skills')
   }
 }
 
@@ -77,25 +65,19 @@ export async function getMarketplaceSkillById(rawId: string): Promise<ServiceRes
     // Validate format
     const parts = skillId.split(':')
     if (parts.length !== 3) {
-      return {
-        error: 'Invalid skill ID format. Skill ID must be in format: marketplace:plugin:skill',
-        status: 400,
-      }
+      return invalidFormat('skillId', 'Skill ID must be in format: marketplace:plugin:skill')
     }
 
     // Get the skill with full content
     const skill = await getSkillById(skillId, true)
 
     if (!skill) {
-      return { error: 'Skill not found', status: 404 }
+      return notFound('Skill')
     }
 
     return { data: skill, status: 200 }
   } catch (error) {
     console.error('Error fetching skill:', error)
-    return {
-      error: 'Failed to fetch skill',
-      status: 500,
-    }
+    return operationFailed('fetch skill')
   }
 }

--- a/services/messages-service.ts
+++ b/services/messages-service.ts
@@ -45,16 +45,7 @@ import {
   deleteMeeting,
 } from '@/lib/meeting-registry'
 import type { SidebarMode } from '@/types/team'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number // HTTP-like status code for the route to use
-}
+import { type ServiceResult, missingField, notFound, invalidRequest, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Messages: GET /api/messages
@@ -84,7 +75,7 @@ export async function getMessages(params: GetMessagesParams): Promise<ServiceRes
   if (action === 'resolve' && agentIdentifier) {
     const resolved = resolveAgentIdentifier(agentIdentifier)
     if (!resolved) {
-      return { data: { error: 'Agent not found', resolved: null }, error: 'Agent not found', status: 404 }
+      return notFound('Agent', agentIdentifier || undefined)
     }
     return { data: { resolved }, status: 200 }
   }
@@ -119,7 +110,7 @@ export async function getMessages(params: GetMessagesParams): Promise<ServiceRes
   if (agentIdentifier && messageId) {
     const message = await getMessage(agentIdentifier, messageId, box as 'inbox' | 'sent')
     if (!message) {
-      return { error: 'Message not found', status: 404 }
+      return notFound('Message', messageId)
     }
     return { data: message, status: 200 }
   }
@@ -150,7 +141,7 @@ export async function getMessages(params: GetMessagesParams): Promise<ServiceRes
 
   // List messages for an agent
   if (!agentIdentifier) {
-    return { error: 'Agent identifier required (agent ID, alias, or session name)', status: 400 }
+    return missingField('agent')
   }
 
   // Parse limit parameter (default: 25 for performance, 0 = unlimited)
@@ -206,12 +197,12 @@ export async function sendMessage(params: SendMessageParams): Promise<ServiceRes
 
   // Validate required fields
   if (!from || !to || !subject || !content) {
-    return { error: 'Missing required fields: from, to, subject, content', status: 400 }
+    return invalidRequest('Missing required fields: from, to, subject, content')
   }
 
   // Validate content structure
   if (!content.type || !content.message) {
-    return { error: 'Content must have type and message fields', status: 400 }
+    return invalidRequest('Content must have type and message fields')
   }
 
   try {
@@ -240,8 +231,7 @@ export async function sendMessage(params: SendMessageParams): Promise<ServiceRes
     }
   } catch (error) {
     console.error('Error sending message:', error)
-    const errorMessage = error instanceof Error ? error.message : 'Failed to send message'
-    return { error: errorMessage, status: 500 }
+    return operationFailed('send message', (error as Error).message)
   }
 }
 
@@ -255,7 +245,7 @@ export async function updateMessage(
   action: string | null,
 ): Promise<ServiceResult<{ success: boolean }>> {
   if (!agentIdentifier || !messageId) {
-    return { error: 'Agent identifier and message ID required', status: 400 }
+    return invalidRequest('Agent identifier and message ID required')
   }
 
   try {
@@ -269,17 +259,17 @@ export async function updateMessage(
         success = await archiveMessage(agentIdentifier, messageId)
         break
       default:
-        return { error: 'Invalid action', status: 400 }
+        return invalidRequest('Invalid action')
     }
 
     if (!success) {
-      return { error: 'Message not found', status: 404 }
+      return notFound('Message', messageId)
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
     console.error('Error updating message:', error)
-    return { error: 'Failed to update message', status: 500 }
+    return operationFailed('update message', (error as Error).message)
   }
 }
 
@@ -292,20 +282,20 @@ export async function removeMessage(
   messageId: string | null,
 ): Promise<ServiceResult<{ success: boolean }>> {
   if (!agentIdentifier || !messageId) {
-    return { error: 'Agent identifier and message ID required', status: 400 }
+    return invalidRequest('Agent identifier and message ID required')
   }
 
   try {
     const success = await deleteMessage(agentIdentifier, messageId)
 
     if (!success) {
-      return { error: 'Message not found', status: 404 }
+      return notFound('Message', messageId)
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
     console.error('Error deleting message:', error)
-    return { error: 'Failed to delete message', status: 500 }
+    return operationFailed('delete message', (error as Error).message)
   }
 }
 
@@ -326,15 +316,12 @@ export async function forwardMessage(params: ForwardMessageParams): Promise<Serv
 
   // Validate required fields
   if ((!messageId && !originalMessage) || !fromSession || !toSession) {
-    return {
-      error: 'Either messageId or originalMessage, plus fromSession and toSession are required',
-      status: 400,
-    }
+    return invalidRequest('Either messageId or originalMessage, plus fromSession and toSession are required')
   }
 
   // Validate that from and to sessions are different
   if (fromSession === toSession) {
-    return { error: 'Cannot forward message to the same session', status: 400 }
+    return invalidRequest('Cannot forward message to the same session')
   }
 
   try {
@@ -360,10 +347,7 @@ export async function forwardMessage(params: ForwardMessageParams): Promise<Serv
     }
   } catch (error) {
     console.error('Error forwarding message:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Failed to forward message',
-      status: 500,
-    }
+    return operationFailed('forward message', (error as Error).message)
   }
 }
 
@@ -383,10 +367,10 @@ export async function getMeetingMessages(
   const { meetingId, participants: participantsParam, since } = params
 
   if (!meetingId) {
-    return { error: 'meetingId is required', status: 400 }
+    return missingField('meetingId')
   }
   if (!participantsParam) {
-    return { error: 'participants is required', status: 400 }
+    return missingField('participants')
   }
 
   const participantIds = participantsParam.split(',').filter(Boolean)
@@ -476,11 +460,11 @@ export function createNewMeeting(
   const { name, agentIds, teamId, sidebarMode } = params
 
   if (!name || typeof name !== 'string') {
-    return { error: 'Meeting name is required', status: 400 }
+    return missingField('name')
   }
 
   if (!agentIds || !Array.isArray(agentIds) || agentIds.length === 0) {
-    return { error: 'At least one agent is required', status: 400 }
+    return invalidRequest('At least one agent is required')
   }
 
   try {
@@ -493,10 +477,7 @@ export function createNewMeeting(
     return { data: { meeting }, status: 201 }
   } catch (error) {
     console.error('Failed to create meeting:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Failed to create meeting',
-      status: 500,
-    }
+    return operationFailed('create meeting', (error as Error).message)
   }
 }
 
@@ -507,7 +488,7 @@ export function createNewMeeting(
 export function getMeetingById(id: string): ServiceResult<{ meeting: any }> {
   const meeting = getMeeting(id)
   if (!meeting) {
-    return { error: 'Meeting not found', status: 404 }
+    return notFound('Meeting', id)
   }
   return { data: { meeting }, status: 200 }
 }
@@ -543,16 +524,13 @@ export function updateExistingMeeting(
       teamId: updates.teamId,
     })
     if (!meeting) {
-      return { error: 'Meeting not found', status: 404 }
+      return notFound('Meeting', id)
     }
 
     return { data: { meeting }, status: 200 }
   } catch (error) {
     console.error('Failed to update meeting:', error)
-    return {
-      error: error instanceof Error ? error.message : 'Failed to update meeting',
-      status: 500,
-    }
+    return operationFailed('update meeting', (error as Error).message)
   }
 }
 
@@ -563,7 +541,7 @@ export function updateExistingMeeting(
 export function deleteExistingMeeting(id: string): ServiceResult<{ success: boolean }> {
   const deleted = deleteMeeting(id)
   if (!deleted) {
-    return { error: 'Meeting not found', status: 404 }
+    return notFound('Meeting', id)
   }
   return { data: { success: true }, status: 200 }
 }

--- a/services/plugin-builder-service.ts
+++ b/services/plugin-builder-service.ts
@@ -18,7 +18,7 @@ import os from 'os'
 import { execFile } from 'child_process'
 import { randomUUID } from 'crypto'
 import matter from 'gray-matter'
-import type { ServiceResult } from '@/services/marketplace-service'
+import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed } from '@/services/service-errors'
 import type {
   PluginBuildConfig,
   PluginBuildResult,
@@ -308,12 +308,12 @@ export async function buildPlugin(config: PluginBuildConfig): Promise<ServiceRes
   // Validate inputs (protects both Next.js routes and headless router)
   const validationError = validateBuildConfig(config)
   if (validationError) {
-    return { error: validationError, status: 400 }
+    return invalidRequest(validationError)
   }
 
   // Concurrency guard
   if (activeOps >= MAX_CONCURRENT_OPS) {
-    return { error: 'Too many concurrent builds. Please wait and try again.', status: 429 }
+    return invalidRequest('Too many concurrent builds. Please wait and try again.')
   }
 
   try {
@@ -383,7 +383,7 @@ export async function buildPlugin(config: PluginBuildConfig): Promise<ServiceRes
   } catch (error) {
     activeOps = Math.max(0, activeOps - 1)
     console.error('Error starting plugin build:', error)
-    return { error: 'Failed to start plugin build', status: 500 }
+    return operationFailed('start plugin build')
   }
 }
 
@@ -392,11 +392,11 @@ export async function buildPlugin(config: PluginBuildConfig): Promise<ServiceRes
  */
 export async function getBuildStatus(buildId: string): Promise<ServiceResult<PluginBuildResult>> {
   if (!buildId || typeof buildId !== 'string') {
-    return { error: 'Build ID is required', status: 400 }
+    return missingField('buildId')
   }
   const result = buildResults.get(buildId)
   if (!result) {
-    return { error: 'Build not found', status: 404 }
+    return notFound('Build', buildId)
   }
   return { data: result, status: 200 }
 }
@@ -408,15 +408,15 @@ export async function getBuildStatus(buildId: string): Promise<ServiceResult<Plu
 export async function scanRepo(url: string, ref: string = 'main'): Promise<ServiceResult<RepoScanResult>> {
   // Validate URL
   const urlErr = validateGitUrl(url)
-  if (urlErr) return { error: urlErr, status: 400 }
+  if (urlErr) return invalidField('url', urlErr)
 
   // Validate ref
   const refErr = validateGitRef(ref)
-  if (refErr) return { error: refErr, status: 400 }
+  if (refErr) return invalidField('ref', refErr)
 
   // Concurrency guard
   if (activeOps >= MAX_CONCURRENT_OPS) {
-    return { error: 'Too many concurrent operations. Please wait and try again.', status: 429 }
+    return invalidRequest('Too many concurrent operations. Please wait and try again.')
   }
 
   const scanId = randomUUID().slice(0, 8)
@@ -451,10 +451,10 @@ export async function scanRepo(url: string, ref: string = 'main'): Promise<Servi
     const message = error instanceof Error ? error.message : String(error)
 
     if (exitCode === 128 || message.includes('not found')) {
-      return { error: `Repository not found or access denied: ${url}`, status: 404 }
+      return notFound('Repository', url)
     }
     console.error('Error scanning repo:', error)
-    return { error: `Failed to scan repository: ${message}`, status: 500 }
+    return operationFailed('scan repository', message)
   } finally {
     activeOps = Math.max(0, activeOps - 1)
   }
@@ -466,24 +466,24 @@ export async function scanRepo(url: string, ref: string = 'main'): Promise<Servi
 export async function pushToGitHub(config: PluginPushConfig): Promise<ServiceResult<PluginPushResult>> {
   // Validate fork URL
   if (!config.forkUrl || typeof config.forkUrl !== 'string') {
-    return { error: 'Fork URL is required', status: 400 }
+    return missingField('forkUrl')
   }
   const urlErr = validateGitUrl(config.forkUrl)
-  if (urlErr) return { error: urlErr, status: 400 }
+  if (urlErr) return invalidField('forkUrl', urlErr)
 
   // Validate manifest
   if (!config.manifest || typeof config.manifest !== 'object') {
-    return { error: 'Manifest is required', status: 400 }
+    return missingField('manifest')
   }
 
   // Validate branch
   const branch = config.branch || 'main'
   const refErr = validateGitRef(branch)
-  if (refErr) return { error: refErr, status: 400 }
+  if (refErr) return invalidField('branch', refErr)
 
   // Concurrency guard
   if (activeOps >= MAX_CONCURRENT_OPS) {
-    return { error: 'Too many concurrent operations. Please wait and try again.', status: 429 }
+    return invalidRequest('Too many concurrent operations. Please wait and try again.')
   }
 
   const pushId = randomUUID().slice(0, 8)
@@ -543,7 +543,7 @@ export async function pushToGitHub(config: PluginPushConfig): Promise<ServiceRes
     await fs.rm(pushDir, { recursive: true, force: true }).catch(() => {})
     const message = error instanceof Error ? error.message : String(error)
     console.error('Error pushing to GitHub:', error)
-    return { error: `Failed to push to GitHub: ${message}`, status: 500 }
+    return operationFailed('push to GitHub', message)
   } finally {
     activeOps = Math.max(0, activeOps - 1)
   }

--- a/services/service-errors.ts
+++ b/services/service-errors.ts
@@ -1,0 +1,281 @@
+/**
+ * Service Errors — Single source of truth
+ *
+ * Unified error types, factory functions, and validation helpers for all services.
+ * Follows the AMP error format: { error: 'code', message: 'Human text', field?, details? }
+ *
+ * Usage in services:
+ *   import { ServiceResult, missingField, notFound, requireString } from '@/services/service-errors'
+ *
+ * Usage in routes:
+ *   import { toResponse } from '@/app/api/_helpers'
+ */
+
+// ============================================================================
+// Error Codes
+// ============================================================================
+
+/**
+ * All service error codes — superset of AMP's 18 codes + generic codes.
+ */
+export type ServiceErrorCode =
+  // AMP protocol codes (18)
+  | 'invalid_request'
+  | 'missing_field'
+  | 'invalid_field'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'not_found'
+  | 'name_taken'
+  | 'rate_limited'
+  | 'internal_error'
+  | 'invalid_signature'
+  | 'agent_not_found'
+  | 'tenant_access_denied'
+  | 'organization_not_set'
+  | 'external_provider'
+  | 'payload_too_large'
+  | 'missing_header'
+  | 'duplicate_message'
+  | 'key_already_registered'
+  // Generic codes (12)
+  | 'already_exists'
+  | 'gone'
+  | 'invalid_state'
+  | 'circular_dependency'
+  | 'self_reference'
+  | 'operation_failed'
+  | 'timeout'
+  | 'method_not_allowed'
+  | 'invalid_format'
+  | 'access_denied'
+  | 'precondition_failed'
+  | 'not_initialized'
+
+// ============================================================================
+// Error & Result Types
+// ============================================================================
+
+/**
+ * Structured error — the shape returned to API consumers.
+ */
+export interface ServiceError {
+  error: ServiceErrorCode
+  message: string
+  field?: string
+  details?: Record<string, unknown>
+}
+
+/**
+ * Unified result type for all services.
+ *
+ * On success: { data: T, status: 2xx }
+ * On error:   { data: ServiceError, status: 4xx/5xx }
+ */
+export interface ServiceResult<T> {
+  data?: T | ServiceError
+  status: number
+  headers?: Record<string, string>
+}
+
+// ============================================================================
+// Type Guard
+// ============================================================================
+
+/**
+ * Check if a ServiceResult's data is a ServiceError.
+ */
+export function isServiceError(data: unknown): data is ServiceError {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'error' in data &&
+    'message' in data &&
+    typeof (data as ServiceError).error === 'string' &&
+    typeof (data as ServiceError).message === 'string'
+  )
+}
+
+// ============================================================================
+// Factory Functions
+// ============================================================================
+
+/**
+ * Create a custom ServiceError result.
+ */
+export function serviceError(
+  code: ServiceErrorCode,
+  message: string,
+  status: number,
+  opts?: { field?: string; details?: Record<string, unknown> }
+): ServiceResult<never> {
+  const err: ServiceError = { error: code, message }
+  if (opts?.field) err.field = opts.field
+  if (opts?.details) err.details = opts.details
+  return { data: err, status }
+}
+
+/** 400 — Required field is missing or empty. */
+export function missingField(field: string): ServiceResult<never> {
+  return serviceError('missing_field', `${field} is required`, 400, { field })
+}
+
+/** 400 — Field value is invalid. */
+export function invalidField(field: string, reason: string): ServiceResult<never> {
+  return serviceError('invalid_field', reason, 400, { field })
+}
+
+/** 400 — Invalid request (generic). */
+export function invalidRequest(message: string): ServiceResult<never> {
+  return serviceError('invalid_request', message, 400)
+}
+
+/** 404 — Entity not found. */
+export function notFound(entity: string, id?: string): ServiceResult<never> {
+  const msg = id ? `${entity} '${id}' not found` : `${entity} not found`
+  return serviceError('not_found', msg, 404)
+}
+
+/** 409 — Entity already exists. */
+export function alreadyExists(entity: string, name?: string): ServiceResult<never> {
+  const msg = name ? `${entity} '${name}' already exists` : `${entity} already exists`
+  return serviceError('already_exists', msg, 409)
+}
+
+/** 410 — Entity has been deleted. */
+export function gone(entity: string): ServiceResult<never> {
+  return serviceError('gone', `${entity} has been deleted`, 410)
+}
+
+/** 400 — Invalid state for the requested operation. */
+export function invalidState(message: string): ServiceResult<never> {
+  return serviceError('invalid_state', message, 400)
+}
+
+/** 400 — Not initialized. */
+export function notInitialized(what: string): ServiceResult<never> {
+  return serviceError('not_initialized', `${what} not initialized`, 400)
+}
+
+/** 400 — Circular dependency. */
+export function circularDependency(message: string): ServiceResult<never> {
+  return serviceError('circular_dependency', message, 400)
+}
+
+/** 400 — Self reference. */
+export function selfReference(message: string): ServiceResult<never> {
+  return serviceError('self_reference', message, 400)
+}
+
+/** 400 — Invalid format. */
+export function invalidFormat(field: string, reason: string): ServiceResult<never> {
+  return serviceError('invalid_format', reason, 400, { field })
+}
+
+/** 412 — Precondition failed. */
+export function preconditionFailed(message: string): ServiceResult<never> {
+  return serviceError('precondition_failed', message, 412)
+}
+
+/** 401 — Unauthorized. */
+export function unauthorized(message = 'Authentication required'): ServiceResult<never> {
+  return serviceError('unauthorized', message, 401)
+}
+
+/** 403 — Forbidden / access denied. */
+export function accessDenied(message = 'Access denied'): ServiceResult<never> {
+  return serviceError('access_denied', message, 403)
+}
+
+/** 403 — Forbidden (AMP-style). */
+export function forbidden(message = 'Forbidden'): ServiceResult<never> {
+  return serviceError('forbidden', message, 403)
+}
+
+/** 405 — Method not allowed. */
+export function methodNotAllowed(method: string): ServiceResult<never> {
+  return serviceError('method_not_allowed', `Method ${method} not allowed`, 405)
+}
+
+/** 409 — Name already taken. */
+export function nameTaken(name: string, suggestions?: string[]): ServiceResult<never> {
+  return serviceError('name_taken', `Name '${name}' is already taken`, 409, {
+    details: suggestions ? { suggestions } : undefined,
+  })
+}
+
+/** 413 — Payload too large. */
+export function payloadTooLarge(message: string): ServiceResult<never> {
+  return serviceError('payload_too_large', message, 413)
+}
+
+/** 429 — Rate limited. */
+export function rateLimited(message = 'Too many requests'): ServiceResult<never> {
+  return serviceError('rate_limited', message, 429)
+}
+
+/** 500 — Operation failed (catch-all for "Failed to X"). */
+export function operationFailed(operation: string, cause?: string): ServiceResult<never> {
+  const msg = cause ? `Failed to ${operation}: ${cause}` : `Failed to ${operation}`
+  return serviceError('operation_failed', msg, 500)
+}
+
+/** 500 — Internal error. */
+export function internalError(message = 'Internal server error'): ServiceResult<never> {
+  return serviceError('internal_error', message, 500)
+}
+
+/** 504 — Timeout. */
+export function timeout(message = 'Operation timed out'): ServiceResult<never> {
+  return serviceError('timeout', message, 504)
+}
+
+// ============================================================================
+// Validation Helpers
+// ============================================================================
+
+/**
+ * Validate that a value is a non-empty string.
+ * Returns a ServiceResult error if invalid, or null if valid.
+ */
+export function requireString(value: unknown, fieldName: string): ServiceResult<never> | null {
+  if (!value || typeof value !== 'string' || value.trim() === '') {
+    return missingField(fieldName)
+  }
+  return null
+}
+
+/**
+ * Validate that a value is an array.
+ * Returns a ServiceResult error if invalid, or null if valid.
+ */
+export function requireArray(value: unknown, fieldName: string): ServiceResult<never> | null {
+  if (!Array.isArray(value)) {
+    return invalidField(fieldName, `${fieldName} must be an array`)
+  }
+  return null
+}
+
+/**
+ * Validate that a name matches the allowed format (letters, numbers, dashes, underscores).
+ * Returns a ServiceResult error if invalid, or null if valid.
+ */
+export function requireNameFormat(value: string, fieldName: string): ServiceResult<never> | null {
+  if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+    return invalidField(fieldName, `${fieldName} must only contain letters, numbers, dashes, and underscores`)
+  }
+  return null
+}
+
+// ============================================================================
+// Success Helper
+// ============================================================================
+
+/**
+ * Create a success result. Convenience for `{ data, status }`.
+ */
+export function ok<T>(data: T, status = 200, headers?: Record<string, string>): ServiceResult<T> {
+  const result: ServiceResult<T> = { data, status }
+  if (headers) result.headers = headers
+  return result
+}

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -36,19 +36,10 @@ import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { sessionActivity, broadcastStatusUpdate } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
 import crypto from 'crypto'
+import { type ServiceResult, missingField, notFound, alreadyExists, invalidField, operationFailed, serviceError } from '@/services/service-errors'
 
 const execAsync = promisify(exec)
 const execFileAsync = promisify(execFile)
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
 
 export type SessionActivityStatus = 'active' | 'idle' | 'waiting'
 
@@ -523,7 +514,7 @@ export function broadcastActivityUpdate(
   notificationType?: string
 ): ServiceResult<{ success: boolean }> {
   if (!sessionName) {
-    return { error: 'sessionName is required', status: 400 }
+    return missingField('sessionName')
   }
 
   broadcastStatusUpdate(sessionName, status, hookStatus, notificationType)
@@ -537,11 +528,11 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
   const { name, workingDirectory, agentId, hostId, label, avatar, programArgs, program } = params
 
   if (!name || typeof name !== 'string') {
-    return { error: 'Session name is required', status: 400 }
+    return missingField('name')
   }
 
   if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-    return { error: 'Session name can only contain letters, numbers, dashes, and underscores', status: 400 }
+    return invalidField('name', 'Session name can only contain letters, numbers, dashes, and underscores')
   }
 
   // Determine target host
@@ -567,15 +558,15 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
       console.error(`[Sessions] Failed to connect to ${targetHost.name} (${targetHost.url}):`, { message: errorMessage, causeCode, causeMessage })
 
       if (errorMessage.includes('aborted') || causeCode === 'ABORT_ERR') {
-        return { error: `Timeout connecting to ${targetHost.name}. Is the remote AI Maestro running?`, status: 504 }
+        return serviceError('timeout', `Timeout connecting to ${targetHost.name}. Is the remote AI Maestro running?`, 504)
       } else if (fullErrorText.includes('ECONNREFUSED') || causeCode === 'ECONNREFUSED') {
-        return { error: `Connection refused by ${targetHost.name}. Verify the remote AI Maestro is running on ${targetHost.url}`, status: 503 }
+        return serviceError('operation_failed', `Connection refused by ${targetHost.name}. Verify the remote AI Maestro is running on ${targetHost.url}`, 503)
       } else if (fullErrorText.includes('EHOSTUNREACH') || causeCode === 'EHOSTUNREACH') {
-        return { error: `Cannot reach ${targetHost.name} at ${targetHost.url}. Try again or check network.`, status: 503 }
+        return serviceError('operation_failed', `Cannot reach ${targetHost.name} at ${targetHost.url}. Try again or check network.`, 503)
       } else if (fullErrorText.includes('ENETUNREACH') || causeCode === 'ENETUNREACH') {
-        return { error: `Network unreachable to ${targetHost.name}. Are you on the same network/VPN?`, status: 503 }
+        return serviceError('operation_failed', `Network unreachable to ${targetHost.name}. Are you on the same network/VPN?`, 503)
       } else {
-        return { error: `Failed to connect to ${targetHost.name}: ${errorMessage} (${causeCode})`, status: 500 }
+        return operationFailed(`connect to ${targetHost.name}`, `${errorMessage} (${causeCode})`)
       }
     }
   }
@@ -586,9 +577,9 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
   const selfHostId = getSelfHostId()
   const actualSessionName = agentId ? `${agentId}@${selfHostId}` : normalizedName
 
-  const alreadyExists = await runtime.sessionExists(actualSessionName)
-  if (alreadyExists) {
-    return { error: 'Session already exists', status: 409 }
+  const sessionExists = await runtime.sessionExists(actualSessionName)
+  if (sessionExists) {
+    return alreadyExists('Session', actualSessionName)
   }
 
   const cwd = workingDirectory || process.cwd()
@@ -695,7 +686,7 @@ export async function deleteSession(sessionName: string): Promise<ServiceResult<
   const runtime = getRuntime()
   const exists = await runtime.sessionExists(sessionName)
   if (!exists) {
-    return { error: 'Session not found', status: 404 }
+    return notFound('Session', sessionName)
   }
 
   await runtime.killSession(sessionName)
@@ -710,10 +701,10 @@ export async function deleteSession(sessionName: string): Promise<ServiceResult<
  */
 export async function renameSession(oldName: string, newName: string): Promise<ServiceResult<{ success: boolean; oldName: string; newName: string; type?: string }>> {
   if (!newName || typeof newName !== 'string') {
-    return { error: 'New session name is required', status: 400 }
+    return missingField('newName')
   }
   if (!/^[a-zA-Z0-9_-]+$/.test(newName)) {
-    return { error: 'Session name can only contain letters, numbers, dashes, and underscores', status: 400 }
+    return invalidField('newName', 'Session name can only contain letters, numbers, dashes, and underscores')
   }
 
   // Check if cloud agent
@@ -724,7 +715,7 @@ export async function renameSession(oldName: string, newName: string): Promise<S
 
   if (isCloudAgent) {
     if (fs.existsSync(newAgentFilePath)) {
-      return { error: 'Agent name already exists', status: 409 }
+      return alreadyExists('Agent', newName)
     }
     const agentConfig = JSON.parse(fs.readFileSync(oldAgentFilePath, 'utf8'))
     agentConfig.id = newName
@@ -740,12 +731,12 @@ export async function renameSession(oldName: string, newName: string): Promise<S
   const runtime = getRuntime()
   const oldExists = await runtime.sessionExists(oldName)
   if (!oldExists) {
-    return { error: 'Session not found', status: 404 }
+    return notFound('Session', oldName)
   }
 
   const newExists = await runtime.sessionExists(newName)
   if (newExists) {
-    return { error: 'Session name already exists', status: 409 }
+    return alreadyExists('Session', newName)
   }
 
   await runtime.renameSession(oldName, newName)
@@ -766,23 +757,21 @@ export async function sendCommand(
   const addNewline = options.addNewline !== false
 
   if (!command || typeof command !== 'string') {
-    return { error: 'Command is required', status: 400 }
+    return missingField('command')
   }
 
   const runtime = getRuntime()
   const exists = await runtime.sessionExists(sessionName)
   if (!exists) {
-    return { error: 'Tmux session not found', status: 404 }
+    return notFound('Session', sessionName)
   }
 
   if (requireIdle && !isSessionIdle(sessionName)) {
     const lastActivity = sessionActivity.get(sessionName)
     const timeSinceActivity = lastActivity ? Date.now() - lastActivity : 0
-    return {
-      data: { success: false, sessionName, idle: false, timeSinceActivity, idleThreshold: IDLE_THRESHOLD_MS },
-      error: 'Session is not idle',
-      status: 409
-    }
+    return serviceError('invalid_state', 'Session is not idle', 409, {
+      details: { success: false, sessionName, idle: false, timeSinceActivity, idleThreshold: IDLE_THRESHOLD_MS }
+    })
   }
 
   await runtime.cancelCopyMode(sessionName)
@@ -841,7 +830,7 @@ export async function restoreSessions(params: { sessionId?: string; all?: boolea
     : persistedSessions.filter(s => s.id === params.sessionId)
 
   if (sessionsToRestore.length === 0) {
-    return { error: 'No sessions to restore', status: 404 }
+    return notFound('Session')
   }
 
   const runtime = getRuntime()
@@ -880,11 +869,11 @@ export async function restoreSessions(params: { sessionId?: string; all?: boolea
  */
 export function deletePersistedSession(sessionId: string): ServiceResult<{ success: boolean }> {
   if (!sessionId) {
-    return { error: 'Session ID is required', status: 400 }
+    return missingField('sessionId')
   }
   const success = unpersistSession(sessionId)
   if (!success) {
-    return { error: 'Failed to delete session', status: 500 }
+    return operationFailed('delete session')
   }
   return { data: { success: true }, status: 200 }
 }

--- a/services/teams-service.ts
+++ b/services/teams-service.ts
@@ -29,16 +29,7 @@ import { loadDocuments, createDocument, getDocument, updateDocument, deleteDocum
 import type { TaskStatus } from '@/types/task'
 import { getAgent } from '@/lib/agent-registry'
 import { notifyAgent } from '@/lib/notification-service'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
+import { type ServiceResult, missingField, notFound, invalidField, operationFailed, selfReference, circularDependency } from '@/services/service-errors'
 
 export interface CreateTeamParams {
   name: string
@@ -116,11 +107,11 @@ export function createNewTeam(params: CreateTeamParams): ServiceResult<{ team: a
   const { name, description, agentIds } = params
 
   if (!name || typeof name !== 'string') {
-    return { error: 'Team name is required', status: 400 }
+    return missingField('name')
   }
 
   if (agentIds && !Array.isArray(agentIds)) {
-    return { error: 'agentIds must be an array', status: 400 }
+    return invalidField('agentIds', 'agentIds must be an array')
   }
 
   try {
@@ -128,7 +119,7 @@ export function createNewTeam(params: CreateTeamParams): ServiceResult<{ team: a
     return { data: { team }, status: 201 }
   } catch (error) {
     console.error('Failed to create team:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to create team', status: 500 }
+    return operationFailed('create team', (error as Error).message)
   }
 }
 
@@ -138,7 +129,7 @@ export function createNewTeam(params: CreateTeamParams): ServiceResult<{ team: a
 export function getTeamById(id: string): ServiceResult<{ team: any }> {
   const team = getTeam(id)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', id)
   }
   return { data: { team }, status: 200 }
 }
@@ -158,12 +149,12 @@ export function updateTeamById(id: string, params: UpdateTeamParams): ServiceRes
     if (params.lastActivityAt !== undefined) updates.lastActivityAt = params.lastActivityAt
     const team = updateTeam(id, updates as any)
     if (!team) {
-      return { error: 'Team not found', status: 404 }
+      return notFound('Team', id)
     }
     return { data: { team }, status: 200 }
   } catch (error) {
     console.error('Failed to update team:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to update team', status: 500 }
+    return operationFailed('update team', (error as Error).message)
   }
 }
 
@@ -173,7 +164,7 @@ export function updateTeamById(id: string, params: UpdateTeamParams): ServiceRes
 export function deleteTeamById(id: string): ServiceResult<{ success: boolean }> {
   const deleted = deleteTeam(id)
   if (!deleted) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', id)
   }
   return { data: { success: true }, status: 200 }
 }
@@ -188,7 +179,7 @@ export function deleteTeamById(id: string): ServiceResult<{ success: boolean }> 
 export function listTeamTasks(teamId: string): ServiceResult<{ tasks: any[] }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const tasks = loadTasks(teamId)
@@ -202,19 +193,19 @@ export function listTeamTasks(teamId: string): ServiceResult<{ tasks: any[] }> {
 export function createTeamTask(teamId: string, params: CreateTaskParams): ServiceResult<{ task: any }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const { subject, description, assigneeAgentId, blockedBy, priority } = params
 
   if (!subject || typeof subject !== 'string' || !subject.trim()) {
-    return { error: 'Subject is required', status: 400 }
+    return missingField('subject')
   }
 
   // Validate blockedBy is an array of strings if provided
   if (blockedBy !== undefined) {
     if (!Array.isArray(blockedBy) || !blockedBy.every((id: unknown) => typeof id === 'string')) {
-      return { error: 'blockedBy must be an array of task ID strings', status: 400 }
+      return invalidField('blockedBy', 'blockedBy must be an array of task ID strings')
     }
   }
 
@@ -230,7 +221,7 @@ export function createTeamTask(teamId: string, params: CreateTaskParams): Servic
     return { data: { task }, status: 201 }
   } catch (error) {
     console.error('Failed to create task:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to create task', status: 500 }
+    return operationFailed('create task', (error as Error).message)
   }
 }
 
@@ -244,12 +235,12 @@ export function updateTeamTask(
 ): ServiceResult<{ task: any; unblocked?: any[] }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const existing = getTask(teamId, taskId)
   if (!existing) {
-    return { error: 'Task not found', status: 404 }
+    return notFound('Task', taskId)
   }
 
   const { subject, description, status, assigneeAgentId, blockedBy, priority } = params
@@ -258,20 +249,20 @@ export function updateTeamTask(
   if (Array.isArray(blockedBy)) {
     for (const depId of blockedBy) {
       if (typeof depId !== 'string') {
-        return { error: 'blockedBy must contain only string task IDs', status: 400 }
+        return invalidField('blockedBy', 'blockedBy must contain only string task IDs')
       }
       if (depId === taskId) {
-        return { error: 'A task cannot depend on itself', status: 400 }
+        return selfReference('A task cannot depend on itself')
       }
       if (wouldCreateCycle(teamId, taskId, depId)) {
-        return { error: `Adding dependency on task ${depId} would create a circular reference`, status: 400 }
+        return circularDependency(`Adding dependency on task ${depId} would create a circular reference`)
       }
     }
   }
 
   // Validate status enum
   if (status !== undefined && !VALID_TASK_STATUSES.includes(status)) {
-    return { error: 'Invalid status. Must be backlog, pending, in_progress, review, or completed', status: 400 }
+    return invalidField('status', 'Invalid status. Must be backlog, pending, in_progress, review, or completed')
   }
 
   try {
@@ -285,13 +276,13 @@ export function updateTeamTask(
     })
 
     if (!result.task) {
-      return { error: 'Task not found', status: 404 }
+      return notFound('Task', taskId)
     }
 
     return { data: { task: result.task, unblocked: result.unblocked }, status: 200 }
   } catch (error) {
     console.error('Failed to update task:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to update task', status: 500 }
+    return operationFailed('update task', (error as Error).message)
   }
 }
 
@@ -301,12 +292,12 @@ export function updateTeamTask(
 export function deleteTeamTask(teamId: string, taskId: string): ServiceResult<{ success: boolean }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const deleted = deleteTask(teamId, taskId)
   if (!deleted) {
-    return { error: 'Task not found', status: 404 }
+    return notFound('Task', taskId)
   }
 
   return { data: { success: true }, status: 200 }
@@ -322,7 +313,7 @@ export function deleteTeamTask(teamId: string, taskId: string): ServiceResult<{ 
 export function listTeamDocuments(teamId: string): ServiceResult<{ documents: any[] }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const documents = loadDocuments(teamId)
@@ -335,13 +326,13 @@ export function listTeamDocuments(teamId: string): ServiceResult<{ documents: an
 export function createTeamDocument(teamId: string, params: CreateDocumentParams): ServiceResult<{ document: any }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const { title, content, pinned, tags } = params
 
   if (!title || typeof title !== 'string') {
-    return { error: 'title is required', status: 400 }
+    return missingField('title')
   }
 
   try {
@@ -355,7 +346,7 @@ export function createTeamDocument(teamId: string, params: CreateDocumentParams)
     return { data: { document }, status: 201 }
   } catch (error) {
     console.error('Failed to create document:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to create document', status: 500 }
+    return operationFailed('create document', (error as Error).message)
   }
 }
 
@@ -365,12 +356,12 @@ export function createTeamDocument(teamId: string, params: CreateDocumentParams)
 export function getTeamDocument(teamId: string, docId: string): ServiceResult<{ document: any }> {
   const team = getTeam(teamId)
   if (!team) {
-    return { error: 'Team not found', status: 404 }
+    return notFound('Team', teamId)
   }
 
   const document = getDocument(teamId, docId)
   if (!document) {
-    return { error: 'Document not found', status: 404 }
+    return notFound('Document', docId)
   }
 
   return { data: { document }, status: 200 }
@@ -393,13 +384,13 @@ export function updateTeamDocument(
 
     const document = updateDocument(teamId, docId, updates as any)
     if (!document) {
-      return { error: 'Document not found', status: 404 }
+      return notFound('Document', docId)
     }
 
     return { data: { document }, status: 200 }
   } catch (error) {
     console.error('Failed to update document:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to update document', status: 500 }
+    return operationFailed('update document', (error as Error).message)
   }
 }
 
@@ -409,7 +400,7 @@ export function updateTeamDocument(
 export function deleteTeamDocument(teamId: string, docId: string): ServiceResult<{ success: boolean }> {
   const deleted = deleteDocument(teamId, docId)
   if (!deleted) {
-    return { error: 'Document not found', status: 404 }
+    return notFound('Document', docId)
   }
 
   return { data: { success: true }, status: 200 }
@@ -426,11 +417,11 @@ export async function notifyTeamAgents(params: NotifyTeamParams): Promise<Servic
   const { agentIds, teamName } = params
 
   if (!agentIds || !Array.isArray(agentIds)) {
-    return { error: 'agentIds array is required', status: 400 }
+    return missingField('agentIds')
   }
 
   if (!teamName || typeof teamName !== 'string') {
-    return { error: 'teamName is required', status: 400 }
+    return missingField('teamName')
   }
 
   try {
@@ -462,6 +453,6 @@ export async function notifyTeamAgents(params: NotifyTeamParams): Promise<Servic
     return { data: { results }, status: 200 }
   } catch (error) {
     console.error('Failed to notify team:', error)
-    return { error: error instanceof Error ? error.message : 'Failed to notify team', status: 500 }
+    return operationFailed('notify team', (error as Error).message)
   }
 }

--- a/services/webhooks-service.ts
+++ b/services/webhooks-service.ts
@@ -21,16 +21,7 @@ import {
   sendTestWebhook,
 } from '@/lib/webhook-service'
 import type { CreateWebhookRequest, WebhookEventType } from '@/types/agent'
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ServiceResult<T> {
-  data?: T
-  error?: string
-  status: number  // HTTP-like status code for the route to use
-}
+import { type ServiceResult, missingField, notFound, invalidField, alreadyExists, operationFailed } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -70,7 +61,7 @@ export function listAllWebhooks(): ServiceResult<{ webhooks: any[] }> {
     return { data: { webhooks: sanitized }, status: 200 }
   } catch (error) {
     console.error('Failed to list webhooks:', error)
-    return { error: 'Failed to list webhooks', status: 500 }
+    return operationFailed('list webhooks')
   }
 }
 
@@ -81,24 +72,24 @@ export function listAllWebhooks(): ServiceResult<{ webhooks: any[] }> {
 export function createNewWebhook(body: CreateWebhookRequest): ServiceResult<{ webhook: any; message?: string }> {
   // Validate required fields
   if (!body.url) {
-    return { error: 'URL is required', status: 400 }
+    return missingField('url')
   }
 
   if (!body.events || !Array.isArray(body.events) || body.events.length === 0) {
-    return { error: 'At least one event is required', status: 400 }
+    return missingField('events')
   }
 
   // Validate URL format
   try {
     new URL(body.url)
   } catch {
-    return { error: 'Invalid URL format', status: 400 }
+    return invalidField('url', 'Invalid URL format')
   }
 
   // Validate event types
   for (const event of body.events) {
     if (!VALID_EVENTS.includes(event)) {
-      return { error: `Invalid event type: ${event}. Valid events: ${VALID_EVENTS.join(', ')}`, status: 400 }
+      return invalidField('events', `Invalid event type: ${event}. Valid events: ${VALID_EVENTS.join(', ')}`)
     }
   }
 
@@ -124,11 +115,11 @@ export function createNewWebhook(body: CreateWebhookRequest): ServiceResult<{ we
     const message = error instanceof Error ? error.message : 'Failed to create webhook'
 
     if (message.includes('already exists')) {
-      return { error: message, status: 409 }
+      return alreadyExists('Webhook')
     }
 
     console.error('Failed to create webhook:', error)
-    return { error: message, status: 500 }
+    return operationFailed('create webhook', message)
   }
 }
 
@@ -140,7 +131,7 @@ export function getWebhookById(id: string): ServiceResult<any> {
     const webhook = getWebhook(id)
 
     if (!webhook) {
-      return { error: 'Webhook not found', status: 404 }
+      return notFound('Webhook', id)
     }
 
     // Don't expose secret
@@ -158,7 +149,7 @@ export function getWebhookById(id: string): ServiceResult<any> {
     }
   } catch (error) {
     console.error('Failed to get webhook:', error)
-    return { error: 'Failed to get webhook', status: 500 }
+    return operationFailed('get webhook')
   }
 }
 
@@ -170,13 +161,13 @@ export function deleteWebhookById(id: string): ServiceResult<{ success: boolean 
     const success = deleteWebhook(id)
 
     if (!success) {
-      return { error: 'Webhook not found', status: 404 }
+      return notFound('Webhook', id)
     }
 
     return { data: { success: true }, status: 200 }
   } catch (error) {
     console.error('Failed to delete webhook:', error)
-    return { error: 'Failed to delete webhook', status: 500 }
+    return operationFailed('delete webhook')
   }
 }
 
@@ -200,10 +191,10 @@ export async function testWebhookById(id: string): Promise<ServiceResult<{ succe
     const message = error instanceof Error ? error.message : 'Failed to send test webhook'
 
     if (message.includes('not found')) {
-      return { error: message, status: 404 }
+      return notFound('Webhook', id)
     }
 
     console.error('Failed to send test webhook:', error)
-    return { error: message, status: 500 }
+    return operationFailed('send test webhook', message)
   }
 }

--- a/tests/document-api.test.ts
+++ b/tests/document-api.test.ts
@@ -74,7 +74,8 @@ describe('GET /api/teams/[id]/documents', () => {
 
     expect(res.status).toBe(404)
     const data = await res.json()
-    expect(data.error).toBe('Team not found')
+    expect(data.error).toBe('not_found')
+    expect(data.message).toMatch(/team/i)
   })
 
   it('returns empty documents array for team with no docs', async () => {
@@ -132,7 +133,8 @@ describe('POST /api/teams/[id]/documents', () => {
 
     expect(res.status).toBe(400)
     const data = await res.json()
-    expect(data.error).toBe('title is required')
+    expect(data.error).toBe('missing_field')
+    expect(data.message).toMatch(/title/i)
   })
 
   it('creates a document with 201 status', async () => {
@@ -195,7 +197,8 @@ describe('GET /api/teams/[id]/documents/[docId]', () => {
 
     expect(res.status).toBe(404)
     const data = await res.json()
-    expect(data.error).toBe('Team not found')
+    expect(data.error).toBe('not_found')
+    expect(data.message).toMatch(/team/i)
   })
 
   it('returns 404 when document does not exist', async () => {
@@ -206,7 +209,8 @@ describe('GET /api/teams/[id]/documents/[docId]', () => {
 
     expect(res.status).toBe(404)
     const data = await res.json()
-    expect(data.error).toBe('Document not found')
+    expect(data.error).toBe('not_found')
+    expect(data.message).toMatch(/document/i)
   })
 
   it('returns the document when it exists', async () => {

--- a/tests/services/agents-core-service.test.ts
+++ b/tests/services/agents-core-service.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { makeAgent, makeAgentSession, resetFixtureCounter } from '../test-utils/fixtures'
+import { type ServiceError } from '@/services/service-errors'
 
 // ============================================================================
 // Mocks — vi.hoisted() ensures availability before vi.mock() runs
@@ -161,8 +162,8 @@ describe('listAgents', () => {
     const result = await listAgents()
 
     expect(result.status).toBe(200)
-    expect(result.data?.agents).toEqual([])
-    expect(result.data?.stats.total).toBe(0)
+    expect((result.data as any)?.agents).toEqual([])
+    expect((result.data as any)?.stats.total).toBe(0)
   })
 
   it('returns agents from registry with session status', async () => {
@@ -175,8 +176,8 @@ describe('listAgents', () => {
     const result = await listAgents()
 
     expect(result.status).toBe(200)
-    expect(result.data?.agents).toHaveLength(1)
-    expect(result.data?.agents[0].name).toBe('my-agent')
+    expect((result.data as any)?.agents).toHaveLength(1)
+    expect((result.data as any)?.agents[0].name).toBe('my-agent')
   })
 
   it('creates orphan agents for sessions without registry entries', async () => {
@@ -187,9 +188,9 @@ describe('listAgents', () => {
 
     const result = await listAgents()
 
-    expect(result.data?.agents).toHaveLength(1)
-    expect(result.data?.agents[0].isOrphan).toBe(true)
-    expect(result.data?.stats.orphans).toBe(1)
+    expect((result.data as any)?.agents).toHaveLength(1)
+    expect((result.data as any)?.agents[0].isOrphan).toBe(true)
+    expect((result.data as any)?.stats.orphans).toBe(1)
     // Orphan should be saved to registry
     expect(mockAgentRegistry.saveAgents).toHaveBeenCalled()
   })
@@ -201,8 +202,8 @@ describe('listAgents', () => {
 
     const result = await listAgents()
 
-    expect(result.data?.agents[0].status).toBe('offline')
-    expect(result.data?.agents[0].session?.status).toBe('offline')
+    expect((result.data as any)?.agents[0].status).toBe('offline')
+    expect((result.data as any)?.agents[0].session?.status).toBe('offline')
   })
 
   it('marks agents active when matching tmux session exists', async () => {
@@ -214,8 +215,8 @@ describe('listAgents', () => {
 
     const result = await listAgents()
 
-    expect(result.data?.agents[0].status).toBe('active')
-    expect(result.data?.agents[0].session?.status).toBe('online')
+    expect((result.data as any)?.agents[0].status).toBe('active')
+    expect((result.data as any)?.agents[0].session?.status).toBe('online')
   })
 
   it('sorts online agents before offline', async () => {
@@ -228,14 +229,14 @@ describe('listAgents', () => {
 
     const result = await listAgents()
 
-    expect(result.data?.agents[0].name).toBe('zzz-online')
-    expect(result.data?.agents[1].name).toBe('aaa-offline')
+    expect((result.data as any)?.agents[0].name).toBe('zzz-online')
+    expect((result.data as any)?.agents[1].name).toBe('aaa-offline')
   })
 
   it('includes host info in response', async () => {
     const result = await listAgents()
 
-    expect(result.data?.hostInfo).toEqual({
+    expect((result.data as any)?.hostInfo).toEqual({
       id: 'test-host',
       name: 'Test Host',
       url: 'http://localhost:23000',
@@ -264,7 +265,7 @@ describe('searchAgentsByQuery', () => {
     const result = searchAgentsByQuery('backend')
 
     expect(result.status).toBe(200)
-    expect(result.data?.agents).toHaveLength(1)
+    expect((result.data as any)?.agents).toHaveLength(1)
     expect(mockAgentRegistry.searchAgents).toHaveBeenCalledWith('backend')
   })
 
@@ -274,7 +275,7 @@ describe('searchAgentsByQuery', () => {
     const result = searchAgentsByQuery('nonexistent')
 
     expect(result.status).toBe(200)
-    expect(result.data?.agents).toEqual([])
+    expect((result.data as any)?.agents).toEqual([])
   })
 })
 
@@ -294,7 +295,7 @@ describe('createNewAgent', () => {
     })
 
     expect(result.status).toBe(201)
-    expect(result.data?.agent.name).toBe('new-agent')
+    expect((result.data as any)?.agent.name).toBe('new-agent')
   })
 
   it('returns 400 when createAgent throws (e.g., duplicate name)', () => {
@@ -307,7 +308,7 @@ describe('createNewAgent', () => {
     })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/already exists/i)
+    expect((result.data as ServiceError).message).toMatch(/already exists/i)
   })
 })
 
@@ -323,7 +324,7 @@ describe('getAgentById', () => {
     const result = getAgentById('agent-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.agent.name).toBe('found')
+    expect((result.data as any)?.agent.name).toBe('found')
   })
 
   it('returns 404 when agent not found', () => {
@@ -357,7 +358,7 @@ describe('updateAgentById', () => {
     const result = updateAgentById('agent-1', { taskDescription: 'Updated task' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.agent.taskDescription).toBe('Updated task')
+    expect((result.data as any)?.agent.taskDescription).toBe('Updated task')
   })
 
   it('returns 404 when agent not found', () => {
@@ -375,7 +376,7 @@ describe('updateAgentById', () => {
     const result = updateAgentById('agent-1', { taskDescription: 'X' })
 
     expect(result.status).toBe(410)
-    expect(result.error).toMatch(/deleted/i)
+    expect((result.data as ServiceError).message).toMatch(/deleted/i)
   })
 
   it('returns 400 when updateAgent throws (e.g., duplicate name)', () => {
@@ -386,7 +387,7 @@ describe('updateAgentById', () => {
     const result = updateAgentById('agent-1', { name: 'taken' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toBe('Name taken')
+    expect((result.data as ServiceError).message).toBe('Name taken')
   })
 })
 
@@ -403,8 +404,8 @@ describe('deleteAgentById', () => {
     const result = deleteAgentById('agent-1', false)
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
-    expect(result.data?.hard).toBe(false)
+    expect((result.data as any)?.success).toBe(true)
+    expect((result.data as any)?.hard).toBe(false)
   })
 
   it('hard deletes agent', () => {
@@ -415,7 +416,7 @@ describe('deleteAgentById', () => {
     const result = deleteAgentById('agent-1', true)
 
     expect(result.status).toBe(200)
-    expect(result.data?.hard).toBe(true)
+    expect((result.data as any)?.hard).toBe(true)
   })
 
   it('returns 404 when agent not found', () => {
@@ -433,7 +434,7 @@ describe('deleteAgentById', () => {
     const result = deleteAgentById('agent-1', false)
 
     expect(result.status).toBe(410)
-    expect(result.error).toMatch(/already deleted/i)
+    expect((result.data as ServiceError).message).toMatch(/deleted/i)
   })
 
   it('allows hard delete of already soft-deleted agent', () => {
@@ -460,8 +461,8 @@ describe('registerAgent', () => {
     const result = registerAgent({ sessionName: 'my-agent', workingDirectory: '/home' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
-    expect(result.data?.agentId).toBe('my-agent')
+    expect((result.data as any)?.success).toBe(true)
+    expect((result.data as any)?.agentId).toBe('my-agent')
   })
 
   it('links existing agent when found by session', () => {
@@ -473,7 +474,7 @@ describe('registerAgent', () => {
 
     expect(result.status).toBe(200)
     expect(mockAgentRegistry.linkSession).toHaveBeenCalledWith('existing-id', 'my-agent', expect.any(String))
-    expect(result.data?.registryAgent?.id).toBe('existing-id')
+    expect((result.data as any)?.registryAgent?.id).toBe('existing-id')
   })
 
   it('registers cloud agent with websocket URL', () => {
@@ -485,7 +486,7 @@ describe('registerAgent', () => {
     })
 
     expect(result.status).toBe(200)
-    expect(result.data?.agentId).toBe('cloud-agent')
+    expect((result.data as any)?.agentId).toBe('cloud-agent')
   })
 
   it('returns 400 when session name is missing (worktree format)', () => {
@@ -500,7 +501,7 @@ describe('registerAgent', () => {
     const result = registerAgent({ id: 'cloud', deployment: {} as any })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/missing/i)
+    expect((result.data as ServiceError).message).toMatch(/required/i)
   })
 
   it('saves agent config to file', () => {
@@ -526,8 +527,8 @@ describe('lookupAgentByName', () => {
     const result = lookupAgentByName('my-agent')
 
     expect(result.status).toBe(200)
-    expect(result.data?.exists).toBe(true)
-    expect(result.data?.agent?.name).toBe('my-agent')
+    expect((result.data as any)?.exists).toBe(true)
+    expect((result.data as any)?.agent?.name).toBe('my-agent')
   })
 
   it('returns exists=false when agent not resolved', () => {
@@ -536,7 +537,7 @@ describe('lookupAgentByName', () => {
     const result = lookupAgentByName('unknown')
 
     expect(result.status).toBe(200)
-    expect(result.data?.exists).toBe(false)
+    expect((result.data as any)?.exists).toBe(false)
   })
 
   it('returns exists=false when resolved but not in registry', () => {
@@ -546,7 +547,7 @@ describe('lookupAgentByName', () => {
     const result = lookupAgentByName('gone-agent')
 
     expect(result.status).toBe(200)
-    expect(result.data?.exists).toBe(false)
+    expect((result.data as any)?.exists).toBe(false)
   })
 })
 
@@ -565,8 +566,8 @@ describe('wakeAgent', () => {
     const result = await wakeAgent('agent-1', { startProgram: false })
 
     expect(result.status).toBe(200)
-    expect(result.data?.woken).toBe(true)
-    expect(result.data?.sessionName).toBe('my-agent')
+    expect((result.data as any)?.woken).toBe(true)
+    expect((result.data as any)?.sessionName).toBe('my-agent')
     expect(mockRuntime.createSession).toHaveBeenCalledWith('my-agent', '/home')
   })
 
@@ -579,7 +580,7 @@ describe('wakeAgent', () => {
     const result = await wakeAgent('agent-1', {})
 
     expect(result.status).toBe(200)
-    expect(result.data?.alreadyRunning).toBe(true)
+    expect((result.data as any)?.alreadyRunning).toBe(true)
     expect(mockRuntime.createSession).not.toHaveBeenCalled()
   })
 
@@ -632,8 +633,8 @@ describe('wakeAgent', () => {
 
     const result = await wakeAgent('agent-1', { sessionIndex: 2, startProgram: false })
 
-    expect(result.data?.sessionName).toBe('my-agent_2')
-    expect(result.data?.sessionIndex).toBe(2)
+    expect((result.data as any)?.sessionName).toBe('my-agent_2')
+    expect((result.data as any)?.sessionIndex).toBe(2)
   })
 
   it('returns 500 when tmux session creation fails', async () => {
@@ -662,7 +663,7 @@ describe('hibernateAgent', () => {
     const result = await hibernateAgent('agent-1', {})
 
     expect(result.status).toBe(200)
-    expect(result.data?.hibernated).toBe(true)
+    expect((result.data as any)?.hibernated).toBe(true)
     expect(mockRuntime.killSession).toHaveBeenCalledWith('my-agent')
   })
 
@@ -675,8 +676,8 @@ describe('hibernateAgent', () => {
     const result = await hibernateAgent('agent-1', {})
 
     expect(result.status).toBe(200)
-    expect(result.data?.hibernated).toBe(true)
-    expect(result.data?.message).toMatch(/already terminated/i)
+    expect((result.data as any)?.hibernated).toBe(true)
+    expect((result.data as any)?.message).toMatch(/already terminated/i)
   })
 
   it('returns 404 when agent not found', async () => {
@@ -734,9 +735,9 @@ describe('sendAgentSessionCommand', () => {
     const result = await sendAgentSessionCommand('agent-1', { command: 'ls -la' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
-    expect(result.data?.commandSent).toBe('ls -la')
-    expect(result.data?.sessionName).toBe('my-agent')
+    expect((result.data as any)?.success).toBe(true)
+    expect((result.data as any)?.commandSent).toBe('ls -la')
+    expect((result.data as any)?.sessionName).toBe('my-agent')
   })
 
   it('returns 409 when session is busy', async () => {
@@ -748,7 +749,7 @@ describe('sendAgentSessionCommand', () => {
     const result = await sendAgentSessionCommand('agent-1', { command: 'ls' })
 
     expect(result.status).toBe(409)
-    expect(result.error).toMatch(/not idle/i)
+    expect((result.data as any)?.idle).toBe(false)
   })
 
   it('allows command when requireIdle is false', async () => {
@@ -816,7 +817,7 @@ describe('sendAgentSessionCommand', () => {
     const result = await sendAgentSessionCommand('agent-1', { command: 'ls' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/no name/i)
+    expect((result.data as ServiceError).message).toMatch(/no name/i)
   })
 })
 
@@ -831,7 +832,7 @@ describe('linkAgentSession', () => {
     const result = linkAgentSession('agent-1', { sessionName: 'my-session' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
   })
 
   it('returns 400 when sessionName is missing', () => {
@@ -862,7 +863,7 @@ describe('unlinkOrDeleteAgentSession', () => {
     const result = await unlinkOrDeleteAgentSession('agent-1', {})
 
     expect(result.status).toBe(200)
-    expect(result.data?.sessionUnlinked).toBe(true)
+    expect((result.data as any)?.sessionUnlinked).toBe(true)
   })
 
   it('kills session and unlinks when kill=true', async () => {
@@ -874,7 +875,7 @@ describe('unlinkOrDeleteAgentSession', () => {
     const result = await unlinkOrDeleteAgentSession('agent-1', { kill: true })
 
     expect(result.status).toBe(200)
-    expect(result.data?.sessionKilled).toBe(true)
+    expect((result.data as any)?.sessionKilled).toBe(true)
     expect(mockRuntime.killSession).toHaveBeenCalledWith('my-agent')
   })
 
@@ -886,7 +887,7 @@ describe('unlinkOrDeleteAgentSession', () => {
     const result = await unlinkOrDeleteAgentSession('agent-1', { deleteAgent: true })
 
     expect(result.status).toBe(200)
-    expect(result.data?.deleted).toBe(true)
+    expect((result.data as any)?.deleted).toBe(true)
     expect(mockAgentRegistry.deleteAgent).toHaveBeenCalledWith('agent-1', true)
   })
 
@@ -922,8 +923,8 @@ describe('getAgentSessionStatus', () => {
     const result = await getAgentSessionStatus('agent-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.hasSession).toBe(true)
-    expect(result.data?.exists).toBe(true)
+    expect((result.data as any)?.hasSession).toBe(true)
+    expect((result.data as any)?.exists).toBe(true)
   })
 
   it('returns hasSession=false when agent has no name', async () => {
@@ -933,7 +934,7 @@ describe('getAgentSessionStatus', () => {
     const result = await getAgentSessionStatus('agent-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.hasSession).toBe(false)
+    expect((result.data as any)?.hasSession).toBe(false)
   })
 
   it('returns 404 when agent not found', async () => {
@@ -952,7 +953,7 @@ describe('getAgentSessionStatus', () => {
 
     const result = await getAgentSessionStatus('agent-1')
 
-    expect(result.data?.idle).toBe(true)
+    expect((result.data as any)?.idle).toBe(true)
   })
 })
 
@@ -970,8 +971,8 @@ describe('initializeStartup', () => {
     const result = await initializeStartup()
 
     expect(result.status).toBe(200)
-    expect(result.data?.initialized).toHaveLength(2)
-    expect(result.data?.failed).toHaveLength(0)
+    expect((result.data as any)?.initialized).toHaveLength(2)
+    expect((result.data as any)?.failed).toHaveLength(0)
   })
 
   it('reports partial failures', async () => {
@@ -983,7 +984,7 @@ describe('initializeStartup', () => {
     const result = await initializeStartup()
 
     expect(result.status).toBe(200)
-    expect(result.data?.failed).toHaveLength(1)
+    expect((result.data as any)?.failed).toHaveLength(1)
   })
 
   it('returns 500 on unexpected error', async () => {
@@ -1006,7 +1007,7 @@ describe('getStartupInfo', () => {
     const result = getStartupInfo()
 
     expect(result.status).toBe(200)
-    expect(result.data?.initialized).toBe(true)
+    expect((result.data as any)?.initialized).toBe(true)
   })
 
   it('returns 500 on error', () => {

--- a/tests/services/amp-service.test.ts
+++ b/tests/services/amp-service.test.ts
@@ -173,11 +173,11 @@ describe('getHealthStatus', () => {
     const result = getHealthStatus()
 
     expect(result.status).toBe(200)
-    expect(result.data?.status).toBe('healthy')
-    expect(result.data?.agents_online).toBe(1)
-    expect(result.data?.provider).toBe('testorg.aimaestro.local')
-    expect(result.data?.version).toBe('0.1.3')
-    expect(result.data?.uptime_seconds).toBeGreaterThanOrEqual(0)
+    expect((result.data as any)?.status).toBe('healthy')
+    expect((result.data as any)?.agents_online).toBe(1)
+    expect((result.data as any)?.provider).toBe('testorg.aimaestro.local')
+    expect((result.data as any)?.version).toBe('0.1.3')
+    expect((result.data as any)?.uptime_seconds).toBeGreaterThanOrEqual(0)
   })
 
   it('returns unhealthy on error', () => {
@@ -186,8 +186,8 @@ describe('getHealthStatus', () => {
     const result = getHealthStatus()
 
     expect(result.status).toBe(503)
-    expect(result.data?.status).toBe('unhealthy')
-    expect(result.data?.agents_online).toBe(0)
+    expect((result.data as any)?.status).toBe('unhealthy')
+    expect((result.data as any)?.agents_online).toBe(0)
   })
 
   it('includes no-cache headers', () => {
@@ -206,14 +206,14 @@ describe('getProviderInfo', () => {
     const result = getProviderInfo()
 
     expect(result.status).toBe(200)
-    expect(result.data?.provider).toBe('testorg.aimaestro.local')
-    expect(result.data?.version).toBe('amp/0.1.3')
-    expect(result.data?.capabilities).toContain('registration')
-    expect(result.data?.capabilities).toContain('local-delivery')
-    expect(result.data?.capabilities).toContain('relay-queue')
-    expect(result.data?.capabilities).toContain('mesh-routing')
-    expect(result.data?.registration_modes).toEqual(['open'])
-    expect(result.data?.rate_limits).toBeDefined()
+    expect((result.data as any)?.provider).toBe('testorg.aimaestro.local')
+    expect((result.data as any)?.version).toBe('amp/0.1.3')
+    expect((result.data as any)?.capabilities).toContain('registration')
+    expect((result.data as any)?.capabilities).toContain('local-delivery')
+    expect((result.data as any)?.capabilities).toContain('relay-queue')
+    expect((result.data as any)?.capabilities).toContain('mesh-routing')
+    expect((result.data as any)?.registration_modes).toEqual(['open'])
+    expect((result.data as any)?.rate_limits).toBeDefined()
   })
 
   it('includes cache headers', () => {
@@ -381,13 +381,13 @@ describe('listAMPAgents', () => {
     const result = listAMPAgents('Bearer test-key')
 
     expect(result.status).toBe(200)
-    expect(result.data.agents).toHaveLength(1)
-    expect(result.data.agents[0]).toEqual({
+    expect((result.data as any).agents).toHaveLength(1)
+    expect((result.data as any).agents[0]).toEqual({
       address: 'alice@testorg.aimaestro.local',
       alias: 'Alice Bot',
       online: true,
     })
-    expect(result.data.total).toBe(1)
+    expect((result.data as any).total).toBe(1)
   })
 
   it('filters by search term', () => {
@@ -399,8 +399,8 @@ describe('listAMPAgents', () => {
     const result = listAMPAgents('Bearer test-key', 'bob')
 
     expect(result.status).toBe(200)
-    expect(result.data.agents).toHaveLength(1)
-    expect(result.data.total).toBe(1)
+    expect((result.data as any).agents).toHaveLength(1)
+    expect((result.data as any).total).toBe(1)
   })
 
   it('filters by tenant', () => {
@@ -412,7 +412,7 @@ describe('listAMPAgents', () => {
     const result = listAMPAgents('Bearer test-key')
 
     expect(result.status).toBe(200)
-    expect(result.data.agents).toHaveLength(1)
+    expect((result.data as any).agents).toHaveLength(1)
   })
 })
 
@@ -453,9 +453,9 @@ describe('getAgentSelf', () => {
     const result = getAgentSelf('Bearer test-key')
 
     expect(result.status).toBe(200)
-    expect(result.data.address).toBe('alice@testorg.aimaestro.local')
-    expect(result.data.fingerprint).toBe('SHA256:abc')
-    expect(result.data.registered_at).toBe('2025-01-01T00:00:00.000Z')
+    expect((result.data as any).address).toBe('alice@testorg.aimaestro.local')
+    expect((result.data as any).fingerprint).toBe('SHA256:abc')
+    expect((result.data as any).registered_at).toBe('2025-01-01T00:00:00.000Z')
   })
 })
 
@@ -486,7 +486,7 @@ describe('getAgentCard', () => {
 
     const result = getAgentCard('Bearer test-key')
     expect(result.status).toBe(404)
-    expect(result.data.message).toContain('keypair')
+    expect((result.data as any).message).toContain('keypair')
   })
 
   it('returns a signed agent card', () => {
@@ -510,19 +510,19 @@ describe('getAgentCard', () => {
     const result = getAgentCard('Bearer test-key')
 
     expect(result.status).toBe(200)
-    expect(result.data.address).toBe('alice@testorg.aimaestro.local')
-    expect(result.data.name).toBe('alice')
-    expect(result.data.alias).toBe('Alice Bot')
-    expect(result.data.public_key).toBe(publicPem)
-    expect(result.data.fingerprint).toBe('SHA256:test-fp')
-    expect(result.data.provider).toBe('testorg.aimaestro.local')
-    expect(result.data.capabilities).toContain('messaging')
-    expect(result.data.capabilities).toContain('read_receipts')
-    expect(result.data.signed_at).toBeDefined()
-    expect(result.data.signature).toBeDefined()
-    expect(typeof result.data.signature).toBe('string')
+    expect((result.data as any).address).toBe('alice@testorg.aimaestro.local')
+    expect((result.data as any).name).toBe('alice')
+    expect((result.data as any).alias).toBe('Alice Bot')
+    expect((result.data as any).public_key).toBe(publicPem)
+    expect((result.data as any).fingerprint).toBe('SHA256:test-fp')
+    expect((result.data as any).provider).toBe('testorg.aimaestro.local')
+    expect((result.data as any).capabilities).toContain('messaging')
+    expect((result.data as any).capabilities).toContain('read_receipts')
+    expect((result.data as any).signed_at).toBeDefined()
+    expect((result.data as any).signature).toBeDefined()
+    expect(typeof (result.data as any).signature).toBe('string')
     // Verify signature is valid base64
-    expect(() => Buffer.from(result.data.signature, 'base64')).not.toThrow()
+    expect(() => Buffer.from((result.data as any).signature, 'base64')).not.toThrow()
   })
 
   it('signature verifies with the public key', () => {
@@ -546,12 +546,12 @@ describe('getAgentCard', () => {
     expect(result.status).toBe(200)
 
     // Verify the signature
-    const signable = `${result.data.address}|${result.data.public_key}|${result.data.signed_at}`
+    const signable = `${(result.data as any).address}|${(result.data as any).public_key}|${(result.data as any).signed_at}`
     const verified = crypto.verify(
       null,
       Buffer.from(signable),
       publicKey,
-      Buffer.from(result.data.signature, 'base64')
+      Buffer.from((result.data as any).signature, 'base64')
     )
     expect(verified).toBe(true)
   })
@@ -570,7 +570,7 @@ describe('getAgentCard', () => {
     })
 
     const result = getAgentCard('Bearer test-key')
-    expect(result.data.address).toBe('custom-addr@provider.com')
+    expect((result.data as any).address).toBe('custom-addr@provider.com')
   })
 })
 

--- a/tests/services/sessions-service.test.ts
+++ b/tests/services/sessions-service.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { resetFixtureCounter } from '../test-utils/fixtures'
+import { type ServiceError } from '@/services/service-errors'
 
 // ============================================================================
 // Mocks — vi.hoisted() ensures availability before vi.mock() runs
@@ -243,8 +244,8 @@ describe('createSession', () => {
     const result = await createSession({ name: 'my-agent' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
-    expect(result.data?.name).toBe('my-agent')
+    expect((result.data as any)?.success).toBe(true)
+    expect((result.data as any)?.name).toBe('my-agent')
     expect(mockRuntime.createSession).toHaveBeenCalled()
   })
 
@@ -252,14 +253,14 @@ describe('createSession', () => {
     const result = await createSession({ name: '' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/name/i)
+    expect((result.data as ServiceError).message).toMatch(/name/i)
   })
 
   it('returns 400 when name contains invalid characters', async () => {
     const result = await createSession({ name: 'my agent!!' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/letters.*numbers.*dashes.*underscores/i)
+    expect((result.data as ServiceError).message).toMatch(/letters.*numbers.*dashes.*underscores/i)
   })
 
   it('returns 409 when session already exists', async () => {
@@ -268,7 +269,7 @@ describe('createSession', () => {
     const result = await createSession({ name: 'existing' })
 
     expect(result.status).toBe(409)
-    expect(result.error).toMatch(/already exists/i)
+    expect((result.data as ServiceError).message).toMatch(/already exists/i)
   })
 
   it('normalizes name to lowercase', async () => {
@@ -357,7 +358,7 @@ describe('deleteSession', () => {
     const result = await deleteSession('my-agent')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
     expect(mockRuntime.killSession).toHaveBeenCalledWith('my-agent')
   })
 
@@ -379,7 +380,7 @@ describe('deleteSession', () => {
     const result = await deleteSession('cloud-agent')
 
     expect(result.status).toBe(200)
-    expect(result.data?.type).toBe('cloud')
+    expect((result.data as any)?.type).toBe('cloud')
     expect(mockRuntime.killSession).not.toHaveBeenCalled()
     expect(mockAgentRegistry.deleteAgentBySession).toHaveBeenCalledWith('cloud-agent', true)
   })
@@ -409,8 +410,8 @@ describe('renameSession', () => {
     const result = await renameSession('old-name', 'new-name')
 
     expect(result.status).toBe(200)
-    expect(result.data?.oldName).toBe('old-name')
-    expect(result.data?.newName).toBe('new-name')
+    expect((result.data as any)?.oldName).toBe('old-name')
+    expect((result.data as any)?.newName).toBe('new-name')
     expect(mockRuntime.renameSession).toHaveBeenCalledWith('old-name', 'new-name')
   })
 
@@ -424,7 +425,7 @@ describe('renameSession', () => {
     const result = await renameSession('old', 'new name!!')
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/letters.*numbers.*dashes.*underscores/i)
+    expect((result.data as ServiceError).message).toMatch(/letters.*numbers.*dashes.*underscores/i)
   })
 
   it('returns 404 when old session not found', async () => {
@@ -471,8 +472,8 @@ describe('sendCommand', () => {
     const result = await sendCommand('my-agent', 'ls -la')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
-    expect(result.data?.commandSent).toBe('ls -la')
+    expect((result.data as any)?.success).toBe(true)
+    expect((result.data as any)?.commandSent).toBe('ls -la')
     expect(mockRuntime.sendKeys).toHaveBeenCalledWith('my-agent', 'ls -la', { literal: true, enter: true })
   })
 
@@ -488,7 +489,7 @@ describe('sendCommand', () => {
     const result = await sendCommand('my-agent', '')
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/command/i)
+    expect((result.data as ServiceError).message).toMatch(/command/i)
   })
 
   it('returns 404 when session does not exist', async () => {
@@ -506,7 +507,7 @@ describe('sendCommand', () => {
     const result = await sendCommand('busy-agent', 'ls')
 
     expect(result.status).toBe(409)
-    expect(result.error).toMatch(/not idle/i)
+    expect((result.data as ServiceError).message).toMatch(/not idle/i)
   })
 
   it('sends command even when busy if requireIdle is false', async () => {
@@ -516,7 +517,7 @@ describe('sendCommand', () => {
     const result = await sendCommand('busy-agent', 'ls', { requireIdle: false })
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
   })
 
   it('respects addNewline option', async () => {
@@ -653,8 +654,8 @@ describe('restoreSessions', () => {
     const result = await restoreSessions({ sessionId: 's1' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.results[0]).toEqual({ sessionId: 's1', status: 'restored' })
-    expect(result.data?.summary.restored).toBe(1)
+    expect((result.data as any)?.results[0]).toEqual({ sessionId: 's1', status: 'restored' })
+    expect((result.data as any)?.summary.restored).toBe(1)
   })
 
   it('restores all sessions when all=true', async () => {
@@ -667,8 +668,8 @@ describe('restoreSessions', () => {
     const result = await restoreSessions({ all: true })
 
     expect(result.status).toBe(200)
-    expect(result.data?.summary.restored).toBe(2)
-    expect(result.data?.summary.total).toBe(2)
+    expect((result.data as any)?.summary.restored).toBe(2)
+    expect((result.data as any)?.summary.total).toBe(2)
   })
 
   it('skips sessions that already exist', async () => {
@@ -679,8 +680,8 @@ describe('restoreSessions', () => {
 
     const result = await restoreSessions({ sessionId: 's1' })
 
-    expect(result.data?.results[0].status).toBe('already_exists')
-    expect(result.data?.summary.alreadyExisted).toBe(1)
+    expect((result.data as any)?.results[0].status).toBe('already_exists')
+    expect((result.data as any)?.summary.alreadyExisted).toBe(1)
     expect(mockRuntime.createSession).not.toHaveBeenCalled()
   })
 
@@ -700,9 +701,9 @@ describe('restoreSessions', () => {
 
     const result = await restoreSessions({ all: true })
 
-    expect(result.data?.summary.restored).toBe(1)
-    expect(result.data?.summary.alreadyExisted).toBe(1)
-    expect(result.data?.summary.failed).toBe(1)
+    expect((result.data as any)?.summary.restored).toBe(1)
+    expect((result.data as any)?.summary.alreadyExisted).toBe(1)
+    expect((result.data as any)?.summary.failed).toBe(1)
   })
 
   it('returns 404 when no sessions to restore', async () => {
@@ -723,7 +724,7 @@ describe('broadcastActivityUpdate', () => {
     const result = broadcastActivityUpdate('my-agent', 'active')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
     expect(mockSharedState.broadcastStatusUpdate).toHaveBeenCalledWith('my-agent', 'active', undefined, undefined)
   })
 
@@ -739,7 +740,7 @@ describe('broadcastActivityUpdate', () => {
     const result = broadcastActivityUpdate('', 'active')
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/sessionName/i)
+    expect((result.data as ServiceError).message).toMatch(/sessionName/i)
   })
 })
 
@@ -754,7 +755,7 @@ describe('deletePersistedSession', () => {
     const result = deletePersistedSession('s1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
   })
 
   it('returns 400 when session ID is missing', () => {

--- a/tests/services/teams-service.test.ts
+++ b/tests/services/teams-service.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { makeTeam, makeTask, makeDocument, makeAgent, resetFixtureCounter } from '../test-utils/fixtures'
+import { type ServiceError } from '@/services/service-errors'
 
 // ============================================================================
 // Mocks — vi.hoisted() ensures these are available when vi.mock() runs
@@ -93,7 +94,7 @@ describe('listAllTeams', () => {
     const result = listAllTeams()
 
     expect(result.status).toBe(200)
-    expect(result.data?.teams).toEqual([])
+    expect((result.data as any)?.teams).toEqual([])
   })
 
   it('returns populated list of teams', () => {
@@ -103,8 +104,8 @@ describe('listAllTeams', () => {
     const result = listAllTeams()
 
     expect(result.status).toBe(200)
-    expect(result.data?.teams).toHaveLength(2)
-    expect(result.data?.teams[0].name).toBe('Alpha')
+    expect((result.data as any)?.teams).toHaveLength(2)
+    expect((result.data as any)?.teams[0].name).toBe('Alpha')
   })
 })
 
@@ -120,7 +121,7 @@ describe('createNewTeam', () => {
     const result = createNewTeam({ name: 'New Team', agentIds: [] })
 
     expect(result.status).toBe(201)
-    expect(result.data?.team.name).toBe('New Team')
+    expect((result.data as any)?.team.name).toBe('New Team')
     expect(mockTeams.createTeam).toHaveBeenCalledWith({ name: 'New Team', description: undefined, agentIds: [] })
   })
 
@@ -138,7 +139,7 @@ describe('createNewTeam', () => {
     const result = createNewTeam({ name: '', agentIds: [] })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/name/i)
+    expect((result.data as ServiceError).message).toMatch(/name/i)
     expect(mockTeams.createTeam).not.toHaveBeenCalled()
   })
 
@@ -146,14 +147,14 @@ describe('createNewTeam', () => {
     const result = createNewTeam({ name: null as any, agentIds: [] })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/name/i)
+    expect((result.data as ServiceError).message).toMatch(/name/i)
   })
 
   it('returns 400 when agentIds is not an array', () => {
     const result = createNewTeam({ name: 'Team', agentIds: 'not-array' as any })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/agentIds/i)
+    expect((result.data as ServiceError).message).toMatch(/agentIds/i)
   })
 
   it('returns 500 when createTeam throws', () => {
@@ -162,7 +163,7 @@ describe('createNewTeam', () => {
     const result = createNewTeam({ name: 'Fail', agentIds: [] })
 
     expect(result.status).toBe(500)
-    expect(result.error).toBe('disk full')
+    expect((result.data as ServiceError).message).toContain('disk full')
   })
 
   it('defaults agentIds to empty array when not provided', () => {
@@ -187,7 +188,7 @@ describe('getTeamById', () => {
     const result = getTeamById('team-123')
 
     expect(result.status).toBe(200)
-    expect(result.data?.team.name).toBe('Found')
+    expect((result.data as any)?.team.name).toBe('Found')
   })
 
   it('returns 404 when team not found', () => {
@@ -196,7 +197,7 @@ describe('getTeamById', () => {
     const result = getTeamById('nonexistent')
 
     expect(result.status).toBe(404)
-    expect(result.error).toMatch(/not found/i)
+    expect((result.data as ServiceError).message).toMatch(/not found/i)
   })
 })
 
@@ -212,7 +213,7 @@ describe('updateTeamById', () => {
     const result = updateTeamById('team-1', { name: 'Updated' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.team.name).toBe('Updated')
+    expect((result.data as any)?.team.name).toBe('Updated')
   })
 
   it('passes all update fields', () => {
@@ -251,7 +252,7 @@ describe('updateTeamById', () => {
     const result = updateTeamById('team-1', { name: 'X' })
 
     expect(result.status).toBe(500)
-    expect(result.error).toBe('write error')
+    expect((result.data as ServiceError).message).toContain('write error')
   })
 })
 
@@ -266,7 +267,7 @@ describe('deleteTeamById', () => {
     const result = deleteTeamById('team-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
   })
 
   it('returns 404 when team not found', () => {
@@ -295,7 +296,7 @@ describe('listTeamTasks', () => {
     const result = listTeamTasks('team-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.tasks).toHaveLength(1)
+    expect((result.data as any)?.tasks).toHaveLength(1)
     expect(mockTasks.resolveTaskDeps).toHaveBeenCalledWith(tasks)
   })
 
@@ -307,7 +308,7 @@ describe('listTeamTasks', () => {
     const result = listTeamTasks('team-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.tasks).toEqual([])
+    expect((result.data as any)?.tasks).toEqual([])
   })
 
   it('returns 404 when team not found', () => {
@@ -334,7 +335,7 @@ describe('createTeamTask', () => {
     const result = createTeamTask('team-1', { subject: 'Build API' })
 
     expect(result.status).toBe(201)
-    expect(result.data?.task.subject).toBe('Build API')
+    expect((result.data as any)?.task.subject).toBe('Build API')
   })
 
   it('passes all task fields to createTask', () => {
@@ -384,7 +385,7 @@ describe('createTeamTask', () => {
     const result = createTeamTask('team-1', { subject: '' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/subject/i)
+    expect((result.data as ServiceError).message).toMatch(/subject/i)
   })
 
   it('returns 400 when subject is whitespace only', () => {
@@ -401,7 +402,7 @@ describe('createTeamTask', () => {
     const result = createTeamTask('team-1', { subject: 'X', blockedBy: [123 as any] })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/blockedBy/i)
+    expect((result.data as ServiceError).message).toMatch(/blockedBy/i)
   })
 
   it('returns 500 when createTask throws', () => {
@@ -427,8 +428,8 @@ describe('updateTeamTask', () => {
     const result = updateTeamTask('team-1', 't1', { status: 'completed' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.task.status).toBe('completed')
-    expect(result.data?.unblocked).toEqual([])
+    expect((result.data as any)?.task.status).toBe('completed')
+    expect((result.data as any)?.unblocked).toEqual([])
   })
 
   it('returns unblocked tasks', () => {
@@ -439,7 +440,7 @@ describe('updateTeamTask', () => {
 
     const result = updateTeamTask('team-1', 't1', { status: 'completed' })
 
-    expect(result.data?.unblocked).toHaveLength(1)
+    expect((result.data as any)?.unblocked).toHaveLength(1)
   })
 
   it('returns 404 when team not found', () => {
@@ -448,7 +449,7 @@ describe('updateTeamTask', () => {
     const result = updateTeamTask('nope', 't1', { subject: 'X' })
 
     expect(result.status).toBe(404)
-    expect(result.error).toMatch(/team/i)
+    expect((result.data as ServiceError).message).toMatch(/team/i)
   })
 
   it('returns 404 when task not found', () => {
@@ -458,7 +459,7 @@ describe('updateTeamTask', () => {
     const result = updateTeamTask('team-1', 'nope', { subject: 'X' })
 
     expect(result.status).toBe(404)
-    expect(result.error).toMatch(/task/i)
+    expect((result.data as ServiceError).message).toMatch(/task/i)
   })
 
   it('returns 400 for self-dependency', () => {
@@ -468,7 +469,7 @@ describe('updateTeamTask', () => {
     const result = updateTeamTask('team-1', 't1', { blockedBy: ['t1'] })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/itself/i)
+    expect((result.data as ServiceError).message).toMatch(/itself/i)
   })
 
   it('returns 400 for circular dependency', () => {
@@ -479,7 +480,7 @@ describe('updateTeamTask', () => {
     const result = updateTeamTask('team-1', 't1', { blockedBy: ['t2'] })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/circular/i)
+    expect((result.data as ServiceError).message).toMatch(/circular/i)
   })
 
   it('returns 400 for invalid status', () => {
@@ -489,7 +490,7 @@ describe('updateTeamTask', () => {
     const result = updateTeamTask('team-1', 't1', { status: 'invalid' as any })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/status/i)
+    expect((result.data as ServiceError).message).toMatch(/status/i)
   })
 
   it('accepts valid status values', () => {
@@ -546,7 +547,7 @@ describe('deleteTeamTask', () => {
     const result = deleteTeamTask('team-1', 't1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
   })
 
   it('returns 404 when team not found', () => {
@@ -580,7 +581,7 @@ describe('listTeamDocuments', () => {
     const result = listTeamDocuments('team-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.documents).toHaveLength(2)
+    expect((result.data as any)?.documents).toHaveLength(2)
   })
 
   it('returns empty list when no documents', () => {
@@ -590,7 +591,7 @@ describe('listTeamDocuments', () => {
     const result = listTeamDocuments('team-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.documents).toEqual([])
+    expect((result.data as any)?.documents).toEqual([])
   })
 
   it('returns 404 when team not found', () => {
@@ -615,7 +616,7 @@ describe('createTeamDocument', () => {
     const result = createTeamDocument('team-1', { title: 'New Doc' })
 
     expect(result.status).toBe(201)
-    expect(result.data?.document.title).toBe('New Doc')
+    expect((result.data as any)?.document.title).toBe('New Doc')
   })
 
   it('passes all fields to createDocument', () => {
@@ -658,7 +659,7 @@ describe('createTeamDocument', () => {
     const result = createTeamDocument('team-1', { title: '' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/title/i)
+    expect((result.data as ServiceError).message).toMatch(/title/i)
   })
 
   it('returns 500 when createDocument throws', () => {
@@ -684,7 +685,7 @@ describe('getTeamDocument', () => {
     const result = getTeamDocument('team-1', 'doc-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.document.title).toBe('Found')
+    expect((result.data as any)?.document.title).toBe('Found')
   })
 
   it('returns 404 when team not found', () => {
@@ -693,7 +694,7 @@ describe('getTeamDocument', () => {
     const result = getTeamDocument('nope', 'doc-1')
 
     expect(result.status).toBe(404)
-    expect(result.error).toMatch(/team/i)
+    expect((result.data as ServiceError).message).toMatch(/team/i)
   })
 
   it('returns 404 when document not found', () => {
@@ -703,7 +704,7 @@ describe('getTeamDocument', () => {
     const result = getTeamDocument('team-1', 'nope')
 
     expect(result.status).toBe(404)
-    expect(result.error).toMatch(/document/i)
+    expect((result.data as ServiceError).message).toMatch(/document/i)
   })
 })
 
@@ -719,7 +720,7 @@ describe('updateTeamDocument', () => {
     const result = updateTeamDocument('team-1', 'doc-1', { title: 'Updated' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.document.title).toBe('Updated')
+    expect((result.data as any)?.document.title).toBe('Updated')
   })
 
   it('passes only provided fields', () => {
@@ -766,7 +767,7 @@ describe('deleteTeamDocument', () => {
     const result = deleteTeamDocument('team-1', 'doc-1')
 
     expect(result.status).toBe(200)
-    expect(result.data?.success).toBe(true)
+    expect((result.data as any)?.success).toBe(true)
   })
 
   it('returns 404 when document not found', () => {
@@ -791,7 +792,7 @@ describe('notifyTeamAgents', () => {
     const result = await notifyTeamAgents({ agentIds: ['a1'], teamName: 'Team Alpha' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.results).toHaveLength(1)
+    expect((result.data as any)?.results).toHaveLength(1)
     expect(mockNotificationService.notifyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: 'a1',
@@ -807,7 +808,7 @@ describe('notifyTeamAgents', () => {
     const result = await notifyTeamAgents({ agentIds: ['nonexistent'], teamName: 'Team' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.results[0]).toEqual(
+    expect((result.data as any)?.results[0]).toEqual(
       expect.objectContaining({ agentId: 'nonexistent', success: false, reason: 'Agent not found' })
     )
   })
@@ -822,7 +823,7 @@ describe('notifyTeamAgents', () => {
     const result = await notifyTeamAgents({ agentIds: ['a1', 'a2'], teamName: 'Team' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.results).toHaveLength(2)
+    expect((result.data as any)?.results).toHaveLength(2)
   })
 
   it('handles notification failure for an agent', async () => {
@@ -833,7 +834,7 @@ describe('notifyTeamAgents', () => {
     const result = await notifyTeamAgents({ agentIds: ['a1'], teamName: 'Team' })
 
     expect(result.status).toBe(200)
-    expect(result.data?.results[0]).toEqual(
+    expect((result.data as any)?.results[0]).toEqual(
       expect.objectContaining({ success: false })
     )
   })
@@ -842,7 +843,7 @@ describe('notifyTeamAgents', () => {
     const result = await notifyTeamAgents({ agentIds: null as any, teamName: 'Team' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/agentIds/i)
+    expect((result.data as ServiceError).message).toMatch(/agentIds/i)
   })
 
   it('returns 400 when agentIds is not an array', async () => {
@@ -855,7 +856,7 @@ describe('notifyTeamAgents', () => {
     const result = await notifyTeamAgents({ agentIds: ['a1'], teamName: '' })
 
     expect(result.status).toBe(400)
-    expect(result.error).toMatch(/teamName/i)
+    expect((result.data as ServiceError).message).toMatch(/teamName/i)
   })
 
   it('returns 400 when teamName is not a string', async () => {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.27.0",
-  "releaseDate": "2026-04-13",
+  "version": "0.29.0",
+  "releaseDate": "2026-04-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

Resolves #285 by standardizing every API error response into one structured shape across the entire codebase. Inspired by @mvillmow's analysis of the 106 route handlers, this PR goes further than middleware extraction — it unifies the underlying error contract that every service and route shares.

**Before:** ~280 services returned plain string errors (`{ error: 'Human text' }`); ~35 AMP routes returned structured codes (`{ error: 'code', message: '...', field?, details? }`). Consumers had to handle two shapes.

**After:** One shape everywhere — the AMP protocol format.

## What changed

- **New `services/service-errors.ts`** — single source of truth for `ServiceResult<T>`, `ServiceError`, `ServiceErrorCode` (30 codes: 18 AMP + 12 generic), 20+ factory functions (`missingField`, `notFound`, `operationFailed`, `alreadyExists`, etc.), and validation helpers (`requireString`, `requireArray`, `requireNameFormat`).
- **New `app/api/_helpers.ts`** — `toResponse()` converts `ServiceResult` into `NextResponse` with consistent error formatting.
- **25 service files migrated** — all ~305 error returns now use shared factories. Local `ServiceResult<T>` definitions removed.
- **88 route files simplified** — all are now thin wrappers: `return toResponse(result)`.
- **25 component files updated** — read `data.message || data.error` for backward-compatible error display.
- **5 test files updated** — 49 assertions now match the structured `ServiceError` shape.
- **`lib/types/amp.ts` refactored** — `AMPErrorCode` is now `Extract<ServiceErrorCode, ...>`, `AMPError extends ServiceError`. `AMPNameTakenError` interface fixed to match runtime shape (`details.suggestions`).
- **`services/headless-router.ts`** — `sendServiceResult()` mirrors `toResponse()` for the headless mode.

## Net diff

`154 files changed, 1365 insertions(+), 1977 deletions(-)` — net **-612 lines** despite adding the new foundation, thanks to the consolidated error handling.

## Test plan

- [x] `yarn test` — 545/545 tests pass
- [x] `yarn build` — production build succeeds
- [x] Verify dashboard loads, agent CRUD works, AMP send/receive works
- [x] Verify all consumers handle both old and new error shapes during transition
- [x] Code review of all 6 review findings (HIGH/MEDIUM/LOW) — all addressed

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)