### PR TITLE
docs: introduce Lola framework as flagship agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)
@@ -128,6 +128,20 @@ Assemble agents into teams, run meetings in split-pane war rooms, and track task
 *At 80 agents, they all looked the same.*
 
 Custom avatars, personality profiles, and visual presence for every agent. When an agent has a face and a role, you instinctively assign it the right work — just like a real team.
+
+---
+
+## Meet Lola — Your AI Chief of Staff
+
+Don't know what to run first? Start with **Lola** — a batteries-included Personal Assistant framework built for AI Maestro. She handles email triage, semantic memory, task management, and content security out of the box. Install the platform, deploy Lola, and you immediately have a working AI Chief of Staff.
+
+```bash
+# Clone and deploy Lola on AI Maestro
+git clone https://github.com/23blocks-OS/lolabot.git
+cd lolabot && ./install.sh
+```
+
+[Learn more about Lola →](https://github.com/23blocks-OS/lolabot)
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.9
+**Current Version:** v0.29.11
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.9",
+      "softwareVersion": "0.29.11",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.29.9",
+      "softwareVersion": "0.29.11",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -449,7 +449,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.9</span>
+                        <span>v0.29.11</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
@@ -807,6 +807,16 @@
                         <h4 class="font-bold text-white text-lg mb-2 group-hover:text-purple-400 transition-colors">Docs Search</h4>
                         <p class="text-slate-400 text-sm leading-relaxed">Auto-generated documentation index. Agents search function signatures and API specs before coding.</p>
                     </a>
+                    <a href="https://github.com/23blocks-OS/lolabot" target="_blank" class="group relative bg-slate-900/80 border border-slate-700 rounded-xl p-6 hover:border-purple-500/50 hover:bg-slate-900 transition-all duration-300 no-underline overflow-hidden">
+                        <div class="absolute top-3 right-3">
+                            <span class="px-2 py-1 bg-gradient-to-r from-rose-500 to-pink-500 text-white text-xs font-bold rounded-full shadow-lg shadow-rose-500/25">NEW</span>
+                        </div>
+                        <div class="w-12 h-12 rounded-lg bg-purple-500/10 border border-purple-500/30 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                            <span class="text-2xl">👩‍💼</span>
+                        </div>
+                        <h4 class="font-bold text-white text-lg mb-2 group-hover:text-purple-400 transition-colors">Lola Framework</h4>
+                        <p class="text-slate-400 text-sm leading-relaxed">Personal Assistant starter kit. Email, semantic memory, task management, and content security.</p>
+                    </a>
                 </div>
             </div>
 
@@ -876,6 +886,54 @@
                         </div>
                         <h4 class="font-bold text-white text-lg mb-2 group-hover:text-amber-400 transition-colors">Team Meetings & Kanban</h4>
                         <p class="text-slate-400 text-sm leading-relaxed">War room for agents with drag-and-drop Kanban board, shared tasks, and real-time chat.</p>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- LOLA SECTION -->
+    <section class="py-16 md:py-24 px-4 md:px-8">
+        <div class="max-w-4xl mx-auto">
+            <div class="relative rounded-2xl border border-rose-500/30 bg-gradient-to-br from-slate-900 via-slate-900 to-rose-950/20 p-8 md:p-12 overflow-hidden">
+                <!-- Glow effect -->
+                <div class="absolute -top-24 -right-24 w-64 h-64 bg-rose-500/10 rounded-full blur-3xl"></div>
+                <div class="absolute -bottom-24 -left-24 w-64 h-64 bg-purple-500/10 rounded-full blur-3xl"></div>
+
+                <div class="relative">
+                    <div class="flex items-center gap-3 mb-4">
+                        <span class="text-4xl">👩‍💼</span>
+                        <div>
+                            <div class="flex items-center gap-2">
+                                <h2 class="font-display text-3xl md:text-4xl font-extrabold text-white">Meet Lola</h2>
+                                <span class="px-2 py-1 bg-gradient-to-r from-rose-500 to-pink-500 text-white text-xs font-bold rounded-full">NEW</span>
+                            </div>
+                            <p class="text-rose-300/80 text-lg">Your AI Chief of Staff</p>
+                        </div>
+                    </div>
+
+                    <p class="text-slate-300 text-lg leading-relaxed mb-6 max-w-2xl">
+                        A batteries-included Personal Assistant framework for Claude Code. Deploy Lola on AI Maestro and immediately get email triage, semantic memory, task management, and content security — no configuration required.
+                    </p>
+
+                    <!-- Capability pills -->
+                    <div class="flex flex-wrap gap-2 mb-8">
+                        <span class="px-3 py-1.5 bg-rose-500/10 border border-rose-500/30 rounded-full text-rose-300 text-sm font-medium">📧 Email</span>
+                        <span class="px-3 py-1.5 bg-purple-500/10 border border-purple-500/30 rounded-full text-purple-300 text-sm font-medium">🧠 Memory</span>
+                        <span class="px-3 py-1.5 bg-amber-500/10 border border-amber-500/30 rounded-full text-amber-300 text-sm font-medium">📋 Tasks</span>
+                        <span class="px-3 py-1.5 bg-cyan-500/10 border border-cyan-500/30 rounded-full text-cyan-300 text-sm font-medium">🔒 Security</span>
+                    </div>
+
+                    <!-- Quick start -->
+                    <div class="bg-black/40 rounded-lg border border-slate-700 p-4 mb-6 font-mono text-sm">
+                        <span class="text-slate-500"># Clone and deploy Lola on AI Maestro</span><br>
+                        <span class="text-green-400">$</span> <span class="text-slate-200">git clone https://github.com/23blocks-OS/lolabot.git</span><br>
+                        <span class="text-green-400">$</span> <span class="text-slate-200">cd lolabot && ./install.sh</span>
+                    </div>
+
+                    <a href="https://github.com/23blocks-OS/lolabot" target="_blank" class="inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-rose-600 to-pink-600 hover:from-rose-500 hover:to-pink-500 text-white font-semibold rounded-lg transition-all duration-200 no-underline shadow-lg shadow-rose-500/25">
+                        Get Started with Lola
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg>
                     </a>
                 </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.9",
+  "version": "0.29.11",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.9"
+VERSION="0.29.11"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.29.9",
-  "releaseDate": "2026-04-23",
+  "version": "0.29.11",
+  "releaseDate": "2026-05-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- Add **Lola** (lolabot) — a batteries-included Personal Assistant framework — as the first agent users deploy on AI Maestro
- README: "Meet Lola" section with quick start command and repo link
- docs/index.html: Standalone hero callout with gradient card, capability pills (Email, Memory, Tasks, Security), and CTA button
- docs/index.html: Lola card added to Tier 2 "Superpowers" feature grid with NEW badge

## Test plan
- [ ] Open `docs/index.html` in browser — Lola hero section renders between Features and Quick Start
- [ ] Verify Lola card appears in Tier 2 grid with rose/pink NEW badge
- [ ] Check README on GitHub — "Meet Lola" section with working links
- [ ] Verify repo link: https://github.com/23blocks-OS/lolabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)