### PR TITLE
docs: add Lola deploy path to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)
@@ -138,7 +138,7 @@ Don't know what to run first? Start with **Lola** — a batteries-included Perso
 ```bash
 # Clone and deploy Lola on AI Maestro
 git clone https://github.com/23blocks-OS/lolabot.git
-cd lolabot && ./install.sh
+cd lolabot && ./setup.sh
 ```
 
 [Learn more about Lola →](https://github.com/23blocks-OS/lolabot)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.11
+**Current Version:** v0.29.12
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.11",
+      "softwareVersion": "0.29.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.29.11",
+      "softwareVersion": "0.29.12",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -449,7 +449,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.11</span>
+                        <span>v0.29.12</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
@@ -928,7 +928,7 @@
                     <div class="bg-black/40 rounded-lg border border-slate-700 p-4 mb-6 font-mono text-sm">
                         <span class="text-slate-500"># Clone and deploy Lola on AI Maestro</span><br>
                         <span class="text-green-400">$</span> <span class="text-slate-200">git clone https://github.com/23blocks-OS/lolabot.git</span><br>
-                        <span class="text-green-400">$</span> <span class="text-slate-200">cd lolabot && ./install.sh</span>
+                        <span class="text-green-400">$</span> <span class="text-slate-200">cd lolabot && ./setup.sh</span>
                     </div>
 
                     <a href="https://github.com/23blocks-OS/lolabot" target="_blank" class="inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-rose-600 to-pink-600 hover:from-rose-500 hover:to-pink-500 text-white font-semibold rounded-lg transition-all duration-200 no-underline shadow-lg shadow-rose-500/25">
@@ -1019,24 +1019,53 @@
                         <div class="w-12 h-12 rounded-full bg-cyan-500 text-slate-900 flex items-center justify-center font-display font-extrabold text-xl">2</div>
                         <h3 class="font-display text-2xl font-bold text-white">Create Your First Agent</h3>
                     </div>
-                    <ol class="space-y-3 text-slate-300">
-                        <li class="flex items-start gap-3">
-                            <span class="text-cyan-400 font-mono">▸</span>
-                            <span>Click the <strong class="text-white">+ button</strong> in the sidebar</span>
-                        </li>
-                        <li class="flex items-start gap-3">
-                            <span class="text-cyan-400 font-mono">▸</span>
-                            <span>Enter a name with hyphens: <code class="bg-slate-800 px-2 py-0.5 rounded text-cyan-400 text-sm">myproject-backend-api</code></span>
-                        </li>
-                        <li class="flex items-start gap-3">
-                            <span class="text-cyan-400 font-mono">▸</span>
-                            <span>Choose your working directory</span>
-                        </li>
-                        <li class="flex items-start gap-3">
-                            <span class="text-cyan-400 font-mono">▸</span>
-                            <span>Click <strong class="text-white">Create Agent</strong></span>
-                        </li>
-                    </ol>
+
+                    <!-- Two paths -->
+                    <div class="grid md:grid-cols-2 gap-6">
+                        <!-- Path A: From scratch -->
+                        <div class="bg-slate-900/60 border border-slate-700 rounded-xl p-6">
+                            <div class="flex items-center gap-2 mb-4">
+                                <span class="text-lg">🛠️</span>
+                                <h4 class="font-bold text-white">From Scratch</h4>
+                            </div>
+                            <ol class="space-y-3 text-slate-300 text-sm">
+                                <li class="flex items-start gap-3">
+                                    <span class="text-cyan-400 font-mono">▸</span>
+                                    <span>Click the <strong class="text-white">+ button</strong> in the sidebar</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <span class="text-cyan-400 font-mono">▸</span>
+                                    <span>Enter a name: <code class="bg-slate-800 px-2 py-0.5 rounded text-cyan-400 text-sm">myproject-backend-api</code></span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <span class="text-cyan-400 font-mono">▸</span>
+                                    <span>Choose your working directory</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <span class="text-cyan-400 font-mono">▸</span>
+                                    <span>Click <strong class="text-white">Create Agent</strong></span>
+                                </li>
+                            </ol>
+                        </div>
+
+                        <!-- Path B: Deploy Lola -->
+                        <div class="bg-gradient-to-br from-slate-900/60 to-rose-950/20 border border-rose-500/30 rounded-xl p-6">
+                            <div class="flex items-center gap-2 mb-4">
+                                <span class="text-lg">👩‍💼</span>
+                                <h4 class="font-bold text-white">Or Deploy Lola</h4>
+                                <span class="px-2 py-0.5 bg-gradient-to-r from-rose-500 to-pink-500 text-white text-xs font-bold rounded-full">NEW</span>
+                            </div>
+                            <p class="text-slate-300 text-sm mb-4">Get a working AI Chief of Staff in seconds — email, memory, tasks, and security included.</p>
+                            <div class="bg-black/40 rounded-lg border border-slate-700 p-3 font-mono text-sm mb-4">
+                                <span class="text-green-400">$</span> <span class="text-slate-200">git clone https://github.com/23blocks-OS/lolabot.git</span><br>
+                                <span class="text-green-400">$</span> <span class="text-slate-200">cd lolabot && ./setup.sh</span>
+                            </div>
+                            <a href="https://github.com/23blocks-OS/lolabot" target="_blank" class="inline-flex items-center gap-1.5 text-rose-400 hover:text-rose-300 text-sm font-medium transition-colors no-underline">
+                                Learn more about Lola
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg>
+                            </a>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Step 3 -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.11",
+  "version": "0.29.12",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.11"
+VERSION="0.29.12"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.29.11",
+  "version": "0.29.12",
   "releaseDate": "2026-05-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Split Quick Start Step 2 ("Create Your First Agent") into two side-by-side paths: **From Scratch** (original flow) and **Or Deploy Lola** (clone lolabot, run setup.sh)
- Fix `install.sh` → `setup.sh` in README and docs to match the actual lolabot repo
- Bump version to 0.29.12

## Test plan
- [ ] Open `docs/index.html` — Step 2 shows two-column grid on desktop, stacks on mobile
- [ ] "From Scratch" path matches original create-agent flow
- [ ] "Or Deploy Lola" card has rose accent, NEW badge, correct `setup.sh` command
- [ ] Lola repo link works: https://github.com/23blocks-OS/lolabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)