### PR TITLE
Rebrand: AI Maestro as the OS for AI-first organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 *I was running 35 AI agents across multiple terminals and became the human mailman between them. So I built AI Maestro.*
 
-**Orchestrate your AI coding agents from one dashboard — with persistent memory, agent-to-agent messaging, and multi-machine support.**
+**The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.13-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)
@@ -30,7 +30,7 @@ Within a week I was running 35 agents across terminals. They were productive, bu
 **So I built AI Maestro** — one dashboard to see every agent, on every machine, with persistent memory and direct agent-to-agent communication. Today I run 80+ agents across multiple computers, building real companies with them every day.
 
 **What makes this different:**
-- **Works with any AI agent** — Claude Code, Aider, Cursor, Copilot, your own scripts. We don't lock you in.
+- **Works with any AI agent** — Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes, Droid, or any terminal-based agent. We don't lock you in.
 - **Multi-machine from day one** — Peer mesh network with no central server. Nobody else does this.
 - **Agents that communicate** — The Agent Messaging Protocol (AMP) lets agents coordinate directly. You orchestrate, they collaborate.
 
@@ -82,7 +82,7 @@ Dashboard opens at `http://localhost:23000`
 
 ## Features
 
-Every feature was born from a real problem. We built them in the order we needed them.
+Every feature was born from running a real AI-first organization. We built them in the order we needed them.
 
 ### One Dashboard
 
@@ -131,9 +131,9 @@ Custom avatars, personality profiles, and visual presence for every agent. When 
 
 ---
 
-## Meet Lola — Your AI Chief of Staff
+## Meet Lola — Your First Hire
 
-Don't know what to run first? Start with **Lola** — a batteries-included Personal Assistant framework built for AI Maestro. She handles email triage, semantic memory, task management, and content security out of the box. Install the platform, deploy Lola, and you immediately have a working AI Chief of Staff.
+Every AI-first organization starts with one agent. **Lola** is yours — a batteries-included Chief of Staff framework built for AI Maestro. She handles email triage, semantic memory, task management, and content security out of the box. Install the platform, deploy Lola, and you have your first employee on day one.
 
 ```bash
 # Clone and deploy Lola on AI Maestro
@@ -147,7 +147,9 @@ cd lolabot && ./setup.sh
 
 ## Who Is This For
 
-**Developers running multiple AI agents.** If you have 3+ agents and you're switching between terminals, losing context, and playing messenger — this is for you. Works with Claude Code, Aider, Cursor, GitHub Copilot, or any terminal-based AI.
+**Founders building AI-first organizations.** You're the CEO, your agents are the team. Solo operators, agency owners, and anyone running a business where AI agents do the work and you drive the strategy. Start with Lola, add specialists, scale your AI workforce.
+
+**Developers running multiple AI agents.** If you have 3+ agents and you're switching between terminals, losing context, and playing messenger — this is for you. Works with Claude Code, Codex, Aider, Cursor, or any terminal-based AI.
 
 **Teams coordinating AI-assisted work.** Multiple developers, multiple agents, multiple machines. One dashboard. Agent-to-agent messaging replaces you as the bottleneck.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.12
+**Current Version:** v0.29.13
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.12",
+      "softwareVersion": "0.29.13",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,17 +12,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Maestro - The Future of Work: Humans + AI Agents</title>
-    <meta name="description" content="The future of work is here. Orchestrate multiple AI coding agents from one dashboard. One human. Multiple AI agents. Working together.">
+    <meta name="description" content="The OS for AI-first organizations. Build and run your AI company from one dashboard — any agent, any machine, persistent memory, direct communication.">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://ai-maestro.23blocks.com/">
     <meta property="og:title" content="AI Maestro - The Future of Work: Humans + AI Agents">
-    <meta property="og:description" content="The future of work is here. One human. Multiple AI agents. Working together. Orchestrate Claude Code, Aider, Cursor from one dashboard.">
+    <meta property="og:description" content="Build your AI-first organization. You're the CEO, your agents are the team. Orchestrate Claude Code, Codex, Aider, Cursor, and any AI agent from one dashboard.">
     <meta property="og:image" content="https://ai-maestro.23blocks.com/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="AI Maestro - Orchestrate your AI coding agents">
+    <meta property="og:image:alt" content="AI Maestro - The OS for AI-First Organizations">
     <meta property="og:site_name" content="AI Maestro">
     <meta property="og:locale" content="en_US">
 
@@ -30,13 +30,13 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://ai-maestro.23blocks.com/">
     <meta name="twitter:title" content="AI Maestro - The Future of Work: Humans + AI Agents">
-    <meta name="twitter:description" content="The future of work is here. One human. Multiple AI agents. Working together.">
+    <meta name="twitter:description" content="Build your AI-first organization. You're the CEO, your agents are the team. Any agent, any machine, one dashboard.">
     <meta name="twitter:image" content="https://ai-maestro.23blocks.com/og-image.png">
     <meta name="twitter:creator" content="@jkpelaez">
 
     <!-- Additional SEO -->
     <meta name="author" content="Juan Peláez">
-    <meta name="keywords" content="AI agent orchestration, Claude Code dashboard, autonomous agents, AI agents communication, multi-agent systems, AI pair programming, future of work AI, human AI collaboration, tmux AI dashboard, Claude skills, agent-to-agent messaging">
+    <meta name="keywords" content="AI-first organization, AI agent orchestration, AI workforce management, autonomous agents, AI agents communication, multi-agent systems, AI company, future of work AI, human AI collaboration, agent-to-agent messaging, AI operating system">
     <link rel="canonical" href="https://ai-maestro.23blocks.com/">
 
     <!-- Favicon & Icons -->
@@ -68,7 +68,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "AI Maestro",
-      "alternateName": "Claude Code Dashboard",
+      "alternateName": "AI-First Organization Platform",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 12.0+, Windows 10/11 (WSL2), Linux",
       "offers": {
@@ -76,8 +76,8 @@
         "price": "0",
         "priceCurrency": "USD"
       },
-      "description": "The future of work platform. Orchestrate multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified dashboard. One human, multiple AI agents, working together.",
-      "softwareVersion": "0.29.12",
+      "description": "The OS for AI-first organizations. Build and run your AI company with any agent (Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes) from one dashboard. You're the CEO, your agents are the team.",
+      "softwareVersion": "0.29.13",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -423,7 +423,7 @@
 
                 <!-- Subheadline -->
                 <p class="text-xl md:text-2xl text-slate-300 max-w-2xl mb-4 leading-relaxed" id="subheadline" style="opacity: 0;">
-                    Orchestrate your AI coding agents from one dashboard.
+                    Build and run your AI-first organization from one dashboard.
                 </p>
 
                 <!-- Vision statement -->
@@ -449,7 +449,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.12</span>
+                        <span>v0.29.13</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
@@ -457,7 +457,7 @@
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>Claude Code • Aider • Cursor • Any AI Agent</span>
+                        <span>Claude Code • Codex • Aider • Cursor • OpenClaw • Hermes • Any Agent</span>
                     </div>
                     <a href="https://agentskills.io/specification" target="_blank" class="flex items-center gap-2 text-emerald-400 hover:text-emerald-300 transition-colors no-underline">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
@@ -487,15 +487,15 @@
                     <div class="space-y-4 text-slate-300">
                         <div class="flex items-start gap-3">
                             <span class="text-red-500 mt-1">—</span>
-                            <p><strong class="text-white">Chaos:</strong> 5 terminals, 5 agents, zero visibility</p>
+                            <p><strong class="text-white">Chaos:</strong> Your AI workforce scattered across terminals with zero visibility</p>
                         </div>
                         <div class="flex items-start gap-3">
                             <span class="text-red-500 mt-1">—</span>
-                            <p><strong class="text-white">Amnesia:</strong> Every session starts from scratch</p>
+                            <p><strong class="text-white">Amnesia:</strong> Agents wake up every morning with no memory</p>
                         </div>
                         <div class="flex items-start gap-3">
                             <span class="text-red-500 mt-1">—</span>
-                            <p><strong class="text-white">Isolation:</strong> You relay every message between agents</p>
+                            <p><strong class="text-white">Isolation:</strong> No coordination between departments — you're the message bus</p>
                         </div>
                     </div>
                 </div>
@@ -512,15 +512,15 @@
                     <div class="space-y-4 text-slate-300">
                         <div class="flex items-start gap-3">
                             <span class="text-cyan-500 mt-1">—</span>
-                            <p><strong class="text-white">One Dashboard:</strong> See all agents, switch instantly</p>
+                            <p><strong class="text-white">Command Center:</strong> One dashboard for your entire AI organization</p>
                         </div>
                         <div class="flex items-start gap-3">
                             <span class="text-cyan-500 mt-1">—</span>
-                            <p><strong class="text-white">Persistent Memory:</strong> Agents remember everything</p>
+                            <p><strong class="text-white">Persistent Memory:</strong> Your agents remember and grow smarter over time</p>
                         </div>
                         <div class="flex items-start gap-3">
                             <span class="text-cyan-500 mt-1">—</span>
-                            <p><strong class="text-white">Direct Communication:</strong> Agents talk to each other</p>
+                            <p><strong class="text-white">Direct Communication:</strong> Agents coordinate across teams and machines</p>
                         </div>
                     </div>
                 </div>
@@ -554,7 +554,7 @@
                     <span class="font-mono text-cyan-400 text-sm tracking-wide">CREW MANIFEST</span>
                 </div>
                 <h2 class="font-display text-4xl md:text-5xl font-extrabold tracking-tight text-white mb-4">Who It's For</h2>
-                <p class="text-xl text-slate-400 max-w-2xl mx-auto">From solo developers to enterprise teams. Start where you are, scale when you need to.</p>
+                <p class="text-xl text-slate-400 max-w-2xl mx-auto">From solo founders to AI-first organizations. Start with one agent, scale your workforce.</p>
             </div>
 
             <!-- Persona cards as "crew badges" -->
@@ -666,19 +666,19 @@
                     <div class="relative bg-slate-900 border border-slate-700 rounded-xl p-6 hover:border-cyan-500/50 transition-all duration-300 h-full">
                         <div class="flex items-center justify-between mb-6">
                             <div class="w-14 h-14 rounded-full bg-gradient-to-br from-cyan-500/30 to-blue-600/10 border-2 border-cyan-500/50 flex items-center justify-center shadow-lg shadow-cyan-500/20">
-                                <span class="text-2xl">🏢</span>
+                                <span class="text-2xl">👑</span>
                             </div>
                             <div class="flex items-center gap-2">
-                                <span class="font-mono text-xs text-cyan-400">ENTERPRISE</span>
+                                <span class="font-mono text-xs text-cyan-400">AI-FIRST</span>
                                 <span class="w-3 h-3 bg-cyan-500 rounded-full block status-pulse"></span>
                             </div>
                         </div>
-                        <h3 class="font-display text-2xl font-bold text-white mb-1 group-hover:text-cyan-400 transition-colors">Company</h3>
+                        <h3 class="font-display text-2xl font-bold text-white mb-1 group-hover:text-cyan-400 transition-colors">AI-First Org</h3>
                         <div class="text-cyan-400 font-mono text-sm mb-4 flex items-center gap-2">
                             <span class="w-1.5 h-1.5 bg-cyan-400 rounded-full"></span>
-                            Teams + Agents
+                            CEO + AI Workforce
                         </div>
-                        <p class="text-slate-300 text-sm leading-relaxed mb-6">"Each department has specialized AI agents. Security, docs, testing. Autonomous coordination."</p>
+                        <p class="text-slate-300 text-sm leading-relaxed mb-6">"I run my company with AI agents. Lola was my first hire. Now I have 40 agents across 3 machines."</p>
                         <div class="pt-4 border-t border-slate-700/50">
                             <div class="font-mono text-xs text-slate-500 mb-3 uppercase tracking-wider">Infrastructure</div>
                             <div class="flex flex-wrap gap-2">
@@ -714,7 +714,7 @@
                     <span class="font-mono text-amber-400 text-sm tracking-wide">SYSTEM CAPABILITIES</span>
                 </div>
                 <h2 class="font-display text-4xl md:text-5xl font-extrabold tracking-tight text-white mb-4">Everything You Need</h2>
-                <p class="text-xl text-slate-400 max-w-2xl mx-auto">Orchestrate AI agents at any scale — from solo developer to enterprise team.</p>
+                <p class="text-xl text-slate-400 max-w-2xl mx-auto">Everything you need to run an AI-first organization — from one agent to an entire workforce.</p>
             </div>
 
             <!-- TIER 1: Core -->
@@ -908,12 +908,12 @@
                                 <h2 class="font-display text-3xl md:text-4xl font-extrabold text-white">Meet Lola</h2>
                                 <span class="px-2 py-1 bg-gradient-to-r from-rose-500 to-pink-500 text-white text-xs font-bold rounded-full">NEW</span>
                             </div>
-                            <p class="text-rose-300/80 text-lg">Your AI Chief of Staff</p>
+                            <p class="text-rose-300/80 text-lg">Your First Hire</p>
                         </div>
                     </div>
 
                     <p class="text-slate-300 text-lg leading-relaxed mb-6 max-w-2xl">
-                        A batteries-included Personal Assistant framework for Claude Code. Deploy Lola on AI Maestro and immediately get email triage, semantic memory, task management, and content security — no configuration required.
+                        Every AI-first organization starts with one agent. Lola is a batteries-included Chief of Staff framework — email triage, semantic memory, task management, and content security out of the box. Install AI Maestro, deploy Lola, add more agents, run your AI company.
                     </p>
 
                     <!-- Capability pills -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.12",
+  "version": "0.29.13",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.12"
+VERSION="0.29.13"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.29.12",
+  "version": "0.29.13",
   "releaseDate": "2026-05-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Repositions AI Maestro from "coding agent dashboard" to "the OS for AI-first organizations"
- Adds "Founders building AI-first organizations" as lead persona in README
- Reframes Lola as "Your First Hire" — every AI company starts with one agent
- Expands agent compatibility list: Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes, Droid
- Updates all meta tags, OG tags, Twitter cards, schema.org, and SEO keywords in docs site
- Rebrands Company persona card to "AI-First Org" with CEO + AI Workforce framing
- Updates problem/solution copy toward organizational scale (workforce, departments, coordination)
- Bumps version to 0.29.13

## Test plan
- [x] `yarn test` — 547/547 passing
- [x] `yarn build` — clean
- [ ] Open `docs/index.html` in browser — verify hero, personas, Lola section
- [ ] Read README on GitHub — narrative flows from AI-first org → features → Lola → personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)