### PR TITLE
feat: standalone agent presence via heartbeat (v0.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.29.2] - 2026-04-16
+
+### Added
+- **Standalone agent presence** — Agents that run outside of tmux (plain terminal, API-only, remote hosts) can now appear live in the dashboard via a heartbeat mechanism. New `POST /api/agents/:id/heartbeat` endpoint lets any agent announce itself periodically. The dashboard discovers standalone agents alongside tmux sessions, Docker containers, and cloud deployments. Agents with a recent heartbeat (< 2 min) show in the sidebar; stale heartbeats auto-expire.
+- **Hook-based heartbeat for Claude Code** — The AI Maestro hook now sends a heartbeat on every event (SessionStart, Stop, Notification), so Claude Code sessions automatically register their presence even when running outside tmux. The hook also sends `agentId` alongside `sessionName` in status broadcasts for more precise activity tracking.
+- **`agentActivity` shared state** — New in-memory Map tracking standalone agent heartbeat timestamps, shared between server.mjs and API routes via the existing globalThis bridge pattern.
+- **Client-side activity by agentId** — The `useSessionActivity` hook now indexes activity updates by both `sessionName` and `agentId`, and `getSessionActivity()` accepts an optional `agentId` parameter for standalone agent lookups.
+- **`standalone` flag on Session type** — Sessions discovered via heartbeat carry `standalone: true` so the UI can distinguish them from tmux/Docker/cloud sessions.
+
+### Fixed
+- **Hook directory matching bug** — Removed `agentWd.startsWith(cwd + '/')` from all 3 hook copies. This condition caused a parent directory agent to incorrectly match when running from any child directory (e.g., agent in `/project` would match cwd `/project-tools`). Only exact matches and "cwd is inside agent's directory" now count.
+
 ## [0.29.1] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.29.3] - 2026-04-17
+
+### Fixed
+- **Standalone agents now visible in dashboard sidebar** — The sidebar uses `/api/agents` (agents-core-service), not `/api/sessions`. Heartbeat data was only integrated into the sessions endpoint. Now `listAgents()` checks the `agentActivity` heartbeat map so standalone agents show as online with `session.standalone: true`.
+- **Heartbeat ID resolution** — The heartbeat function now resolves agent identifiers by both UUID and name, fixing a mismatch where heartbeats stored under the agent name couldn't be found by UUID lookup in `listAgents()`.
+- **Standalone agent terminal view** — Clicking a standalone agent no longer attempts a WebSocket/tmux connection. The dashboard shows a "Standalone Agent" placeholder explaining the agent runs outside tmux. This applies whether the agent is online (recent heartbeat) or offline (expired heartbeat).
+- **Persistent standalone flag** — Agents with no tmux sessions and no cloud deployment are marked `standalone: true` even when offline, preventing the "Start Session" prompt for agents that were never meant to have a terminal.
+
 ## [0.29.2] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)
@@ -88,7 +88,7 @@ Every feature was born from a real problem. We built them in the order we needed
 
 *I had 35 terminals and couldn't tell which was which.*
 
-See and manage all your AI agents in one place. Create agents from the UI, organize them with smart naming (`project-backend-api` becomes a 3-level tree with auto-coloring), and switch between any agent with a click. Auto-discovers your existing tmux sessions.
+See and manage all your AI agents in one place. Create agents from the UI, organize them with smart naming (`project-backend-api` becomes a 3-level tree with auto-coloring), and switch between any agent with a click. Auto-discovers tmux sessions, Docker containers, cloud deployments, and standalone agents (plain terminals, API-only agents, or remote hosts that register via heartbeat).
 
 ### Any Machine
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/agents/[id]/heartbeat/route.ts
+++ b/app/api/agents/[id]/heartbeat/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { heartbeat } from '@/services/sessions-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/agents/:id/heartbeat
+ * Standalone agents call this periodically to appear in the dashboard.
+ * Body: { status?: 'active' | 'idle' | 'waiting' }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const body = await request.json().catch(() => ({}))
+    const result = heartbeat(id, body.status)
+    return toResponse(result)
+  } catch (error) {
+    console.error('[Heartbeat API] Error:', error)
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/sessions/activity/update/route.ts
+++ b/app/api/sessions/activity/update/route.ts
@@ -11,9 +11,9 @@ export const dynamic = 'force-dynamic'
  */
 export async function POST(request: NextRequest) {
   try {
-    const { sessionName, status, hookStatus, notificationType } = await request.json()
+    const { sessionName, status, hookStatus, notificationType, agentId } = await request.json()
 
-    const result = broadcastActivityUpdate(sessionName, status, hookStatus, notificationType)
+    const result = broadcastActivityUpdate(sessionName, status, hookStatus, notificationType, agentId)
     return toResponse(result)
   } catch (error) {
     console.error('[Activity Update API] Error:', error)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -677,8 +677,28 @@ export default function DashboardPage() {
               </div>
             )}
 
-            {/* Truly offline agent (no session config) - show profile prompt */}
-            {activeAgent && activeAgent.session?.status === 'offline' && !(activeAgent.sessions && activeAgent.sessions.length > 0) && (
+            {/* Standalone agent (no tmux session, heartbeat-based) */}
+            {activeAgent && activeAgent.session?.standalone && (
+              <div className="flex-1 flex items-center justify-center text-gray-400">
+                <div className="text-center max-w-md">
+                  <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-violet-900/30 flex items-center justify-center">
+                    <Terminal className="w-10 h-10 text-violet-400" />
+                  </div>
+                  <p className="text-xl mb-2 text-gray-300">{activeAgent.label || activeAgent.name || activeAgent.alias}</p>
+                  <p className="text-sm mb-2 text-gray-500">Standalone Agent</p>
+                  <p className="text-xs text-gray-600">This agent is running outside tmux. No terminal view available.</p>
+                  <button
+                    onClick={() => handleShowAgentProfile(activeAgent)}
+                    className="mt-4 px-6 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-all"
+                  >
+                    View Profile
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Truly offline agent (no session config, not standalone) - show profile prompt */}
+            {activeAgent && activeAgent.session?.status === 'offline' && !activeAgent.session?.standalone && !(activeAgent.sessions && activeAgent.sessions.length > 0) && (
               <div className="flex-1 flex items-center justify-center text-gray-400">
                 <div className="text-center max-w-md">
                   <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-gray-800 flex items-center justify-center">
@@ -889,6 +909,17 @@ export default function DashboardPage() {
                                 </>
                               )}
                             </button>
+                          </div>
+                        </div>
+                      ) : session.standalone ? (
+                        <div className="flex-1 flex items-center justify-center text-gray-400">
+                          <div className="text-center max-w-md">
+                            <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-violet-900/30 flex items-center justify-center">
+                              <Terminal className="w-10 h-10 text-violet-400" />
+                            </div>
+                            <p className="text-xl mb-2 text-gray-300">{agent.label || agent.name || agent.alias}</p>
+                            <p className="text-sm mb-2 text-gray-500">Standalone Agent</p>
+                            <p className="text-xs text-gray-600">This agent is running outside tmux (plain terminal, API-only, or remote host). No terminal view available.</p>
                           </div>
                         </div>
                       ) : (

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.1
+**Current Version:** v0.29.2
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.2
+**Current Version:** v0.29.3
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.1",
+      "softwareVersion": "0.29.2",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",
@@ -54,6 +54,7 @@
         "Conversation history with full-text search",
         "Auto-generated documentation search",
         "Zero-configuration auto-discovery of tmux sessions",
+        "Standalone agent presence via heartbeat (no tmux required)",
         "Real-time WebSocket terminal streaming",
         "Mobile remote access via Tailscale VPN",
         "Peer mesh network across multiple machines",
@@ -88,7 +89,7 @@
             <h2>What is AI Maestro?</h2>
             <p>AI Maestro is an open-source, browser-based dashboard for orchestrating multiple AI coding agents from one unified interface. It provides persistent memory, code understanding, and four ways for agents to communicate (internal messaging, Slack, email, external APIs).</p>
 
-            <p><strong>Version:</strong> 0.24.21 (March 2026)</p>
+            <p><strong>Version:</strong> 0.29.2 (April 2026)</p>
             <p><strong>License:</strong> MIT (Free and Open Source)</p>
             <p><strong>GitHub:</strong> https://github.com/23blocks-OS/ai-maestro</p>
             <p><strong>Website:</strong> https://ai-maestro.23blocks.com</p>
@@ -102,6 +103,7 @@
                 <li><strong>Cursor</strong> - AI-first code editor</li>
                 <li><strong>GitHub Copilot CLI</strong> - GitHub's AI coding assistant</li>
                 <li><strong>Any terminal-based AI agent</strong> - Universal compatibility via tmux</li>
+                <li><strong>Standalone agents</strong> - Non-tmux agents (plain terminal, API-only) supported via heartbeat API</li>
             </ul>
         </section>
 
@@ -115,6 +117,7 @@
                 <li><strong>Universal Support:</strong> Works with Claude Code, Aider, Cursor, GitHub Copilot, or any terminal AI.</li>
                 <li><strong>Real-time Terminals:</strong> WebSocket streaming with full ANSI support. No lag, no polling.</li>
                 <li><strong>Smart Organization:</strong> 3-level hierarchy with dynamic colors (project-category-agent naming).</li>
+                <li><strong>Standalone Agent Presence:</strong> Agents without tmux (plain terminals, API-only, remote hosts) appear live in the dashboard via heartbeat. No tmux required.</li>
             </ul>
 
             <h3>Tier 2: The Superpowers</h3>
@@ -326,6 +329,7 @@ cd ai-maestro && yarn install && yarn dev
                 <li><strong>GET /api/agents</strong> - List all registered agents</li>
                 <li><strong>POST /api/agents</strong> - Create new agent</li>
                 <li><strong>GET /api/agents/:id</strong> - Get agent details</li>
+                <li><strong>POST /api/agents/:id/heartbeat</strong> - Register standalone agent presence (no tmux needed)</li>
             </ul>
 
             <h3>Messaging</h3>
@@ -390,13 +394,14 @@ cd ai-maestro && yarn install && yarn dev
         <section>
             <h2>Quick Facts for LLMs</h2>
             <ul>
-                <li><strong>Current Version:</strong> 0.24.21 (March 2026)</li>
+                <li><strong>Current Version:</strong> 0.29.2 (April 2026)</li>
                 <li><strong>License:</strong> MIT (completely free)</li>
                 <li><strong>Primary Use Case:</strong> Orchestrate Claude Code + other AI agents</li>
                 <li><strong>Skills Standard:</strong> All 6 skills comply with the Agent Skills Standard (agentskills.io/specification), compatible with 30+ agents</li>
                 <li><strong>Installation Time:</strong> 5 minutes for basic setup</li>
                 <li><strong>Platform Support:</strong> macOS, Windows (WSL2), Linux</li>
                 <li><strong>Zero Config:</strong> Yes, auto-discovers tmux sessions</li>
+                <li><strong>Standalone Agents:</strong> Yes, heartbeat-based presence for non-tmux agents</li>
                 <li><strong>Agent Communication:</strong> 4 channels (internal, Slack, email, external)</li>
                 <li><strong>Slack Integration:</strong> Yes, for team collaboration</li>
                 <li><strong>Email Identity:</strong> Yes, assign email addresses to agents</li>

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.2",
+      "softwareVersion": "0.29.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.29.1",
+      "softwareVersion": "0.29.2",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -109,6 +109,7 @@
         "Cross-host agent transfer",
         "Team Meetings with multi-agent war room sessions",
         "Kanban Board with 5-column drag-and-drop task management",
+        "Standalone agent presence via heartbeat (no tmux required)",
         "Composable Plugin Builder for custom agent skill sets",
         "Agent Skills Standard compliant - works with Claude Code, OpenCode, Codex CLI, Gemini CLI, Cursor, GitHub Copilot, and 30+ agents"
       ]
@@ -448,7 +449,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.1</span>
+                        <span>v0.29.2</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
@@ -755,6 +756,13 @@
                         </div>
                         <h4 class="font-bold text-white text-lg mb-2 group-hover:text-cyan-400 transition-colors">Smart Organization</h4>
                         <p class="text-slate-400 text-sm leading-relaxed">3-level hierarchy with dynamic colors. Instant visual organization for any project.</p>
+                    </div>
+                    <div class="group bg-slate-900/80 border border-slate-700 rounded-xl p-6 hover:border-cyan-500/50 hover:bg-slate-900 transition-all duration-300">
+                        <div class="w-12 h-12 rounded-lg bg-cyan-500/10 border border-cyan-500/30 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                            <span class="text-2xl">📡</span>
+                        </div>
+                        <h4 class="font-bold text-white text-lg mb-2 group-hover:text-cyan-400 transition-colors">Standalone Agents</h4>
+                        <p class="text-slate-400 text-sm leading-relaxed">Agents without tmux appear live via heartbeat. Plain terminals, API agents, remote hosts — all visible.</p>
                     </div>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.29.2",
+      "softwareVersion": "0.29.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -449,7 +449,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.2</span>
+                        <span>v0.29.3</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/hooks/useSessionActivity.ts
+++ b/hooks/useSessionActivity.ts
@@ -92,16 +92,19 @@ export function useSessionActivity() {
             setActivity(data.activity || {})
             setLoading(false)
           } else if (data.type === 'status_update') {
-            // Real-time status update
-            setActivity(prev => ({
-              ...prev,
-              [data.sessionName]: {
+            // Real-time status update — index by both sessionName and agentId
+            setActivity(prev => {
+              const update: SessionActivityInfo = {
                 lastActivity: data.timestamp,
                 status: data.status,
                 hookStatus: data.hookStatus,
                 notificationType: data.notificationType
               }
-            }))
+              const next = { ...prev }
+              if (data.sessionName) next[data.sessionName] = update
+              if (data.agentId) next[data.agentId] = update
+              return next
+            })
           }
         } catch (err) {
           console.error('[useSessionActivity] Failed to parse message:', err)
@@ -155,13 +158,14 @@ export function useSessionActivity() {
   }, [connect, fetchActivity])
 
   /**
-   * Get activity status for a specific session
+   * Get activity status for a specific session or agent
    * @param sessionName The tmux session name
+   * @param agentId Optional agent ID (for standalone agents)
    * @returns Activity info or null if not found
    */
   const getSessionActivity = useCallback(
-    (sessionName: string): SessionActivityInfo | null => {
-      return activity[sessionName] || null
+    (sessionName: string, agentId?: string): SessionActivityInfo | null => {
+      return activity[sessionName] || (agentId ? activity[agentId] : null) || null
     },
     [activity]
   )

--- a/lib/agent-utils.ts
+++ b/lib/agent-utils.ts
@@ -70,5 +70,6 @@ export function agentToSession(agent: Agent): Session {
     windows: 1,
     agentId: agent.id,
     hostId: agent.hostId,
+    standalone: agent.session?.standalone,
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -57,7 +57,6 @@ async function broadcastStatusUpdate(cwd, state) {
             if (!agentWd) return false;
             if (agentWd === cwd) return true;
             if (cwd.startsWith(agentWd + '/')) return true;
-            if (agentWd.startsWith(cwd + '/')) return true;
             return false;
         });
 
@@ -72,13 +71,23 @@ async function broadcastStatusUpdate(cwd, state) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 sessionName,
+                agentId: agent.id,
                 status: state.status,
                 hookStatus: state.status,
                 notificationType: state.notificationType
             })
         });
 
-        debugLog({ event: 'status_broadcast', sessionName, status: state.status });
+        // Also send heartbeat so standalone agents appear in dashboard
+        if (agent.id) {
+            await fetch(`http://localhost:23000/api/agents/${encodeURIComponent(agent.id)}/heartbeat`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status: state.status })
+            }).catch(() => {});
+        }
+
+        debugLog({ event: 'status_broadcast', sessionName, agentId: agent.id, status: state.status });
     } catch (err) {
         debugLog({ event: 'status_broadcast_error', error: err.message });
     }
@@ -207,7 +216,6 @@ async function checkUnreadMessages(cwd) {
             if (cwd.startsWith(agentWd + '/')) return true;
 
             // Agent's working directory is subdirectory of cwd
-            if (agentWd.startsWith(cwd + '/')) return true;
 
             return false;
         });

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.1"
+VERSION="0.29.2"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.2"
+VERSION="0.29.3"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -60,7 +60,7 @@ import { getHosts, getSelfHost, getSelfHostId, isSelf } from '@/lib/hosts-config
 import { persistSession, unpersistSession } from '@/lib/session-persistence'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { initializeAllAgents, getStartupStatus } from '@/lib/agent-startup'
-import { sessionActivity } from '@/services/shared-state'
+import { sessionActivity, agentActivity } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
 import type { Host } from '@/types/host'
 import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed, gone, timeout } from '@/services/service-errors'
@@ -464,6 +464,14 @@ export async function listAgents(): Promise<ServiceResult<{
 
       const hasOnlineSession = updatedSessions.some(s => s.status === 'online')
 
+      // Check for standalone agent heartbeat (agents without tmux sessions)
+      const heartbeatTs = agentActivity.get(agent.id)
+      const heartbeatAge = heartbeatTs ? (Date.now() - heartbeatTs) / 1000 : Infinity
+      const hasRecentHeartbeat = heartbeatAge < 120 // 2 minutes
+      const isOnline = hasOnlineSession || hasRecentHeartbeat
+      // Standalone = no tmux sessions discovered AND not a cloud agent
+      const isStandalone = agentSessions.length === 0 && agent.deployment?.type !== 'cloud'
+
       // Create session status for API response (backward compatibility)
       const onlineSession = updatedSessions.find(s => s.status === 'online')
       const primarySession = updatedSessions.find(s => s.index === 0) || updatedSessions[0]
@@ -480,19 +488,29 @@ export async function listAgents(): Promise<ServiceResult<{
             hostId,
             hostName,
           }
+        : hasRecentHeartbeat
+        ? {
+            status: 'online',
+            workingDirectory: agent.workingDirectory || primarySession?.workingDirectory,
+            lastActivity: new Date(heartbeatTs!).toISOString(),
+            hostId,
+            hostName,
+            standalone: true,
+          }
         : {
             status: 'offline',
             workingDirectory: agent.workingDirectory || primarySession?.workingDirectory,
             hostId,
             hostName,
+            ...(isStandalone && { standalone: true }),
           }
 
       const updatedAgent: Agent = {
         ...agent,
         name: agentName,
         sessions: updatedSessions,
-        status: hasOnlineSession ? 'active' : 'offline',
-        lastActive: hasOnlineSession ? new Date().toISOString() : agent.lastActive,
+        status: isOnline ? 'active' : 'offline',
+        lastActive: isOnline ? new Date().toISOString() : agent.lastActive,
       }
 
       resultAgents.push(mergeAgentWithSession(updatedAgent, sessionStatus, hostId, hostName, hostUrl, false))

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -152,6 +152,7 @@ import {
   deletePersistedSession,
   getActivity,
   broadcastActivityUpdate,
+  heartbeat,
 } from '@/services/sessions-service'
 
 import {
@@ -489,7 +490,7 @@ const routes: Route[] = [
   }},
   { method: 'POST', pattern: /^\/api\/sessions\/activity\/update$/, paramNames: [], handler: async (req, res) => {
     const body = await readJsonBody(req)
-    const result = broadcastActivityUpdate(body.sessionName, body.status, body.hookStatus, body.notificationType)
+    const result = broadcastActivityUpdate(body.sessionName, body.status, body.hookStatus, body.notificationType, body.agentId)
     sendServiceResult(res, result)
   }},
 
@@ -933,6 +934,12 @@ const routes: Route[] = [
     } else {
       sendJson(res, 200, { success: true })
     }
+  }},
+
+  // Agent heartbeat (standalone presence)
+  { method: 'POST', pattern: /^\/api\/agents\/([^/]+)\/heartbeat$/, paramNames: ['id'], handler: async (req, res, params) => {
+    const body = await readJsonBody(req).catch(() => ({}))
+    sendServiceResult(res, heartbeat(params.id, body.status))
   }},
 
   // Agent CRUD (must be LAST among /api/agents/[id]/* routes)

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -33,7 +33,7 @@ import { getHosts, getSelfHost, getSelfHostId, isSelf, getHostById } from '@/lib
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
 import { parseNameForDisplay } from '@/types/agent'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
-import { sessionActivity, broadcastStatusUpdate } from '@/services/shared-state'
+import { sessionActivity, agentActivity, broadcastStatusUpdate } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
 import crypto from 'crypto'
 import { type ServiceResult, missingField, notFound, alreadyExists, invalidField, operationFailed, serviceError } from '@/services/service-errors'
@@ -299,6 +299,38 @@ async function fetchLocalSessions(hostId: string): Promise<Session[]> {
       // Docker not available
     }
 
+    // Discover standalone agents (registered with heartbeat, no tmux session)
+    try {
+      const allAgents = loadAgents()
+      for (const agent of allAgents) {
+        const agentName = agent.name || agent.alias
+        if (!agentName || sessions.find(s => s.name === agentName)) continue
+        if (agent.deployment?.type === 'cloud') continue
+
+        const heartbeatTs = agentActivity.get(agent.id)
+        if (!heartbeatTs) continue
+
+        const age = (Date.now() - heartbeatTs) / 1000
+        if (age > 120) continue  // stale heartbeat (2 min)
+
+        sessions.push({
+          id: agentName,
+          name: agentName,
+          workingDirectory: agent.workingDirectory || agent.sessions?.[0]?.workingDirectory || '',
+          status: age > 3 ? 'idle' : 'active',
+          createdAt: agent.createdAt,
+          lastActivity: new Date(heartbeatTs).toISOString(),
+          windows: 0,
+          hostId,
+          version: AI_MAESTRO_VERSION,
+          agentId: agent.id,
+          standalone: true,
+        })
+      }
+    } catch (error) {
+      console.error('Error discovering standalone agents:', error)
+    }
+
     // Discover OpenClaw sessions (custom tmux sockets)
     try {
       const openclawSocketDir = process.env.OPENCLAW_TMUX_SOCKET_DIR
@@ -511,13 +543,25 @@ export function broadcastActivityUpdate(
   sessionName: string,
   status: string,
   hookStatus?: string,
-  notificationType?: string
+  notificationType?: string,
+  agentId?: string
 ): ServiceResult<{ success: boolean }> {
-  if (!sessionName) {
+  if (!sessionName && !agentId) {
     return missingField('sessionName')
   }
 
-  broadcastStatusUpdate(sessionName, status, hookStatus, notificationType)
+  broadcastStatusUpdate(sessionName, status, hookStatus, notificationType, agentId)
+  return { data: { success: true }, status: 200 }
+}
+
+/**
+ * Record a heartbeat for a standalone agent (no tmux session).
+ * Makes the agent appear in the dashboard session list.
+ */
+export function heartbeat(agentId: string, status?: string): ServiceResult<{ success: boolean }> {
+  if (!agentId) return missingField('agentId')
+  agentActivity.set(agentId, Date.now())
+  broadcastStatusUpdate('', status || 'active', undefined, undefined, agentId)
   return { data: { success: true }, status: 200 }
 }
 

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -27,7 +27,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import type { Session } from '@/types/session'
-import { getAgentBySession, getAgentByName, createAgent, deleteAgentBySession, renameAgentSession } from '@/lib/agent-registry'
+import { getAgent, getAgentBySession, getAgentByName, createAgent, deleteAgentBySession, renameAgentSession } from '@/lib/agent-registry'
 import { loadAgents } from '@/lib/agent-registry'
 import { getHosts, getSelfHost, getSelfHostId, isSelf, getHostById } from '@/lib/hosts-config'
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
@@ -560,8 +560,11 @@ export function broadcastActivityUpdate(
  */
 export function heartbeat(agentId: string, status?: string): ServiceResult<{ success: boolean }> {
   if (!agentId) return missingField('agentId')
-  agentActivity.set(agentId, Date.now())
-  broadcastStatusUpdate('', status || 'active', undefined, undefined, agentId)
+  // Resolve: agentId could be a UUID or a name. Store heartbeat under the UUID.
+  const agent = getAgent(agentId) || getAgentByName(agentId)
+  const resolvedId = agent?.id || agentId
+  agentActivity.set(resolvedId, Date.now())
+  broadcastStatusUpdate('', status || 'active', undefined, undefined, resolvedId)
   return { data: { success: true }, status: 200 }
 }
 

--- a/services/shared-state-bridge.mjs
+++ b/services/shared-state-bridge.mjs
@@ -13,6 +13,7 @@
 if (!globalThis._sharedState) {
   globalThis._sharedState = {
     sessionActivity: new Map(),      // sessionName -> lastActivityTimestamp (ms)
+    agentActivity: new Map(),        // agentId -> lastHeartbeatTimestamp (ms) for standalone agents
     terminalSessions: new Map(),     // sessionName -> { clients, ptyProcess, logStream, ... }
     statusSubscribers: new Set(),    // Set<WebSocket> for /status subscribers
     companionClients: new Map(),     // agentId -> Set<WebSocket> for /companion-ws
@@ -22,6 +23,7 @@ if (!globalThis._sharedState) {
 const state = globalThis._sharedState
 
 export const sessionActivity = state.sessionActivity
+export const agentActivity = state.agentActivity
 export const terminalSessions = state.terminalSessions
 export const statusSubscribers = state.statusSubscribers
 export const companionClients = state.companionClients
@@ -30,10 +32,11 @@ export const companionClients = state.companionClients
  * Broadcast a status update to all /status WebSocket subscribers.
  * Used by API routes and server.mjs.
  */
-export function broadcastStatusUpdate(sessionName, status, hookStatus, notificationType) {
+export function broadcastStatusUpdate(sessionName, status, hookStatus, notificationType, agentId) {
   const message = JSON.stringify({
     type: 'status_update',
     sessionName,
+    ...(agentId && { agentId }),
     status,
     hookStatus,
     notificationType,

--- a/services/shared-state.ts
+++ b/services/shared-state.ts
@@ -27,6 +27,7 @@ export interface PTYSessionState {
 export interface StatusUpdate {
   type: 'status_update'
   sessionName: string
+  agentId?: string
   status: string
   hookStatus?: string
   notificationType?: string
@@ -41,6 +42,7 @@ declare global {
   // eslint-disable-next-line no-var
   var _sharedState: {
     sessionActivity: Map<string, number>
+    agentActivity: Map<string, number>
     terminalSessions: Map<string, PTYSessionState>
     statusSubscribers: Set<WebSocket>
     companionClients: Map<string, Set<WebSocket>>
@@ -50,6 +52,7 @@ declare global {
 if (!globalThis._sharedState) {
   globalThis._sharedState = {
     sessionActivity: new Map<string, number>(),
+    agentActivity: new Map<string, number>(),
     terminalSessions: new Map<string, PTYSessionState>(),
     statusSubscribers: new Set<WebSocket>(),
     companionClients: new Map<string, Set<WebSocket>>(),
@@ -64,6 +67,9 @@ const state = globalThis._sharedState
 
 /** sessionName -> last activity timestamp (ms). Populated by server.mjs PTY data handler. */
 export const sessionActivity: Map<string, number> = state.sessionActivity
+
+/** agentId -> last heartbeat timestamp (ms). Populated by heartbeat API for standalone agents. */
+export const agentActivity: Map<string, number> = state.agentActivity
 
 /** sessionName -> PTY process + connected clients. Populated by server.mjs WebSocket handler. */
 export const terminalSessions: Map<string, PTYSessionState> = state.terminalSessions
@@ -82,11 +88,13 @@ export function broadcastStatusUpdate(
   sessionName: string,
   status: string,
   hookStatus?: string,
-  notificationType?: string
+  notificationType?: string,
+  agentId?: string
 ): void {
   const message = JSON.stringify({
     type: 'status_update',
     sessionName,
+    ...(agentId && { agentId }),
     status,
     hookStatus,
     notificationType,

--- a/tests/services/agents-core-service.test.ts
+++ b/tests/services/agents-core-service.test.ts
@@ -71,6 +71,7 @@ const {
     },
     mockSharedState: {
       sessionActivity: new Map<string, number>(),
+      agentActivity: new Map<string, number>(),
     },
     mockAgentStartup: {
       initializeAllAgents: vi.fn().mockResolvedValue({ initialized: [], failed: [] }),
@@ -144,6 +145,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   resetFixtureCounter()
   mockSharedState.sessionActivity.clear()
+  mockSharedState.agentActivity.clear()
   mockRuntime.listSessions.mockResolvedValue([])
   mockRuntime.sessionExists.mockResolvedValue(false)
   mockRuntime.createSession.mockResolvedValue(undefined)

--- a/tests/services/sessions-service.test.ts
+++ b/tests/services/sessions-service.test.ts
@@ -62,6 +62,7 @@ const {
     },
     mockSharedState: {
       sessionActivity: new Map<string, number>(),
+      agentActivity: new Map<string, number>(),
       broadcastStatusUpdate: vi.fn(),
     },
     mockFs: {
@@ -120,6 +121,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   resetFixtureCounter()
   mockSharedState.sessionActivity.clear()
+  mockSharedState.agentActivity.clear()
   // Reset runtime mock defaults
   mockRuntime.listSessions.mockResolvedValue([])
   mockRuntime.sessionExists.mockResolvedValue(false)
@@ -725,18 +727,31 @@ describe('broadcastActivityUpdate', () => {
 
     expect(result.status).toBe(200)
     expect((result.data as any)?.success).toBe(true)
-    expect(mockSharedState.broadcastStatusUpdate).toHaveBeenCalledWith('my-agent', 'active', undefined, undefined)
+    expect(mockSharedState.broadcastStatusUpdate).toHaveBeenCalledWith('my-agent', 'active', undefined, undefined, undefined)
   })
 
   it('passes hookStatus and notificationType', () => {
     broadcastActivityUpdate('my-agent', 'waiting', 'waiting_for_input', 'permission')
 
     expect(mockSharedState.broadcastStatusUpdate).toHaveBeenCalledWith(
-      'my-agent', 'waiting', 'waiting_for_input', 'permission'
+      'my-agent', 'waiting', 'waiting_for_input', 'permission', undefined
     )
   })
 
-  it('returns 400 when sessionName is missing', () => {
+  it('passes agentId when provided', () => {
+    broadcastActivityUpdate('my-agent', 'active', undefined, undefined, 'agent-123')
+
+    expect(mockSharedState.broadcastStatusUpdate).toHaveBeenCalledWith(
+      'my-agent', 'active', undefined, undefined, 'agent-123'
+    )
+  })
+
+  it('allows empty sessionName when agentId is provided', () => {
+    const result = broadcastActivityUpdate('', 'active', undefined, undefined, 'agent-123')
+    expect(result.status).toBe(200)
+  })
+
+  it('returns 400 when both sessionName and agentId are missing', () => {
     const result = broadcastActivityUpdate('', 'active')
 
     expect(result.status).toBe(400)

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -511,6 +511,7 @@ export interface AgentSessionStatus {
   // GAP6 FIX: Include host context for distributed agents
   hostId?: string                 // Host ID where session runs (e.g., 'local', 'mac-mini')
   hostName?: string               // Human-readable host name
+  standalone?: boolean            // Agent registered via heartbeat, no tmux session
 }
 
 /**

--- a/types/session.ts
+++ b/types/session.ts
@@ -33,6 +33,9 @@ export interface Session {
 
   // Custom tmux socket (e.g., OpenClaw agents)
   socketPath?: string           // Custom tmux socket path for -S flag
+
+  // Standalone agent (no tmux session, heartbeat-based presence)
+  standalone?: boolean          // true if agent registered via heartbeat, no terminal
 }
 
 export type SessionStatus = Session['status']

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.29.2",
+  "version": "0.29.3",
   "releaseDate": "2026-04-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.29.1",
+  "version": "0.29.2",
   "releaseDate": "2026-04-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- **Standalone agent presence** — Agents without tmux (plain terminal, API-only, remote hosts) can now appear live in the dashboard via a heartbeat mechanism (`POST /api/agents/:id/heartbeat`)
- **Hook-based auto-heartbeat** — Claude Code hook now sends heartbeat + agentId on every event, so any Claude Code session auto-registers regardless of whether it runs in tmux
- **Bug fix** — Removed `agentWd.startsWith(cwd + '/')` from hook directory matching that caused wrong-agent matches for parent directories

## What changed

| Area | Files | Change |
|------|-------|--------|
| Shared state | `shared-state.ts`, `shared-state-bridge.mjs` | Added `agentActivity` Map, `agentId` to `StatusUpdate`, extended `broadcastStatusUpdate()` |
| Session service | `sessions-service.ts` | Added `heartbeat()`, standalone agent discovery in `fetchLocalSessions()`, `agentId` in `broadcastActivityUpdate()` |
| API | `agents/[id]/heartbeat/route.ts` (new), `sessions/activity/update/route.ts` | Heartbeat endpoint + agentId passthrough |
| Headless router | `headless-router.ts` | Added heartbeat route + agentId passthrough |
| Client | `useSessionActivity.ts` | Index activity by both sessionName and agentId |
| Types | `types/session.ts` | Added `standalone?: boolean` |
| Hook | 3 copies of `ai-maestro-hook.cjs` | Send agentId + heartbeat, fix startsWith bug |
| Tests | `sessions-service.test.ts` | Updated mocks/assertions, added new test cases |
| Docs | `CHANGELOG.md`, `README.md`, `docs/index.html`, `docs/ai-index.html` | Feature documentation |

## Test plan

- [x] `yarn test` — 547/547 tests pass
- [x] `yarn build` — succeeds
- [ ] Manual: `POST /api/agents/<id>/heartbeat` for a registered agent, verify it appears in `/api/sessions`
- [ ] Manual: Open dashboard, verify standalone agent shows in sidebar
- [ ] Manual: Stop heartbeats, verify agent disappears after 2 minutes
- [ ] Manual: Verify hook startsWith fix — agents in subdirectories no longer match parent cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)