### PR TITLE
docs: unified footer with ecosystem cross-links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1304,33 +1304,38 @@
     <!-- FOOTER -->
     <footer class="py-16 pb-8 bg-slate-950 border-t border-slate-800 px-4 md:px-8">
         <div class="max-w-7xl mx-auto">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-12 mb-12">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-12 mb-12">
                 <div>
                     <div class="flex items-center gap-3 mb-4">
                         <img src="logo-constellation.svg" alt="AI Maestro" class="w-8 h-8">
                         <span class="font-display font-bold text-lg text-white">AI MAESTRO</span>
                     </div>
-                    <p class="text-slate-400 text-sm">The future of work is here. Orchestrate multiple AI coding agents from one dashboard.</p>
+                    <p class="text-slate-400 text-sm">The OS for AI-first organizations. One human, many AI agents.</p>
                 </div>
                 <div>
-                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">LINKS</h4>
-                    <a href="https://github.com/23blocks-OS/ai-maestro" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">GitHub</a>
-                    <a href="plugin-builder.html" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">Plugin Builder</a>
-                    <a href="https://github.com/23blocks-OS/ai-maestro/issues" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">Issues</a>
-                    <a href="https://github.com/23blocks-OS/ai-maestro/blob/main/CONTRIBUTING.md" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">Contributing</a>
-                    <a href="https://github.com/23blocks-OS/ai-maestro/blob/main/LICENSE" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">License (MIT)</a>
+                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">ECOSYSTEM</h4>
+                    <a href="https://factory.lolabots.com" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">Lolabot Factory</a>
+                    <a href="https://ai-maestro.23blocks.com" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">AI Maestro</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro-plugins" target="_blank" rel="noopener noreferrer" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">Plugin Builder</a>
+                </div>
+                <div>
+                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">RESOURCES</h4>
+                    <a href="https://github.com/23blocks-OS/ai-maestro" target="_blank" rel="noopener noreferrer" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">GitHub</a>
+                    <a href="https://github.com/msitarzewski/agency-agents" target="_blank" rel="noopener noreferrer" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">Agent Library</a>
+                    <a href="https://ai-maestro.23blocks.com" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">Documentation</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro/issues" target="_blank" rel="noopener noreferrer" class="block text-slate-400 no-underline mb-2.5 hover:text-cyan-400 transition-colors text-sm">Issues</a>
                 </div>
                 <div>
                     <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">BUILT BY</h4>
                     <p class="text-slate-400 text-sm mb-2">
-                        <a href="https://x.com/jkpelaez" target="_blank" class="text-white hover:text-cyan-400 transition-colors">Juan Peláez</a> @ <a href="https://23blocks.com" target="_blank" class="text-white hover:text-cyan-400 transition-colors">23blocks</a>
+                        <a href="https://x.com/jkpelaez" target="_blank" rel="noopener noreferrer" class="text-white hover:text-cyan-400 transition-colors">Juan Pelaez</a> @ <a href="https://23blocks.com" target="_blank" rel="noopener noreferrer" class="text-white hover:text-cyan-400 transition-colors">23blocks</a>
                     </p>
-                    <p class="text-slate-500 text-xs">Made with <span class="text-red-500">♥</span> in Boulder, Colorado</p>
+                    <p class="text-slate-500 text-xs">Boulder, Colorado</p>
                     <p class="text-slate-500 text-xs mt-1">Coded with Claude</p>
                 </div>
             </div>
-            <div class="pt-8 border-t border-slate-800 text-center">
-                <p class="text-slate-500 text-sm">© 2025 Juan Peláez / 23blocks. MIT License.</p>
+            <div class="pt-8 border-t border-slate-800 flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-slate-500 text-sm">&copy; 2025 Juan Pelaez / 23blocks. MIT License.</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- Update AI Maestro docs footer to 4-column layout matching Lolabot Factory
- Add Ecosystem section with cross-links to factory.lolabots.com and Plugin Builder
- Add Agent Library and Documentation links to Resources section
- Consistent branding across the 23blocks ecosystem

## Test plan
- [ ] Verify docs/index.html renders correctly on GitHub Pages
- [ ] Check all footer links resolve correctly
- [ ] Verify responsive layout (1→2→4 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)