### PR TITLE
fix: chat messages not reaching agents via WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.35.6] - 2026-05-15
 
+### Fixed
+- **Chat messages not reaching agents** — WebSocket chat handlers in `server.mjs` used `ptyProcess.write()` which bypassed tmux input handling and failed silently when no terminal tab was open (`ptyProcess: null`). Replaced both handlers (chat-only and full-terminal) with `tmux send-keys -l` using proper single-quote escaping and a 100ms delay before Enter, matching the proven `agent-runtime.ts` pattern.
+
 ### Added
 - **Host circuit breaker** — Automatically disables unreachable remote hosts after 3 consecutive failures in `getUnifiedAgents()`, eliminating 3s timeout delays per dead host on every poll cycle. Configurable via `CIRCUIT_BREAKER_THRESHOLD` env var.
 - **`POST /api/hosts/:id/reactivate`** — New endpoint to manually re-enable a circuit-broken host. Also registered in headless router.

--- a/server.mjs
+++ b/server.mjs
@@ -1202,24 +1202,25 @@ async function startServer(handleRequest) {
             }
             startJsonlWatcher(sessionName, sessionState, parsed.agentId)
           } else if (parsed.type === 'chat:send') {
-            if (parsed.message && sessionState.ptyProcess) {
-              sessionState.ptyProcess.write(parsed.message + '\r')
-              if (ws.readyState === 1) {
-                ws.send(JSON.stringify({ type: 'chat:sent' }))
-              }
-              setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 500)
-              setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 1500)
-            } else if (parsed.message) {
-              // No PTY — try to send via tmux send-keys as fallback
+            if (parsed.message) {
+              // Always use tmux send-keys -l with proper escaping and delay.
+              // Direct ptyProcess.write() bypasses tmux input handling and
+              // doesn't give Claude Code the 100ms gap it needs between text
+              // and Enter to process the input.
               try {
-                execSync(`tmux send-keys -t "${sessionName}" -l ${JSON.stringify(parsed.message)}`, { timeout: 3000 })
+                const escaped = parsed.message.replace(/'/g, "'\\''")
+                execSync(`tmux send-keys -t "${sessionName}" -l '${escaped}'`, { timeout: 3000 })
+                // 100ms delay so Claude Code processes the literal text before Enter
+                await new Promise(r => setTimeout(r, 100))
                 execSync(`tmux send-keys -t "${sessionName}" Enter`, { timeout: 3000 })
                 if (ws.readyState === 1) {
                   ws.send(JSON.stringify({ type: 'chat:sent' }))
                 }
+                setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 500)
+                setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 1500)
               } catch (err) {
                 if (ws.readyState === 1) {
-                  ws.send(JSON.stringify({ type: 'chat:error', error: 'Failed to send: no PTY connection' }))
+                  ws.send(JSON.stringify({ type: 'chat:error', error: 'Failed to send: ' + err.message }))
                 }
               }
             }
@@ -1572,14 +1573,23 @@ async function startServer(handleRequest) {
           }
 
           if (parsed.type === 'chat:send') {
-            if (parsed.message && sessionState.ptyProcess) {
-              sessionState.ptyProcess.write(parsed.message + '\r')
-              if (ws.readyState === 1) {
-                ws.send(JSON.stringify({ type: 'chat:sent' }))
+            if (parsed.message) {
+              try {
+                const escaped = parsed.message.replace(/'/g, "'\\''")
+                execSync(`tmux send-keys -t "${sessionName}" -l '${escaped}'`, { timeout: 3000 })
+                await new Promise(r => setTimeout(r, 100))
+                execSync(`tmux send-keys -t "${sessionName}" Enter`, { timeout: 3000 })
+                if (ws.readyState === 1) {
+                  ws.send(JSON.stringify({ type: 'chat:sent' }))
+                }
+                // Burst re-read of JSONL after a short delay to catch the response
+                setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 500)
+                setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 1500)
+              } catch (err) {
+                if (ws.readyState === 1) {
+                  ws.send(JSON.stringify({ type: 'chat:error', error: 'Failed to send: ' + err.message }))
+                }
               }
-              // Burst re-read of JSONL after a short delay to catch the response
-              setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 500)
-              setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), 1500)
             }
             return
           }


### PR DESCRIPTION
## Summary
- Both WebSocket chat handlers (`chat-only` at line 1204 and `full-terminal` at line 1575) used `ptyProcess.write()` which bypassed tmux input handling
- Chat-only mode had `ptyProcess: null`, causing silent failure — fallback used `JSON.stringify` for shell escaping (wrong)
- Replaced with `tmux send-keys -l` + proper single-quote escaping + 100ms delay before Enter, matching `agent-runtime.ts`

## Test plan
- [x] `yarn build` passes
- [x] End-to-end verified: sent message via `tmux send-keys -l` pattern, Claude Code received and processed it
- [x] Both handlers (chat-only and full-terminal) updated identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)