### PR TITLE
feat: infrastructure icons, WebSocket heartbeat, chat scroll fix (v0.35.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.1] - 2026-05-14
+
+### Added
+- **Infrastructure type icons** — New `InfraIcon` component displays infrastructure type (Docker, EC2, ECS, Cloud, Standalone) as a small icon next to agent names across all views (sidebar, tablet, mobile). Local agents show no icon to reduce clutter.
+- **WebSocket heartbeat** — Client-side ping/pong mechanism (30s interval, 10s timeout) detects dead connections that mobile browsers kill silently without firing close events. Server responds to pings in both terminal and chat-only WebSocket handlers.
+
+### Fixed
+- **Mobile WebSocket disconnection** — Mobile browsers (iOS Safari, Android Chrome) silently kill WebSocket connections after a few minutes without triggering close events. The new heartbeat mechanism detects dead connections within 40s and triggers reconnection.
+- **Chat messages hidden behind input** — Messages went behind the textarea and send button when sending because auto-scroll only triggered on received messages, not pending messages. Fixed in both desktop and mobile chat views.
+- **Non-AWS cloud agents mislabeled** — GCP, Azure, and DigitalOcean agents were incorrectly shown with AWS EC2 icon. Added generic "Cloud" infra type for non-AWS providers.
+- **Unsafe type cast in deployment detection** — Replaced `(cloud as Record<string, unknown>).runtime` with proper `runtime?: string` field on `AgentDeployment.cloud` interface.
+
 ## [0.35.0] - 2026-05-14
 
 ### Added

--- a/components/AgentBadge.tsx
+++ b/components/AgentBadge.tsx
@@ -11,10 +11,10 @@ import {
   Power,
   Copy,
   Mail,
-  Box,
 } from 'lucide-react'
 import { computeHash, getAvatarUrl } from '@/lib/hash-utils'
 import { Agent, AgentSession } from '@/types/agent'
+import InfraIcon from './InfraIcon'
 import { SessionActivityStatus } from '@/hooks/useSessionActivity'
 
 interface AgentBadgeProps {
@@ -345,11 +345,7 @@ export default function AgentBadge({
             ${isHibernated ? 'text-slate-600' : 'text-slate-400'}
           `}>
             {agent.name}
-            {agent.deployment?.cloud?.provider === 'local-container' && (
-              <span className="flex-shrink-0" aria-label="Docker container">
-                <Box className="w-3 h-3 text-blue-400" />
-              </span>
-            )}
+            <InfraIcon agent={agent} size={12} />
           </p>
 
           {agent.hostId && (

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -46,6 +46,7 @@ import { useHosts } from '@/hooks/useHosts'
 import { useSessionActivity, type SessionActivityStatus } from '@/hooks/useSessionActivity'
 import { SubconsciousStatus } from './SubconsciousStatus'
 import AgentBadge from './AgentBadge'
+import InfraIcon from './InfraIcon'
 import SidebarViewSwitcher, { type SidebarView } from './sidebar/SidebarViewSwitcher'
 import TeamListView from './sidebar/TeamListView'
 import MeetingListView from './sidebar/MeetingListView'
@@ -1309,6 +1310,8 @@ export default function AgentList({
                                                 >
                                                   {agent.label || agent.name || agent.alias}
                                                 </span>
+
+                                                <InfraIcon agent={agent} size={12} />
 
                                                 {/* Cached indicator */}
                                                 {agent._cached && (

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -215,22 +215,22 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     }
   }, [agent?.id, agent?.name, agent?.alias, isActive, getChatWsUrl])
 
-  // Auto-scroll to bottom when new messages arrive
+  // Auto-scroll to bottom when new messages or pending messages arrive
   useEffect(() => {
-    if (messages.length === 0) return
+    if (messages.length === 0 && pendingMessages.length === 0) return
 
     const hasNewMessages = messages.length > prevMessageCountRef.current
     const isInitialLoad = prevMessageCountRef.current === 0
 
     prevMessageCountRef.current = messages.length
 
-    // Scroll on initial load (instant) or new messages (smooth)
+    // Scroll on initial load (instant) or new messages/pending messages (smooth)
     if (isInitialLoad) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'instant' })
-    } else if (hasNewMessages) {
+    } else if (hasNewMessages || pendingMessages.length > 0) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
     }
-  }, [messages])
+  }, [messages, pendingMessages])
 
   // Send quick response (assisted mode — for permission buttons)
   const sendQuickResponse = (text: string) => {

--- a/components/InfraIcon.tsx
+++ b/components/InfraIcon.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { Box, Server, Cloud, Wifi } from 'lucide-react'
+import type { Agent } from '@/types/agent'
+
+type InfraType = 'local' | 'docker' | 'ec2' | 'ecs' | 'cloud' | 'standalone'
+
+export function getInfraType(agent: Agent): InfraType {
+  if (agent.session?.standalone) return 'standalone'
+
+  const deployment = agent.deployment
+  if (!deployment) return 'local'
+
+  if (deployment.type === 'cloud') {
+    const cloud = deployment.cloud
+    if (!cloud) return 'local'
+
+    if (cloud.provider === 'local-container') return 'docker'
+
+    if (cloud.provider === 'aws') {
+      if (cloud.runtime === 'ecs-fargate') return 'ecs'
+      return 'ec2'
+    }
+
+    // Non-AWS cloud providers (gcp, azure, digitalocean)
+    return 'cloud'
+  }
+
+  return 'local'
+}
+
+const infraConfig: Record<InfraType, { icon: typeof Box; color: string; label: string }> = {
+  local:      { icon: Server, color: 'text-gray-500',   label: 'Local (tmux)' },
+  docker:     { icon: Box,    color: 'text-blue-400',   label: 'Docker container' },
+  ec2:        { icon: Server, color: 'text-orange-400', label: 'AWS EC2' },
+  ecs:        { icon: Cloud,  color: 'text-purple-400', label: 'AWS ECS/Fargate' },
+  cloud:      { icon: Cloud,  color: 'text-sky-400',    label: 'Cloud' },
+  standalone: { icon: Wifi,   color: 'text-teal-400',   label: 'Standalone agent' },
+}
+
+interface InfraIconProps {
+  agent: Agent
+  size?: number
+  className?: string
+  showLocal?: boolean // Whether to show icon for local agents (default: false)
+}
+
+export default function InfraIcon({ agent, size = 12, className = '', showLocal = false }: InfraIconProps) {
+  const infraType = getInfraType(agent)
+
+  // Skip rendering for local agents unless explicitly requested
+  if (infraType === 'local' && !showLocal) return null
+
+  const config = infraConfig[infraType]
+  const Icon = config.icon
+
+  return (
+    <span className={`flex-shrink-0 ${className}`} title={config.label} aria-label={config.label}>
+      <Icon style={{ width: size, height: size }} className={config.color} />
+    </span>
+  )
+}

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -370,13 +370,13 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
     }
   }, [agentId, wsSessionName, getChatWsUrl])
 
-  // Auto-scroll when new messages arrive
+  // Auto-scroll when new messages or pending messages arrive
   useEffect(() => {
-    if (messages.length > prevMessageCountRef.current) {
+    if (messages.length > prevMessageCountRef.current || pendingMessages.length > 0) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
     }
     prevMessageCountRef.current = messages.length
-  }, [messages.length])
+  }, [messages.length, pendingMessages])
 
   // Send message via WebSocket
   const sendMessage = () => {

--- a/components/MobileHostsList.tsx
+++ b/components/MobileHostsList.tsx
@@ -13,6 +13,7 @@ import {
   X
 } from 'lucide-react'
 import type { Agent } from '@/types/agent'
+import InfraIcon from './InfraIcon'
 import { useHosts } from '@/hooks/useHosts'
 import { useSessionActivity } from '@/hooks/useSessionActivity'
 
@@ -405,10 +406,11 @@ export default function MobileHostsList({
                                 isActive ? 'text-blue-400' : 'text-gray-400'
                               }`} />
                               <div className="flex-1 min-w-0 text-left">
-                                <p className={`text-sm font-medium truncate ${
+                                <p className={`text-sm font-medium truncate flex items-center gap-1 ${
                                   isActive ? 'text-blue-400' : 'text-white'
                                 }`}>
                                   {displayName}
+                                  <InfraIcon agent={agent} size={12} />
                                 </p>
                                 {breadcrumb && (
                                   <p className="text-xs text-gray-500 truncate">{breadcrumb}</p>

--- a/components/TabletDashboard.tsx
+++ b/components/TabletDashboard.tsx
@@ -7,6 +7,7 @@ import MobileMessageCenter from './MobileMessageCenter'
 import MobileWorkTree from './MobileWorkTree'
 import MobileConversationDetail from './MobileConversationDetail'
 import { Terminal, Mail, RefreshCw, Activity, Phone, MessageSquare, Plus, Settings, Monitor } from 'lucide-react'
+import InfraIcon from './InfraIcon'
 import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 import { useHosts } from '@/hooks/useHosts'
@@ -183,7 +184,10 @@ export default function TabletDashboard({
 
                 {/* Name + status */}
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium truncate">{name}</p>
+                  <p className="text-sm font-medium truncate flex items-center gap-1">
+                    {name}
+                    <InfraIcon agent={agent} size={12} />
+                  </p>
                   <p className="text-xs text-gray-500 truncate">
                     {agent.session?.status === 'online' ? 'Online' : 'Offline'}
                   </p>

--- a/hooks/useWebSocket.ts
+++ b/hooks/useWebSocket.ts
@@ -5,6 +5,8 @@ import type { WebSocketMessage, WebSocketStatus } from '@/types/websocket'
 
 const WS_RECONNECT_DELAY = 3000
 const WS_MAX_RECONNECT_ATTEMPTS = 5
+const WS_HEARTBEAT_INTERVAL = 30000  // Send ping every 30s
+const WS_HEARTBEAT_TIMEOUT = 10000   // Expect pong within 10s
 
 interface UseWebSocketOptions {
   sessionId: string
@@ -42,6 +44,9 @@ export function useWebSocket({
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectAttemptsRef = useRef(0)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout>()
+  const heartbeatIntervalRef = useRef<NodeJS.Timeout>()
+  const pongTimeoutRef = useRef<NodeJS.Timeout>()
+  const lastDataRef = useRef<number>(Date.now())
 
   // CRITICAL: Store callbacks in refs so WebSocket handlers always call the latest version.
   // Without this, the WebSocket's onmessage closure captures a stale onMessage callback
@@ -103,6 +108,48 @@ export function useWebSocket({
     }
   }, [])
 
+  const stopHeartbeat = useCallback(() => {
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current)
+      heartbeatIntervalRef.current = undefined
+    }
+    if (pongTimeoutRef.current) {
+      clearTimeout(pongTimeoutRef.current)
+      pongTimeoutRef.current = undefined
+    }
+  }, [])
+
+  const startHeartbeat = useCallback((ws: WebSocket) => {
+    stopHeartbeat()
+    lastDataRef.current = Date.now()
+
+    heartbeatIntervalRef.current = setInterval(() => {
+      if (ws.readyState !== WebSocket.OPEN) {
+        stopHeartbeat()
+        return
+      }
+
+      // Send a ping
+      try {
+        ws.send(JSON.stringify({ type: 'ping' }))
+      } catch {
+        // Send failed — connection is dead
+        stopHeartbeat()
+        ws.close()
+        return
+      }
+
+      // Set a per-ping timeout: if no data arrives within WS_HEARTBEAT_TIMEOUT, connection is dead
+      pongTimeoutRef.current = setTimeout(() => {
+        if (Date.now() - lastDataRef.current > WS_HEARTBEAT_TIMEOUT) {
+          console.warn('[WS] Heartbeat timeout — no pong received, forcing reconnect')
+          stopHeartbeat()
+          ws.close()
+        }
+      }, WS_HEARTBEAT_TIMEOUT)
+    }, WS_HEARTBEAT_INTERVAL)
+  }, [stopHeartbeat])
+
   const connect = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       return
@@ -126,13 +173,21 @@ export function useWebSocket({
         setStatus('connected')
         setConnectionError(null)
         reconnectAttemptsRef.current = 0
+        startHeartbeat(ws)
         onOpenRef.current?.()
       }
 
       ws.onmessage = (event) => {
+        // Track last data receipt for heartbeat detection
+        lastDataRef.current = Date.now()
+
         // Try to parse as JSON for error/status messages
         try {
           const parsed = JSON.parse(event.data)
+          if (parsed.type === 'pong') {
+            // Heartbeat response — already tracked via lastDataRef above
+            return
+          }
           if (parsed.type === 'error') {
             setConnectionError(new Error(parsed.message))
             if (parsed.hint) {
@@ -169,6 +224,8 @@ export function useWebSocket({
       }
 
       ws.onclose = (event) => {
+        stopHeartbeat()
+
         // Guard against stale closures: if this socket was replaced by a newer
         // one (orphaned), don't update state or schedule reconnects
         if (wsRef.current !== ws) return
@@ -204,9 +261,11 @@ export function useWebSocket({
       setConnectionError(error as Error)
       setStatus('error')
     }
-  }, [getWebSocketUrl])
+  }, [getWebSocketUrl, startHeartbeat, stopHeartbeat])
 
   const disconnect = useCallback(() => {
+    stopHeartbeat()
+
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current)
     }
@@ -218,7 +277,7 @@ export function useWebSocket({
 
     setIsConnected(false)
     setStatus('disconnected')
-  }, [])
+  }, [stopHeartbeat])
 
   // Auto-connect on mount or when autoConnect changes
   useEffect(() => {

--- a/server.mjs
+++ b/server.mjs
@@ -1147,6 +1147,13 @@ async function startServer(handleRequest) {
       ws.on('message', async (data) => {
         try {
           const parsed = JSON.parse(data.toString())
+
+          // Heartbeat ping/pong for chatOnly connections
+          if (parsed.type === 'ping') {
+            if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'pong' }))
+            return
+          }
+
           if (parsed.type === 'chat:requestHistory') {
             try {
               const history = await getChatHistory(sessionName, parsed.agentId)
@@ -1488,6 +1495,12 @@ async function startServer(handleRequest) {
         // Check if it's a JSON message (for resize events, logging control, etc.)
         try {
           const parsed = JSON.parse(message)
+
+          // Heartbeat ping/pong — respond immediately to keep mobile connections alive
+          if (parsed.type === 'ping') {
+            if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'pong' }))
+            return
+          }
 
           if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
             sessionState.ptyProcess.resize(parsed.cols, parsed.rows)

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -295,6 +295,7 @@ export interface AgentDeployment {
     healthCheckUrl?: string           // Health check endpoint (e.g., http://localhost:46000/health)
     containerName?: string            // Docker container name
     status?: 'provisioning' | 'running' | 'stopped' | 'error'
+    runtime?: string                  // Runtime variant (e.g., 'ec2-native', 'ecs-fargate')
   }
 
   // Sandbox configuration (currently consumed by cloud/container deployments)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.0",
+  "version": "0.35.1",
   "releaseDate": "2026-05-14",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **InfraIcon component** — Shows Docker/EC2/ECS/Cloud/Standalone icons next to agent names in sidebar, tablet, and mobile views
- **WebSocket heartbeat** — Client-side ping/pong (30s/10s) detects silently dead mobile connections and triggers reconnection
- **Chat scroll fix** — Auto-scroll now triggers on pending messages too, preventing messages from hiding behind the input area
- **Type safety** — Added `runtime?: string` to `AgentDeployment.cloud` interface, added generic Cloud infra type for non-AWS providers

## Test plan
- [ ] Verify infra icons appear for Docker/EC2/ECS agents in sidebar
- [ ] Verify no icon for local (tmux) agents
- [ ] Test mobile: leave app backgrounded for 5+ minutes, return and verify reconnection
- [ ] Send chat messages and verify they scroll into view above the input area
- [ ] Build passes, 755 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)