### PR TITLE
fix: proxy chat WebSocket to remote hosts

### DIFF
--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -96,8 +96,13 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const host = window.location.host
     const sessionName = agent.name || agent.alias || agent.id
-    return `${protocol}//${host}/term?name=${encodeURIComponent(sessionName)}&chatOnly=1`
-  }, [agent.name, agent.alias, agent.id])
+    let url = `${protocol}//${host}/term?name=${encodeURIComponent(sessionName)}&chatOnly=1`
+    // Route through remote host proxy when agent lives on a different machine
+    if (agent.hostId && agent.hostId !== 'local') {
+      url += `&host=${encodeURIComponent(agent.hostId)}`
+    }
+    return url
+  }, [agent.name, agent.alias, agent.id, agent.hostId])
 
   const sendChatMessage = useCallback((type: string, payload?: Record<string, any>) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -7,6 +7,7 @@ interface MobileChatViewProps {
   agentId: string
   agentName: string
   sessionName?: string  // tmux session name for WebSocket (falls back to agentName)
+  hostId?: string       // Host ID for remote agent routing (e.g., 'mac-mini')
 }
 
 interface ChatMessage {
@@ -224,7 +225,7 @@ function ThinkingBlock({ text }: { text: string }) {
   )
 }
 
-export default function MobileChatView({ agentId, agentName, sessionName: sessionNameProp }: MobileChatViewProps) {
+export default function MobileChatView({ agentId, agentName, sessionName: sessionNameProp, hostId }: MobileChatViewProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [hookState, setHookState] = useState<{
     status?: string;
@@ -265,8 +266,12 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
   const getChatWsUrl = useCallback(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const host = window.location.host
-    return `${protocol}//${host}/term?name=${encodeURIComponent(wsSessionName)}&chatOnly=1`
-  }, [wsSessionName])
+    let url = `${protocol}//${host}/term?name=${encodeURIComponent(wsSessionName)}&chatOnly=1`
+    if (hostId && hostId !== 'local') {
+      url += `&host=${encodeURIComponent(hostId)}`
+    }
+    return url
+  }, [wsSessionName, hostId])
 
   const sendChatWs = useCallback((type: string, payload?: Record<string, any>) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {

--- a/components/MobileDashboard.tsx
+++ b/components/MobileDashboard.tsx
@@ -224,6 +224,7 @@ export default function MobileDashboard({
                           agentId={agent.id}
                           agentName={getAgentDisplayName(agent)}
                           sessionName={agent.name || agent.alias}
+                          hostId={agent.hostId}
                         />
                       </div>
                     )}

--- a/components/TabletDashboard.tsx
+++ b/components/TabletDashboard.tsx
@@ -265,6 +265,7 @@ export default function TabletDashboard({
                       agentId={agent.id}
                       agentName={getAgentDisplayName(agent)}
                       sessionName={agent.name || agent.alias}
+                      hostId={agent.hostId}
                     />
                   </div>
                 )}

--- a/server.mjs
+++ b/server.mjs
@@ -629,7 +629,7 @@ async function startServer(handleRequest) {
 
   // Handle remote worker connections (proxy WebSocket to remote host)
   // With retry logic for flaky networks
-  function handleRemoteWorker(clientWs, sessionName, workerUrl) {
+  function handleRemoteWorker(clientWs, sessionName, workerUrl, extraParams = '') {
     const MAX_RETRIES = 5
     const RETRY_DELAYS = [500, 1000, 2000, 3000, 5000] // Exponential backoff
     let retryCount = 0
@@ -637,7 +637,7 @@ async function startServer(handleRequest) {
     let clientClosed = false
 
     // Build WebSocket URL for remote worker
-    const workerWsUrl = `${workerUrl}/term?name=${encodeURIComponent(sessionName)}`
+    const workerWsUrl = `${workerUrl}/term?name=${encodeURIComponent(sessionName)}${extraParams}`
       .replace(/^http:/, 'ws:')
       .replace(/^https:/, 'wss:')
 
@@ -1116,6 +1116,27 @@ async function startServer(handleRequest) {
     // Lightweight connection that only participates in chat:* protocol.
     // Skips PTY attach, history capture, and raw terminal broadcast.
     if (query.chatOnly === '1') {
+      // Remote host: proxy the chatOnly WebSocket to the remote server
+      if (query.host && typeof query.host === 'string') {
+        try {
+          const host = getHostById(query.host)
+          if (!host) {
+            ws.close(1008, `Host not found: ${query.host}`)
+            return
+          }
+          if (!isSelf(host.id)) {
+            console.log(`[Chat] Proxying chat-only WS for ${sessionName} to remote host ${host.id}`)
+            handleRemoteWorker(ws, sessionName, host.url, '&chatOnly=1')
+            return
+          }
+          // isSelf — fall through to local chatOnly handling
+        } catch (err) {
+          console.error(`[Chat] Error routing chatOnly to remote host:`, err)
+          ws.close(1011, 'Remote host routing error')
+          return
+        }
+      }
+
       console.log(`[Chat] Chat-only client connected for ${sessionName}`)
 
       // Get or create minimal session state for chatClients

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.2",
+  "version": "0.35.3",
   "releaseDate": "2026-05-14",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Fix**: Chat view now works for remote host agents (was always connecting locally, showing no messages)
- **Root cause**: ChatView/MobileChatView didn't pass `&host=` in WebSocket URL, and server checked `chatOnly` before `host` — remote chat was never proxied

## Changes
| File | Change |
|------|--------|
| `server.mjs` | Add remote host proxy inside chatOnly block; add `extraParams` to `handleRemoteWorker` |
| `components/ChatView.tsx` | Include `&host=` in WebSocket URL when agent has remote hostId |
| `components/MobileChatView.tsx` | Add `hostId` prop, include in WebSocket URL |
| `components/MobileDashboard.tsx` | Pass `hostId` to MobileChatView |
| `components/TabletDashboard.tsx` | Pass `hostId` to MobileChatView |

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — 755/755 pass
- [ ] Manual: Connect to remote agent → chat tab shows messages
- [ ] Manual: Local agents still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)