### PR TITLE
fix: hibernated agents incorrectly shown as standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.14-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.29.15-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-01-03
-**Current Version:** v0.29.14
+**Current Version:** v0.29.15
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.14",
+      "softwareVersion": "0.29.15",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The OS for AI-first organizations. Build and run your AI company with any agent (Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes) from one dashboard. You're the CEO, your agents are the team.",
-      "softwareVersion": "0.29.14",
+      "softwareVersion": "0.29.15",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -451,7 +451,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.14</span>
+                        <span>v0.29.15</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.14",
+  "version": "0.29.15",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.14"
+VERSION="0.29.15"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -468,9 +468,12 @@ export async function listAgents(): Promise<ServiceResult<{
       const heartbeatTs = agentActivity.get(agent.id)
       const heartbeatAge = heartbeatTs ? (Date.now() - heartbeatTs) / 1000 : Infinity
       const hasRecentHeartbeat = heartbeatAge < 600 // 10 minutes — standalone agents send heartbeats on hook events (SessionStart, Stop, Notification) which may have gaps during long tool executions
-      const isOnline = hasOnlineSession || hasRecentHeartbeat
-      // Standalone = no tmux sessions discovered AND not a cloud agent
-      const isStandalone = agentSessions.length === 0 && agent.deployment?.type !== 'cloud'
+      // Standalone = no tmux sessions discovered, no session history in registry, AND not a cloud agent
+      // Agents with session history (e.g. hibernated agents) are NOT standalone even if they have heartbeats
+      const hasTmuxSessionHistory = (agent.sessions || []).length > 0
+      const isStandalone = agentSessions.length === 0 && !hasTmuxSessionHistory && agent.deployment?.type !== 'cloud'
+      // Only count heartbeat as "online" for truly standalone agents (no tmux session history)
+      const isOnline = hasOnlineSession || (hasRecentHeartbeat && isStandalone)
 
       // Create session status for API response (backward compatibility)
       const onlineSession = updatedSessions.find(s => s.status === 'online')
@@ -488,7 +491,7 @@ export async function listAgents(): Promise<ServiceResult<{
             hostId,
             hostName,
           }
-        : hasRecentHeartbeat
+        : (hasRecentHeartbeat && isStandalone)
         ? {
             status: 'online',
             workingDirectory: agent.workingDirectory || primarySession?.workingDirectory,

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -299,13 +299,16 @@ async function fetchLocalSessions(hostId: string): Promise<Session[]> {
       // Docker not available
     }
 
-    // Discover standalone agents (registered with heartbeat, no tmux session)
+    // Discover standalone agents (registered with heartbeat, no tmux session, no session history)
+    // Agents with session history (e.g. hibernated agents) are NOT standalone
     try {
       const allAgents = loadAgents()
       for (const agent of allAgents) {
         const agentName = agent.name || agent.alias
         if (!agentName || sessions.find(s => s.name === agentName)) continue
         if (agent.deployment?.type === 'cloud') continue
+        // Skip agents with tmux session history — they are managed (hibernated), not standalone
+        if ((agent.sessions || []).length > 0) continue
 
         const heartbeatTs = agentActivity.get(agent.id)
         if (!heartbeatTs) continue

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.29.14",
-  "releaseDate": "2026-05-04",
+  "version": "0.29.15",
+  "releaseDate": "2026-05-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

- Hibernated agents (like Raine) were incorrectly classified as "standalone" when they had a recent heartbeat but no active tmux session
- The UI showed "Standalone Agent — no terminal view" instead of the hibernation screen with Wake button
- Root cause: standalone detection didn't check for tmux session history in the agent registry

## Changes

- **`services/agents-core-service.ts`** — `isStandalone` now requires no session history (`agent.sessions.length === 0`). Heartbeats only mark agents as online if truly standalone.
- **`services/sessions-service.ts`** — Legacy `/api/sessions` endpoint skips agents with session history when discovering standalone agents.

## Test plan

- [x] Hibernate an agent with session history → verify it shows hibernation screen with Wake button (not standalone)
- [x] Standalone agents (heartbeat only, no session history) still appear correctly as standalone
- [x] Build passes
- [x] Production restart verified

bump: 0.29.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)