### PR TITLE
fix: prevent duplicate agent creation from UUID-based session naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.5] - 2026-05-14
+
+### Fixed
+- **Duplicate agent creation from UUID-based session naming** — When `agentId` was passed to `createSession()`, the tmux session was named `uuid@host` instead of the agent's friendly name, causing session discovery to fail matching and triggering phantom agent creation via AMP. Now always uses the normalized agent name for tmux sessions.
+- **Orphan session fallback matching** — Session discovery had no fallback when `getAgentBySession()` failed for legacy UUID-named sessions. Added fallback that extracts UUIDs from `uuid@host` session names and looks up the agent by ID directly.
+
 ## [0.35.1] - 2026-05-14
 
 ### Added

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -29,7 +29,7 @@ import os from 'os'
 import type { Session } from '@/types/session'
 import { getAgent, getAgentBySession, getAgentByName, createAgent, deleteAgentBySession, renameAgentSession } from '@/lib/agent-registry'
 import { loadAgents } from '@/lib/agent-registry'
-import { getHosts, getSelfHost, getSelfHostId, isSelf, getHostById } from '@/lib/hosts-config'
+import { getHosts, getSelfHost, isSelf, getHostById } from '@/lib/hosts-config'
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
 import { parseNameForDisplay } from '@/types/agent'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
@@ -210,7 +210,15 @@ async function fetchLocalSessions(hostId: string): Promise<Session[]> {
         status = 'disconnected'
       }
 
-      const agent = getAgentBySession(disc.name)
+      let agent = getAgentBySession(disc.name)
+
+      // Fallback: session name might be UUID@host (from legacy bug where agentId was used as session name)
+      if (!agent) {
+        const uuidMatch = disc.name.match(/^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:@|$)/)
+        if (uuidMatch) {
+          agent = getAgent(uuidMatch[1])
+        }
+      }
 
       sessions.push({
         id: disc.name,
@@ -633,8 +641,9 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
   // Local session creation
   const runtime = getRuntime()
   const normalizedName = name.toLowerCase()
-  const selfHostId = getSelfHostId()
-  const actualSessionName = agentId ? `${agentId}@${selfHostId}` : normalizedName
+  // Always use the friendly agent name for the tmux session (never UUID)
+  // agentId is only used for linking to an existing agent, not naming
+  const actualSessionName = normalizedName
 
   const sessionExists = await runtime.sessionExists(actualSessionName)
   if (sessionExists) {
@@ -671,8 +680,8 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
 
   // Persist session metadata (legacy)
   persistSession({
-    id: actualSessionName,
-    name: actualSessionName,
+    id: normalizedName,
+    name: normalizedName,
     workingDirectory: cwd,
     createdAt: new Date().toISOString(),
     ...(agentId && { agentId }),

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.4",
+  "version": "0.35.5",
   "releaseDate": "2026-05-14",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Bug 1**: `createSession()` named tmux sessions `uuid@host` when `agentId` was passed, breaking session discovery matching. Now always uses the friendly agent name.
- **Bug 2**: Session discovery had no fallback for UUID-named legacy sessions. Added fallback that extracts UUID and looks up the agent by ID directly.
- Prevents phantom/orphan agent creation (e.g., "george-felipe-grad" becoming 3 separate agents)

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — all 755 tests pass
- [ ] Create agent via wizard → verify tmux session uses agent name (not UUID)
- [ ] Verify no new orphan agents appear after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)