### PR TITLE
feat: host circuit breaker — auto-disable unreachable hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.6] - 2026-05-15
+
+### Added
+- **Host circuit breaker** — Automatically disables unreachable remote hosts after 3 consecutive failures in `getUnifiedAgents()`, eliminating 3s timeout delays per dead host on every poll cycle. Configurable via `CIRCUIT_BREAKER_THRESHOLD` env var.
+- **`POST /api/hosts/:id/reactivate`** — New endpoint to manually re-enable a circuit-broken host. Also registered in headless router.
+- **Mesh self-healing** — `registerPeer()` auto-re-enables circuit-broken hosts when they come back online and re-register.
+- **Disabled hosts in `GET /api/hosts`** — `listHosts()` now appends disabled hosts with `status: 'disabled'` so the settings UI can show them with a "Reactivate" button.
+- `offlineReason` and `offlineSince` fields on the `Host` type for tracking circuit breaker metadata.
+- `loadAllHostsRaw()` and `updateHostRaw()` in `hosts-config.ts` to operate on the unfiltered host list (bypasses `enabled` filtering).
+- `lastSyncSuccess` now populated on every successful remote host fetch.
+
 ## [0.35.5] - 2026-05-14
 
 ### Fixed

--- a/app/api/hosts/[id]/reactivate/route.ts
+++ b/app/api/hosts/[id]/reactivate/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from 'next/server'
+import { reactivateHost } from '@/services/hosts-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/hosts/[id]/reactivate
+ *
+ * Re-enable a host that was disabled by the circuit breaker.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const result = await reactivateHost(id)
+  return toResponse(result)
+}

--- a/lib/hosts-config.ts
+++ b/lib/hosts-config.ts
@@ -861,6 +861,65 @@ export function updateHost(
 }
 
 /**
+ * Load ALL hosts from hosts.json without filtering by enabled status.
+ * Used by circuit breaker reactivation flow where we need to find disabled hosts.
+ */
+export function loadAllHostsRaw(): Host[] {
+  try {
+    if (!fs.existsSync(HOSTS_CONFIG_PATH)) {
+      return [getDefaultSelfHost()]
+    }
+    const fileContent = fs.readFileSync(HOSTS_CONFIG_PATH, 'utf-8')
+    const config = JSON.parse(fileContent) as HostsConfig
+    return config.hosts.map(migrateHost)
+  } catch (error) {
+    console.error('[Hosts] Failed to load raw hosts:', error)
+    return []
+  }
+}
+
+/**
+ * Update a host in the raw (unfiltered) host list.
+ * Unlike updateHost(), this can find and update disabled hosts.
+ * Refuses to disable the self host.
+ */
+export function updateHostRaw(
+  hostId: string,
+  updates: Partial<Host>
+): { success: boolean; host?: Host; error?: string } {
+  try {
+    const allHosts = loadAllHostsRaw()
+    const hostIndex = allHosts.findIndex(
+      h => h.id.toLowerCase() === hostId.toLowerCase()
+    )
+    if (hostIndex === -1) {
+      return { success: false, error: `Host '${hostId}' not found` }
+    }
+
+    // Prevent disabling self host
+    if (isSelf(allHosts[hostIndex].id) && updates.enabled === false) {
+      return { success: false, error: 'Cannot disable self host' }
+    }
+
+    const updatedHost = { ...allHosts[hostIndex], ...updates, id: allHosts[hostIndex].id }
+    allHosts[hostIndex] = updatedHost
+
+    const result = saveHosts(allHosts)
+    if (!result.success) {
+      return result
+    }
+
+    return { success: true, host: updatedHost }
+  } catch (error) {
+    console.error('[Hosts] Failed to update host (raw):', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update host',
+    }
+  }
+}
+
+/**
  * Delete a host
  */
 export function deleteHost(hostId: string): { success: boolean; error?: string } {

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -56,7 +56,7 @@ import {
   unlinkSession,
 } from '@/lib/agent-registry'
 import { resolveAgentIdentifier } from '@/lib/messageQueue'
-import { getHosts, getSelfHost, getSelfHostId, isSelf } from '@/lib/hosts-config'
+import { getHosts, getSelfHost, getSelfHostId, isSelf, updateHostRaw } from '@/lib/hosts-config'
 import { persistSession, unpersistSession } from '@/lib/session-persistence'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { initializeAllAgents, getStartupStatus } from '@/lib/agent-startup'
@@ -73,6 +73,39 @@ import {
 } from '@/lib/container-utils'
 import type { Host } from '@/types/host'
 import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed, gone, timeout } from '@/services/service-errors'
+
+// ---------------------------------------------------------------------------
+// Circuit breaker — auto-disable hosts after consecutive failures
+// ---------------------------------------------------------------------------
+
+const hostFailureCounts = new Map<string, number>()
+const CIRCUIT_BREAKER_THRESHOLD = parseInt(process.env.CIRCUIT_BREAKER_THRESHOLD || '3', 10)
+
+function recordHostSuccess(hostId: string): void {
+  hostFailureCounts.delete(hostId)
+}
+
+function recordHostFailure(host: Host): void {
+  if (isSelf(host.id)) return
+
+  const count = (hostFailureCounts.get(host.id) || 0) + 1
+  hostFailureCounts.set(host.id, count)
+
+  if (count >= CIRCUIT_BREAKER_THRESHOLD) {
+    console.warn(`[Circuit Breaker] Host '${host.id}' hit ${count} consecutive failures — disabling`)
+    updateHostRaw(host.id, {
+      enabled: false,
+      offlineReason: `circuit-breaker: ${count} consecutive failures`,
+      offlineSince: new Date().toISOString(),
+      lastSyncError: `Disabled after ${count} consecutive failures`,
+    })
+    hostFailureCounts.delete(host.id)
+  }
+}
+
+export function resetCircuitBreaker(hostId: string): void {
+  hostFailureCounts.delete(hostId)
+}
 
 interface DiscoveredSession {
   name: string
@@ -531,6 +564,7 @@ function createOrphanAgent(
         platform: os.platform(),
       }
     },
+    runtime: 'tmux',
     tools: {},
     status: 'active',
     createdAt: session.createdAt,
@@ -1165,6 +1199,7 @@ export async function getUnifiedAgents(params: UnifiedAgentsParams): Promise<Ser
       clearTimeout(timeoutId)
 
       if (!response.ok) {
+        recordHostFailure(host)
         return {
           host,
           success: false,
@@ -1175,6 +1210,10 @@ export async function getUnifiedAgents(params: UnifiedAgentsParams): Promise<Ser
       }
 
       const data: HostAgentResponse = await response.json()
+      recordHostSuccess(host.id)
+      if (!isSelf(host.id)) {
+        updateHostRaw(host.id, { lastSyncSuccess: new Date().toISOString() })
+      }
       return {
         host,
         success: true,
@@ -1185,6 +1224,10 @@ export async function getUnifiedAgents(params: UnifiedAgentsParams): Promise<Ser
       const errorMessage = error instanceof Error
         ? error.name === 'AbortError' ? 'Request timeout' : error.message
         : 'Unknown error'
+      recordHostFailure(host)
+      if (!isSelf(host.id)) {
+        updateHostRaw(host.id, { lastSyncError: errorMessage })
+      }
       return {
         host,
         success: false,

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -167,6 +167,7 @@ import {
   getMeshStatus,
   registerPeer,
   exchangePeers,
+  reactivateHost,
 } from '@/services/hosts-service'
 
 import {
@@ -1003,6 +1004,9 @@ const routes: Route[] = [
   { method: 'PUT', pattern: /^\/api\/hosts\/([^/]+)$/, paramNames: ['id'], handler: async (req, res, params) => {
     const body = await readJsonBody(req)
     sendServiceResult(res, await updateExistingHost(params.id, body))
+  }},
+  { method: 'POST', pattern: /^\/api\/hosts\/([^/]+)\/reactivate$/, paramNames: ['id'], handler: async (_req, res, params) => {
+    sendServiceResult(res, await reactivateHost(params.id))
   }},
   { method: 'DELETE', pattern: /^\/api\/hosts\/([^/]+)$/, paramNames: ['id'], handler: async (_req, res, params) => {
     sendServiceResult(res, await deleteExistingHost(params.id))

--- a/services/hosts-service.ts
+++ b/services/hosts-service.ts
@@ -38,6 +38,8 @@ import {
   getOrganizationInfo,
   hasOrganization,
   adoptOrganization,
+  loadAllHostsRaw,
+  updateHostRaw,
 } from '@/lib/hosts-config'
 import { addHostWithSync, syncWithAllPeers, getPublicUrl, hasProcessedPropagation, markPropagationProcessed } from '@/lib/host-sync'
 import type { Host } from '@/types/host'
@@ -50,6 +52,7 @@ import type {
   HostIdentityResponse,
 } from '@/types/host-sync'
 import { type ServiceResult, missingField, invalidField, notFound, operationFailed, invalidRequest } from '@/services/service-errors'
+import { resetCircuitBreaker } from '@/services/agents-core-service'
 
 const execAsync = promisify(exec)
 
@@ -367,7 +370,18 @@ export async function listHosts(): Promise<ServiceResult<{ hosts: any[] }>> {
       }
     }
 
-    return { data: { hosts: hostsWithSelf }, status: 200 }
+    // Append disabled (circuit-broken) hosts so the UI can show them
+    const allRaw = loadAllHostsRaw()
+    const enabledIds = new Set(hostsWithSelf.map(h => h.id.toLowerCase()))
+    const disabledHosts = allRaw
+      .filter(h => h.enabled === false && !enabledIds.has(h.id.toLowerCase()))
+      .map(h => ({
+        ...h,
+        isSelf: false,
+        status: 'disabled' as const,
+      }))
+
+    return { data: { hosts: [...hostsWithSelf, ...disabledHosts] }, status: 200 }
   } catch (error) {
     console.error('[Hosts API] Failed to fetch hosts:', error)
     return operationFailed('fetch hosts')
@@ -828,6 +842,38 @@ export async function registerPeer(body: PeerRegistrationRequest): Promise<Servi
       }
     }
 
+    // Check if this peer was circuit-broken — re-enable it
+    const allRaw = loadAllHostsRaw()
+    const circuitBroken = allRaw.find(
+      h => h.id.toLowerCase() === body.host.id.toLowerCase() && h.enabled === false
+    )
+    if (circuitBroken) {
+      console.log(`[Host Sync] Re-enabling circuit-broken host '${circuitBroken.id}' via peer registration`)
+      updateHostRaw(circuitBroken.id, {
+        enabled: true,
+        offlineReason: undefined,
+        offlineSince: undefined,
+        lastSyncError: undefined,
+        url: body.host.url,
+        aliases: body.host.aliases || circuitBroken.aliases,
+        syncedAt: new Date().toISOString(),
+        syncSource: body.source?.initiator || 'peer-registration',
+      })
+      resetCircuitBreaker(circuitBroken.id)
+      clearHostsCache()
+      return {
+        data: {
+          success: true,
+          registered: false,
+          alreadyKnown: true,
+          host: getLocalHostIdentity(),
+          knownHosts: getKnownHostIdentities(body.host.id),
+          ...getOrgInfo(),
+        },
+        status: 200,
+      }
+    }
+
     // Build list of all identifiers to check for duplicates
     const incomingIdentifiers: string[] = [
       body.host.id,
@@ -937,6 +983,49 @@ export async function registerPeer(body: PeerRegistrationRequest): Promise<Servi
       },
       status: 500,
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/hosts/:id/reactivate — re-enable a circuit-broken host
+// ---------------------------------------------------------------------------
+
+export async function reactivateHost(id: string): Promise<ServiceResult<{ success: boolean; host?: Host }>> {
+  try {
+    if (!id) {
+      return missingField('id')
+    }
+
+    const allHosts = loadAllHostsRaw()
+    const host = allHosts.find(h => h.id.toLowerCase() === id.toLowerCase())
+
+    if (!host) {
+      return notFound('Host', id)
+    }
+
+    if (host.enabled !== false) {
+      return invalidRequest(`Host '${id}' is already enabled`)
+    }
+
+    const result = updateHostRaw(id, {
+      enabled: true,
+      offlineReason: undefined,
+      offlineSince: undefined,
+      lastSyncError: undefined,
+    })
+
+    if (!result.success) {
+      return operationFailed('reactivate host', result.error)
+    }
+
+    resetCircuitBreaker(id)
+    clearHostsCache()
+
+    console.log(`[Hosts] Reactivated circuit-broken host: ${id}`)
+    return { data: { success: true, host: result.host }, status: 200 }
+  } catch (error) {
+    console.error(`[Hosts] Failed to reactivate host '${id}':`, error)
+    return operationFailed('reactivate host')
   }
 }
 

--- a/types/host.ts
+++ b/types/host.ts
@@ -31,6 +31,12 @@ export interface Host {
   /** Whether this host is enabled */
   enabled?: boolean
 
+  /** Reason the host was disabled (e.g. "circuit-breaker: 3 consecutive failures") */
+  offlineReason?: string
+
+  /** ISO timestamp when the host was disabled */
+  offlineSince?: string
+
   /** Whether this host is accessed via Tailscale VPN */
   tailscale?: boolean
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.5",
-  "releaseDate": "2026-05-14",
+  "version": "0.35.6",
+  "releaseDate": "2026-05-15",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- Auto-disables remote hosts after 3 consecutive failures in `getUnifiedAgents()`, eliminating 3s timeout delays per dead host on every poll cycle
- New `POST /api/hosts/:id/reactivate` endpoint for manual recovery
- Mesh self-healing: `registerPeer()` auto-re-enables circuit-broken hosts when they come back online
- `GET /api/hosts` now includes disabled hosts with `status: 'disabled'` for UI display

## Files changed
| File | Change |
|------|--------|
| `types/host.ts` | Added `offlineReason`, `offlineSince` fields |
| `lib/hosts-config.ts` | Added `loadAllHostsRaw()`, `updateHostRaw()` |
| `services/agents-core-service.ts` | Circuit breaker logic + wired into fetch loop |
| `services/hosts-service.ts` | `reactivateHost()`, peer recovery, disabled host listing |
| `app/api/hosts/[id]/reactivate/route.ts` | New route |
| `services/headless-router.ts` | Registered reactivate route |
| `CHANGELOG.md` | v0.35.6 entry |

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (755/755)
- [ ] Simulate: set `enabled: false` on a host in `hosts.json`, confirm `GET /api/agents/unified` skips it
- [ ] `POST /api/hosts/leonidas/reactivate` re-enables, confirmed via `GET /api/hosts`
- [ ] Confirm `listHosts()` returns disabled hosts with `status: 'disabled'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)