### PR TITLE
fix: terminal content cut-off during active output (v0.29.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.29.8] - 2026-04-17
+
+### Fixed
+- **Terminal content no longer appears "cut off" during active output** — Removed server-side PTY pause/resume backpressure in `server.mjs` that was adding artificial delays between chunks. When tmux redraws the screen (cursor/clear sequences followed by content), these delays made intermediate "cleared" states visible. xterm.js already batches writes via `requestAnimationFrame`, so chunks now flow at their natural rate and render atomically within a single frame.
+- **Synchronized Output passthrough for tmux** — Updated `scripts/setup-tmux.sh` to set `default-terminal` to `tmux-256color` (was `screen-256color`) and added `terminal-features` with `sync` flag. This enables DEC mode 2026 (Synchronized Output) passthrough so xterm.js can defer rendering until the end-of-update sequence, making screen redraws truly atomic. Both tmux 3.6a and xterm.js 6.0.0 support this — it just wasn't configured.
+
 ## [0.29.3] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.5
+**Current Version:** v0.29.8
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.5",
+      "softwareVersion": "0.29.8",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.29.5",
+      "softwareVersion": "0.29.8",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -449,7 +449,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.5</span>
+                        <span>v0.29.8</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.5",
+  "version": "0.29.8",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.5"
+VERSION="0.29.8"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/scripts/setup-tmux.sh
+++ b/scripts/setup-tmux.sh
@@ -46,8 +46,13 @@ set -g mouse on
 # Default is 2,000 which is too small for long AI conversations
 set -g history-limit 50000
 
-# Improve colors for better terminal display
-set -g default-terminal "screen-256color"
+# Use tmux-256color for modern terminal feature detection
+set -g default-terminal "tmux-256color"
+
+# Enable Synchronized Output (DEC mode 2026) passthrough
+# This lets xterm.js batch screen redraws atomically, preventing
+# the "cut off" appearance during rapid output (e.g. Claude Code TUI updates)
+set -as terminal-features ',xterm*:sync'
 
 # Optional: Enable clipboard integration (macOS)
 # Uncomment if you want copy/paste to work with system clipboard
@@ -70,7 +75,7 @@ echo ""
 echo "📝 Settings applied:"
 echo "   • Mouse mode: enabled (scroll with mouse wheel)"
 echo "   • History limit: 50,000 lines (was 2,000)"
-echo "   • Colors: 256-color support"
+echo "   • Terminal: tmux-256color with synchronized output"
 echo ""
 echo "🔄 To apply changes:"
 echo "   1. Restart tmux: exit all sessions and start tmux again"

--- a/server.mjs
+++ b/server.mjs
@@ -920,74 +920,62 @@ async function startServer(handleRequest) {
       }
       terminalSessions.set(sessionName, sessionState)
 
-      // Stream PTY output to all clients with flow control (backpressure)
-      // This prevents overwhelming xterm.js with too much data at once
+      // Stream PTY output to all clients
+      // No server-side pause/resume: xterm.js batches writes via requestAnimationFrame,
+      // so multiple chunks arriving within one frame render as a single atomic update.
+      // The old pause/resume pattern added artificial delays between chunks, making
+      // intermediate "cleared" states visible during tmux screen redraws (cut-off bug).
+      // See: https://xtermjs.org/docs/guides/flowcontrol/
       ptyProcess.onData((data) => {
-        // Pause PTY to implement backpressure
-        ptyProcess.pause()
+        try {
+          // Check if this is a redraw/status update we should filter from logs
+          const cleanedData = data.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '') // Remove all ANSI codes
 
-        // Check if this is a redraw/status update we should filter from logs
-        const cleanedData = data.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '') // Remove all ANSI codes
+          // Detect Claude Code status patterns and thinking steps
+          const isStatusPattern =
+            /[✳·]\s*\w+ing[\.…]/.test(cleanedData) || // "✳ Forming...", "· Thinking…", etc.
+            cleanedData.includes('esc to interrupt') ||
+            cleanedData.includes('? for shortcuts') ||
+            /Tip:/.test(cleanedData) ||
+            /^[─>]+\s*$/.test(cleanedData.replace(/[\r\n]/g, '')) || // Just border characters
+            /\[\d+\/\d+\]/.test(cleanedData) || // Thinking step markers like [1/418], [2/418]
+            /^\d{2}:\d{2}:\d{2}\s+\[\d+\/\d+\]/.test(cleanedData) // Timestamped steps like "15:34:46 [1/418]"
 
-        // Detect Claude Code status patterns and thinking steps
-        const isStatusPattern =
-          /[✳·]\s*\w+ing[\.…]/.test(cleanedData) || // "✳ Forming...", "· Thinking…", etc.
-          cleanedData.includes('esc to interrupt') ||
-          cleanedData.includes('? for shortcuts') ||
-          /Tip:/.test(cleanedData) ||
-          /^[─>]+\s*$/.test(cleanedData.replace(/[\r\n]/g, '')) || // Just border characters
-          /\[\d+\/\d+\]/.test(cleanedData) || // Thinking step markers like [1/418], [2/418]
-          /^\d{2}:\d{2}:\d{2}\s+\[\d+\/\d+\]/.test(cleanedData) // Timestamped steps like "15:34:46 [1/418]"
-
-        // Write to log file only if global logging is enabled, session logging is enabled, and it's not a status pattern
-        if (globalLoggingEnabled && sessionState.logStream && sessionState.loggingEnabled && !isStatusPattern) {
-          try {
-            sessionState.logStream.write(data)
-          } catch (error) {
-            console.error(`Error writing to log file for session ${sessionName}:`, error)
+          // Write to log file only if global logging is enabled, session logging is enabled, and it's not a status pattern
+          if (globalLoggingEnabled && sessionState.logStream && sessionState.loggingEnabled && !isStatusPattern) {
+            try {
+              sessionState.logStream.write(data)
+            } catch (error) {
+              console.error(`Error writing to log file for session ${sessionName}:`, error)
+            }
           }
-        }
 
-        // Track substantial activity (filter out cursor blinks and pure escape sequences)
-        const hasSubstantialContent = data.length >= 3 &&
-          !(data.startsWith('\x1b') && !/[\x20-\x7E]/.test(data))
+          // Track substantial activity (filter out cursor blinks and pure escape sequences)
+          const hasSubstantialContent = data.length >= 3 &&
+            !(data.startsWith('\x1b') && !/[\x20-\x7E]/.test(data))
 
-        if (hasSubstantialContent) {
-          trackSessionActivity(sessionName)
-        }
-
-        // Feed data to cerebellum terminal buffer (for voice subsystem)
-        if (sessionState.terminalBuffer && hasSubstantialContent) {
-          sessionState.terminalBuffer.write(data)
-        }
-
-        // Send data to all clients and wait for write completion
-        const writePromises = []
-        sessionState.clients.forEach((client) => {
-          if (client.readyState === 1) { // WebSocket.OPEN
-            writePromises.push(
-              new Promise((resolve) => {
-                try {
-                  // WebSocket.send() is synchronous, but we wrap it to handle errors
-                  client.send(data, (error) => {
-                    if (error) {
-                      console.error('Error sending data to client:', error)
-                    }
-                    resolve()
-                  })
-                } catch (error) {
-                  console.error('Error sending data to client:', error)
-                  resolve()
-                }
-              })
-            )
+          if (hasSubstantialContent) {
+            trackSessionActivity(sessionName)
           }
-        })
 
-        // Resume PTY after all clients have received the data
-        Promise.all(writePromises).finally(() => {
-          ptyProcess.resume()
-        })
+          // Feed data to cerebellum terminal buffer (for voice subsystem)
+          if (sessionState.terminalBuffer && hasSubstantialContent) {
+            sessionState.terminalBuffer.write(data)
+          }
+
+          // Send data to all connected clients synchronously
+          sessionState.clients.forEach((client) => {
+            if (client.readyState === 1) { // WebSocket.OPEN
+              try {
+                client.send(data)
+              } catch (error) {
+                console.error('Error sending data to client:', error)
+              }
+            }
+          })
+        } catch (error) {
+          console.error(`[PTY] Error in onData handler for ${sessionName}:`, error)
+        }
       })
 
       ptyProcess.onExit(({ exitCode, signal }) => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.29.5",
+  "version": "0.29.8",
   "releaseDate": "2026-04-17",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Remove server-side PTY pause/resume backpressure** — The `ptyProcess.pause()`/`resume()` pattern in `server.mjs` added artificial delays between chunks, making tmux screen redraws (cursor/clear then content) appear "cut off". xterm.js already batches writes via `requestAnimationFrame`, so chunks now flow at natural rate and render atomically.
- **Configure tmux for Synchronized Output** — Updated `setup-tmux.sh` to use `tmux-256color` terminal type and enable DEC mode 2026 (`sync` terminal feature), so xterm.js can defer rendering until end-of-update sequences.
- **Safety net** — Wrapped `onData` handler in try/catch to prevent uncaught exceptions from freezing the terminal.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — all 547 tests pass
- [ ] Manual: open dashboard, watch agent produce output — content should no longer appear "cut off"
- [ ] Manual: `tmux show -g terminal-features` should show `sync` after re-running setup script

🤖 Generated with [Claude Code](https://claude.com/claude-code)