### PR TITLE
feat: favorites speed dial, chat X-Ray mode, permission prompts in chat (v0.35.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.9] - 2026-05-16
+
+### Added
+- **Favorites / Speed Dial** — Pin frequently-used agents to a horizontal strip at the top of the sidebar for one-click access. Toggle via context menu ("Add to Favorites" / "Remove from Favorites") or star button on hover in list view. Persisted in localStorage.
+- **Chat permission prompts** — When an agent requests permission (e.g., to run a Bash command), the full prompt now appears in the chat with the command preview and clickable option buttons (Yes, Yes and don't ask again, No). Previously only visible in the terminal view.
+- **Real-time activity indicators in meeting chat** — Meeting chat now shows "Agent is working..." (spinner) and "Agent is waiting for input" (pulse) using WebSocket-backed session activity instead of naive heuristics.
+
+### Changed
+- **X-Ray mode** — Renamed Power/Assisted chat mode to "X-Ray". Single `ScanEye` icon toggles on (amber glow) / off (gray) instead of swapping between two different icons.
+- **Permission buttons always visible** — Chat permission action buttons now render in both X-Ray on and off modes. Previously gated to assisted-only, leaving no way to respond in power mode.
+
+### Fixed
+- **Hook not sending full hookState** — The `ai-maestro-hook.cjs` was writing permission details (toolName, toolInput, options) to a file but only sending `status` via the WebSocket broadcast. Now includes the full `hookState` object in the payload.
+- **Headless router missing hookState** — The headless router's activity update endpoint was not forwarding `body.hookState` to `broadcastActivityUpdate`.
+- **Bash commands overflow in chat** — Long commands rendered as a single line overflowing off-screen. Now uses `whitespace-pre-wrap` + `break-all` to wrap within the chat bubble.
+- **Meeting chat messages behind textarea** — Added `min-h-0` to the messages container for proper flex overflow constraint.
+- **No auto-scroll on permission prompt** — Added scroll trigger when `hookState` changes to `permission_request`.
+
 ## [0.35.7] - 2026-05-15
 
 ### Added

--- a/components/AgentBadge.tsx
+++ b/components/AgentBadge.tsx
@@ -11,6 +11,7 @@ import {
   Power,
   Copy,
   Mail,
+  Star,
 } from 'lucide-react'
 import { computeHash, getAvatarUrl } from '@/lib/hash-utils'
 import { Agent, AgentSession } from '@/types/agent'
@@ -30,6 +31,8 @@ interface AgentBadgeProps {
   onOpenTerminal?: (agent: Agent) => void
   onSendMessage?: (agent: Agent) => void
   onCopyId?: (agent: Agent) => void
+  isFavorite?: boolean
+  onToggleFavorite?: (agent: Agent) => void
   showActions?: boolean
 }
 
@@ -101,6 +104,8 @@ export default function AgentBadge({
   onOpenTerminal,
   onSendMessage,
   onCopyId,
+  isFavorite,
+  onToggleFavorite,
   showActions = true,
 }: AgentBadgeProps) {
   const [showMenu, setShowMenu] = React.useState(false)
@@ -226,6 +231,19 @@ export default function AgentBadge({
                 </button>
               )}
 
+              {onToggleFavorite && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleMenuAction(() => onToggleFavorite(agent))
+                  }}
+                  className="w-full px-3 py-1.5 text-left text-sm text-slate-300 hover:bg-slate-700 flex items-center gap-2"
+                >
+                  <Star className={`w-3.5 h-3.5 ${isFavorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
+                  {isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
+                </button>
+              )}
+
               {onRename && (
                 <button
                   onClick={(e) => {
@@ -301,30 +319,35 @@ export default function AgentBadge({
       {/* Badge content */}
       <div className="p-3 pt-10 flex flex-col items-center text-center">
         {/* Avatar - Photo or Emoji */}
-        <div
-          className={`
-            relative w-20 h-20 rounded-full overflow-hidden
-            ring-4 ${ringColor} shadow-lg
-            ${isHibernated ? 'opacity-50 grayscale' : ''}
-          `}
-        >
-          {hasEmojiAvatar ? (
-            <div className="w-full h-full bg-slate-700 flex items-center justify-center">
-              <span className="text-4xl">{agent.avatar}</span>
-            </div>
-          ) : imageError ? (
-            <div className="w-full h-full bg-gradient-to-br from-slate-600 to-slate-800 flex items-center justify-center">
-              <span className="text-2xl font-bold text-white/70">
-                {(agent.label || agent.name || '??').slice(0, 2).toUpperCase()}
-              </span>
-            </div>
-          ) : (
-            <img
-              src={avatarUrl}
-              alt={agent.label || agent.name}
-              className="w-full h-full object-cover"
-              onError={() => setImageError(true)}
-            />
+        <div className="relative">
+          <div
+            className={`
+              relative w-20 h-20 rounded-full overflow-hidden
+              ring-4 ${ringColor} shadow-lg
+              ${isHibernated ? 'opacity-50 grayscale' : ''}
+            `}
+          >
+            {hasEmojiAvatar ? (
+              <div className="w-full h-full bg-slate-700 flex items-center justify-center">
+                <span className="text-4xl">{agent.avatar}</span>
+              </div>
+            ) : imageError ? (
+              <div className="w-full h-full bg-gradient-to-br from-slate-600 to-slate-800 flex items-center justify-center">
+                <span className="text-2xl font-bold text-white/70">
+                  {(agent.label || agent.name || '??').slice(0, 2).toUpperCase()}
+                </span>
+              </div>
+            ) : (
+              <img
+                src={avatarUrl}
+                alt={agent.label || agent.name}
+                className="w-full h-full object-cover"
+                onError={() => setImageError(true)}
+              />
+            )}
+          </div>
+          {isFavorite && (
+            <Star className="absolute -bottom-0.5 -left-0.5 w-4 h-4 fill-yellow-400 text-yellow-400 drop-shadow" />
           )}
         </div>
 

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -34,6 +34,7 @@ import {
   Search,
   X,
   Brain,
+  Star,
 } from 'lucide-react'
 import Link from 'next/link'
 import AgentCreationWizard from './AgentCreationWizard'
@@ -48,7 +49,7 @@ import TeamListView from './sidebar/TeamListView'
 import MeetingListView from './sidebar/MeetingListView'
 import { useToast } from '@/contexts/ToastContext'
 import { getAgentBaseUrl } from '@/lib/agent-utils'
-import { computeHash } from '@/lib/hash-utils'
+import { computeHash, getAvatarUrl } from '@/lib/hash-utils'
 
 interface AgentListProps {
   agents: UnifiedAgent[]
@@ -203,6 +204,27 @@ export default function AgentList({
 
   // Search state
   const [searchQuery, setSearchQuery] = useState('')
+
+  // Favorites state (persisted in localStorage)
+  const [favoriteIds, setFavoriteIds] = useState<Set<string>>(() => {
+    if (typeof window === 'undefined') return new Set()
+    try {
+      const stored = localStorage.getItem('agent-favorites')
+      return stored ? new Set(JSON.parse(stored)) : new Set()
+    } catch { return new Set() }
+  })
+
+  useEffect(() => {
+    localStorage.setItem('agent-favorites', JSON.stringify([...favoriteIds]))
+  }, [favoriteIds])
+
+  const toggleFavorite = (agentId: string) => {
+    setFavoriteIds(prev => {
+      const next = new Set(prev)
+      next.has(agentId) ? next.delete(agentId) : next.add(agentId)
+      return next
+    })
+  }
 
   // Sidebar view state (agents / teams / meetings)
   const [sidebarView, setSidebarView] = useState<SidebarView>(() => {
@@ -760,6 +782,74 @@ export default function AgentList({
           )}
         </div>
 
+        {/* Favorites Speed Dial */}
+        {(() => {
+          const favoriteAgents = agents.filter(a => favoriteIds.has(a.id))
+          if (favoriteAgents.length === 0) return null
+          return (
+            <div className="mt-3 px-2">
+              <div className="flex items-center gap-1.5 mb-2">
+                <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" />
+                <span className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">Favorites</span>
+              </div>
+              <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-thin">
+                {favoriteAgents.map(agent => {
+                  const isActive = activeAgentId === agent.id
+                  const session = agent.sessions?.[0]
+                  const isOnline = session?.status === 'online' || agent.session?.status === 'online'
+                  const avatarUrl = agent.avatar && (agent.avatar.startsWith('http') || agent.avatar.startsWith('/'))
+                    ? agent.avatar
+                    : getAvatarUrl(agent.id)
+                  const isEmoji = agent.avatar && !agent.avatar.startsWith('http') && !agent.avatar.startsWith('/') && agent.avatar.length <= 8
+
+                  return (
+                    <div
+                      key={agent.id}
+                      className="relative flex flex-col items-center flex-shrink-0 group/fav cursor-pointer"
+                      onClick={() => onAgentSelect(agent)}
+                      title={agent.label || agent.name}
+                    >
+                      <div className={`relative w-9 h-9 rounded-full overflow-hidden ring-2 transition-all ${
+                        isActive ? 'ring-blue-500 shadow-lg shadow-blue-500/30' : 'ring-slate-600 hover:ring-slate-400'
+                      }`}>
+                        {isEmoji ? (
+                          <div className="w-full h-full bg-slate-700 flex items-center justify-center">
+                            <span className="text-lg">{agent.avatar}</span>
+                          </div>
+                        ) : (
+                          <img
+                            src={avatarUrl}
+                            alt={agent.label || agent.name}
+                            className="w-full h-full object-cover"
+                          />
+                        )}
+                        {/* Online dot */}
+                        {isOnline && (
+                          <span className="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-400 rounded-full ring-2 ring-slate-900" />
+                        )}
+                      </div>
+                      {/* Remove button on hover */}
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          toggleFavorite(agent.id)
+                        }}
+                        className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-slate-700 text-slate-400 hover:bg-red-500/80 hover:text-white items-center justify-center text-[10px] hidden group-hover/fav:flex transition-colors"
+                        title="Remove from favorites"
+                      >
+                        <X className="w-2.5 h-2.5" />
+                      </button>
+                      <span className="mt-1 text-[10px] text-gray-400 truncate max-w-[44px] text-center leading-tight">
+                        {agent.label || agent.name}
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })()}
+
         {/* Host List - Collapsible */}
         <div className="mt-3">
           <button
@@ -1021,6 +1111,8 @@ export default function AgentList({
                                             onOpenTerminal={isOnline ? () => handleAgentClick(agent) : undefined}
                                             onSendMessage={() => {/* TODO: Implement send message dialog */}}
                                             onCopyId={() => navigator.clipboard.writeText(agent.id)}
+                                            isFavorite={favoriteIds.has(agent.id)}
+                                            onToggleFavorite={(a) => toggleFavorite(a.id)}
                                           />
                                         )
                                       })}
@@ -1303,6 +1395,21 @@ export default function AgentList({
 
                                           {/* Action buttons - show on hover */}
                                           <div className="hidden group-hover/agent:flex items-center gap-1">
+                                            {/* Favorite toggle */}
+                                            <button
+                                              onClick={(e) => {
+                                                e.stopPropagation()
+                                                toggleFavorite(agent.id)
+                                              }}
+                                              className={`p-1 rounded transition-all duration-200 ${
+                                                favoriteIds.has(agent.id)
+                                                  ? 'text-yellow-400 hover:bg-yellow-500/20'
+                                                  : 'text-gray-400 hover:bg-yellow-500/20 hover:text-yellow-400'
+                                              }`}
+                                              title={favoriteIds.has(agent.id) ? 'Remove from favorites' : 'Add to favorites'}
+                                            >
+                                              <Star className={`w-3 h-3 ${favoriteIds.has(agent.id) ? 'fill-yellow-400' : ''}`} />
+                                            </button>
                                             {/* Hibernate button - show when agent is online */}
                                             {isOnline && (
                                               <button

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback, useMemo, type KeyboardEvent, type ChangeEvent } from 'react'
-import { User, Bot, Wrench, Loader2, Send, RefreshCw, AlertCircle, ChevronDown, ChevronRight, Copy, Check, MessageSquare, Zap, Shield, Brain, X } from 'lucide-react'
+import { User, Bot, Wrench, Loader2, Send, RefreshCw, AlertCircle, ChevronDown, ChevronRight, Copy, Check, MessageSquare, ScanEye, Brain, X } from 'lucide-react'
 import { MarkdownContent } from '@/components/chat/MarkdownRenderer'
 import type { Agent } from '@/types/agent'
 
@@ -502,7 +502,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       case 'Bash':
         return (
           <div className="px-3 pb-3">
-            <pre className="text-xs bg-gray-950/50 p-2 rounded overflow-x-auto max-h-48 overflow-y-auto font-mono text-green-300">
+            <pre className="text-xs bg-gray-950/50 p-2 rounded whitespace-pre-wrap break-all max-h-48 overflow-y-auto font-mono text-green-300">
               {input.command || ''}
             </pre>
           </div>
@@ -611,12 +611,12 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
             onClick={toggleChatMode}
             className={`p-2 rounded-lg transition-colors ${
               chatMode === 'power'
-                ? 'text-amber-400 hover:bg-gray-700'
-                : 'text-blue-400 hover:bg-gray-700'
+                ? 'text-amber-400 bg-amber-400/10 hover:bg-amber-400/20'
+                : 'text-gray-500 hover:bg-gray-700 hover:text-gray-300'
             }`}
-            title={chatMode === 'power' ? 'Power mode — switch to Assisted' : 'Assisted mode — switch to Power'}
+            title={chatMode === 'power' ? 'X-Ray on — click to turn off' : 'X-Ray off — click to see thinking & tools'}
           >
-            {chatMode === 'power' ? <Zap className="w-4 h-4" /> : <Shield className="w-4 h-4" />}
+            <ScanEye className="w-4 h-4" />
           </button>
           <button
             onClick={requestHistory}
@@ -854,7 +854,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
 
                 {/* Command preview for Bash */}
                 {hookState.toolName === 'Bash' && hookState.toolInput?.command && (
-                  <div className="text-xs bg-gray-950/50 p-2 rounded font-mono overflow-x-auto max-h-32 overflow-y-auto mb-3">
+                  <div className="text-xs bg-gray-950/50 p-2 rounded font-mono whitespace-pre-wrap break-all max-h-32 overflow-y-auto mb-3">
                     {hookState.toolInput.command}
                   </div>
                 )}
@@ -866,8 +866,8 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                   </div>
                 )}
 
-                {/* Action buttons (assisted mode) */}
-                {chatMode === 'assisted' && hookState.options && hookState.options.length > 0 ? (
+                {/* Action buttons — always shown so user can respond from chat */}
+                {hookState.options && hookState.options.length > 0 ? (
                   <div className="space-y-1.5">
                     {hookState.options.map((option, idx) => (
                       <button
@@ -883,7 +883,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                       </button>
                     ))}
                   </div>
-                ) : chatMode === 'assisted' ? (
+                ) : (
                   /* Yes/No fallback */
                   <div className="flex gap-2">
                     <button onClick={() => sendQuickResponse('y')} disabled={isSending}
@@ -895,7 +895,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                       No
                     </button>
                   </div>
-                ) : null}
+                )}
               </div>
             </div>
           </div>

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -322,6 +322,13 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     }
   }, [messages, pendingMessages])
 
+  // Auto-scroll when permission prompt appears
+  useEffect(() => {
+    if (hookState?.status === 'permission_request') {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [hookState])
+
   // Send quick response (assisted mode — for permission buttons)
   const sendQuickResponse = (text: string) => {
     setIsSending(true)

--- a/components/InfraIcon.tsx
+++ b/components/InfraIcon.tsx
@@ -1,19 +1,17 @@
 'use client'
 
-import { Box, Server, Cloud, Wifi } from 'lucide-react'
+import { Box, Server, Cloud, Wifi, Network } from 'lucide-react'
 import type { Agent } from '@/types/agent'
 
-type InfraType = 'local' | 'docker' | 'ec2' | 'ecs' | 'cloud' | 'standalone'
+type InfraType = 'local' | 'remote' | 'docker' | 'ec2' | 'ecs' | 'cloud' | 'standalone'
 
 export function getInfraType(agent: Agent): InfraType {
   if (agent.session?.standalone) return 'standalone'
 
   const deployment = agent.deployment
-  if (!deployment) return 'local'
-
-  if (deployment.type === 'cloud') {
+  if (deployment?.type === 'cloud') {
     const cloud = deployment.cloud
-    if (!cloud) return 'local'
+    if (!cloud) return isRemote(agent) ? 'remote' : 'local'
 
     if (cloud.provider === 'local-container') return 'docker'
 
@@ -26,30 +24,35 @@ export function getInfraType(agent: Agent): InfraType {
     return 'cloud'
   }
 
+  // No cloud deployment — check if it's a remote mesh agent
+  if (isRemote(agent)) return 'remote'
+
   return 'local'
 }
 
+function isRemote(agent: Agent): boolean {
+  return Boolean(agent.hostId && agent.hostId !== 'local')
+}
+
 const infraConfig: Record<InfraType, { icon: typeof Box; color: string; label: string }> = {
-  local:      { icon: Server, color: 'text-gray-500',   label: 'Local (tmux)' },
-  docker:     { icon: Box,    color: 'text-blue-400',   label: 'Docker container' },
-  ec2:        { icon: Server, color: 'text-orange-400', label: 'AWS EC2' },
-  ecs:        { icon: Cloud,  color: 'text-purple-400', label: 'AWS ECS/Fargate' },
-  cloud:      { icon: Cloud,  color: 'text-sky-400',    label: 'Cloud' },
-  standalone: { icon: Wifi,   color: 'text-teal-400',   label: 'Standalone agent' },
+  local:      { icon: Server,  color: 'text-gray-500',   label: 'Local (tmux)' },
+  remote:     { icon: Network, color: 'text-purple-400', label: 'Remote (mesh)' },
+  docker:     { icon: Box,     color: 'text-blue-400',   label: 'Docker container' },
+  ec2:        { icon: Server,  color: 'text-orange-400', label: 'AWS EC2' },
+  ecs:        { icon: Cloud,   color: 'text-purple-400', label: 'AWS ECS/Fargate' },
+  cloud:      { icon: Cloud,   color: 'text-sky-400',    label: 'Cloud' },
+  standalone: { icon: Wifi,    color: 'text-teal-400',   label: 'Standalone agent' },
 }
 
 interface InfraIconProps {
   agent: Agent
   size?: number
   className?: string
-  showLocal?: boolean // Whether to show icon for local agents (default: false)
+  showLocal?: boolean // Whether to show icon for local agents (default: true)
 }
 
-export default function InfraIcon({ agent, size = 12, className = '', showLocal = false }: InfraIconProps) {
+export default function InfraIcon({ agent, size = 12, className = '', showLocal = true }: InfraIconProps) {
   const infraType = getInfraType(agent)
-
-  // Skip rendering for local agents unless explicitly requested
-  if (infraType === 'local' && !showLocal) return null
 
   const config = infraConfig[infraType]
   const Icon = config.icon

--- a/components/team-meeting/MeetingChatPanel.tsx
+++ b/components/team-meeting/MeetingChatPanel.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { Send, Users, User, X } from 'lucide-react'
+import { Send, Users, User, X, Loader2 } from 'lucide-react'
 import type { Agent } from '@/types/agent'
+import { useSessionActivity } from '@/hooks/useSessionActivity'
 
 interface ChatMessage {
   id: string
@@ -35,6 +36,7 @@ export default function MeetingChatPanel({ agents, messages, onSendToAgent, onBr
   const [inputText, setInputText] = useState('')
   const [sending, setSending] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const { getSessionActivity } = useSessionActivity()
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -126,7 +128,7 @@ export default function MeetingChatPanel({ agents, messages, onSendToAgent, onBr
       </div>
 
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-2">
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2 space-y-2">
         {filteredMessages.length === 0 && (
           <p className="text-[11px] text-gray-600 text-center py-8">
             No messages yet. Send a message to get started.
@@ -154,6 +156,44 @@ export default function MeetingChatPanel({ agents, messages, onSendToAgent, onBr
             </span>
           </div>
         ))}
+        {/* Activity indicators - show real-time agent processing status */}
+        {(() => {
+          // Determine which agents to show status for
+          const targetAgents = recipient === 'all' ? agents : agents.filter(a => a.id === recipient)
+          const activeAgents = targetAgents.filter(a => {
+            const info = getSessionActivity(a.name, a.id)
+            return info?.status === 'active'
+          })
+          const waitingAgents = targetAgents.filter(a => {
+            const info = getSessionActivity(a.name, a.id)
+            return info?.status === 'waiting'
+          })
+
+          return (
+            <>
+              {activeAgents.map(a => (
+                <div key={`activity-${a.id}`} className="flex flex-col items-start">
+                  <div className="flex items-center gap-2 rounded-lg px-3 py-2 bg-gray-800/50 text-gray-400">
+                    <Loader2 className="w-3 h-3 animate-spin text-amber-400" />
+                    <span className={isOverlay ? 'text-sm' : 'text-[11px]'}>
+                      {a.label || a.name} is working...
+                    </span>
+                  </div>
+                </div>
+              ))}
+              {waitingAgents.map(a => (
+                <div key={`waiting-${a.id}`} className="flex flex-col items-start">
+                  <div className="flex items-center gap-2 rounded-lg px-3 py-2 bg-gray-800/50 text-gray-400">
+                    <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                    <span className={isOverlay ? 'text-sm' : 'text-[11px]'}>
+                      {a.label || a.name} is waiting for input
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </>
+          )
+        })()}
         <div ref={messagesEndRef} />
       </div>
 

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -119,6 +119,31 @@ function ensureAgentsDir() {
 }
 
 /**
+ * Backfill the runtime field for agents that predate it.
+ * Infers runtime from deployment type and AMP metadata.
+ * Returns true if any agents were updated.
+ */
+function backfillRuntime(agents: Agent[]): boolean {
+  let changed = false
+  for (const agent of agents) {
+    if (agent.runtime) continue
+    if (agent.deployment?.type === 'cloud') {
+      agent.runtime = 'docker'
+    } else if (
+      agent.ampRegistered &&
+      (agent.sessions || []).length === 0 &&
+      !agent.metadata?.autoRegistered
+    ) {
+      agent.runtime = 'api'
+    } else {
+      agent.runtime = 'tmux'
+    }
+    changed = true
+  }
+  return changed
+}
+
+/**
  * Load all agents from registry
  */
 // mtime-based cache to avoid redundant disk reads within the same tick
@@ -158,6 +183,12 @@ export function loadAgents(): Agent[] {
     if (needsMigration) {
       saveAgents(agents)
       console.log('[Agent Registry] Migrated claudeArgs → programArgs')
+    }
+
+    // Backfill runtime for agents that predate the runtime field
+    if (backfillRuntime(agents)) {
+      saveAgents(agents)
+      console.log('[Agent Registry] Backfilled runtime field on existing agents')
     }
 
     _cachedAgents = agents
@@ -419,6 +450,7 @@ export function createAgent(request: CreateAgentRequest): Agent {
     model: request.model,
     taskDescription: request.taskDescription,
     programArgs: request.programArgs || '',
+    runtime: request.runtime || 'tmux',
     launchCount: 0,
     tags: normalizeTags(request.tags),
     capabilities: [],

--- a/services/agents-cloud-service.ts
+++ b/services/agents-cloud-service.ts
@@ -487,6 +487,7 @@ export async function createCloudAgent(body: CloudCreateRequest): Promise<Servic
         type: 'cloud',
         cloud: cloudMeta as unknown as Agent['deployment']['cloud'],
       } as Agent['deployment'],
+      runtime: 'docker',
       tags: body.tags,
     }
 

--- a/services/agents-docker-service.ts
+++ b/services/agents-docker-service.ts
@@ -1348,6 +1348,7 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
       programArgs: body.programArgs,
       taskDescription: body.prompt || '',
       workingDirectory: workDir,
+      runtime: 'docker',
       createSession: true,
       deploymentType: 'cloud',
       hostId: body.hostId,

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -653,6 +653,7 @@ export async function registerAgent(
           model: 'Claude',
           taskDescription: body.metadata?.description as string || `AMP-registered agent: ${normalizedName}`,
           workingDirectory: body.metadata?.working_directory as string || undefined,
+          runtime: 'api',
           createSession: false,
           metadata: {
             amp: {

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -492,7 +492,7 @@ const routes: Route[] = [
   }},
   { method: 'POST', pattern: /^\/api\/sessions\/activity\/update$/, paramNames: [], handler: async (req, res) => {
     const body = await readJsonBody(req)
-    const result = broadcastActivityUpdate(body.sessionName, body.status, body.hookStatus, body.notificationType, body.agentId)
+    const result = broadcastActivityUpdate(body.sessionName, body.status, body.hookStatus, body.notificationType, body.agentId, body.hookState)
     sendServiceResult(res, result)
   }},
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -490,6 +490,7 @@ export interface CreateAgentRequest {
   programArgs?: string          // CLI arguments passed to the program on launch
   tags?: string[]
   workingDirectory?: string
+  runtime?: 'tmux' | 'docker' | 'api' | 'direct'
   createSession?: boolean       // Auto-create tmux session
   sessionIndex?: number         // Session index to create (default 0)
   deploymentType?: DeploymentType // Where to deploy (local or cloud)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.8",
+  "version": "0.35.9",
   "releaseDate": "2026-05-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.7",
+  "version": "0.35.8",
   "releaseDate": "2026-05-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Favorites speed dial** — pin agents to a horizontal strip at the top of the sidebar for one-click access, persisted in localStorage
- **X-Ray mode** — renamed Power/Assisted toggle with single ScanEye icon (on/off), replaces confusing dual-icon swap
- **Chat permission prompts** — hook now sends full hookState (tool name, command, options) via WebSocket so permission requests render in chat with actionable buttons
- **Bash command wrapping** — commands in chat now wrap properly instead of overflowing off-screen
- **Meeting chat activity** — real-time "agent is working..." indicators using WebSocket session activity
- **Meeting chat scroll fix** — messages no longer render behind the textarea

## Test plan
- [ ] Open sidebar → no favorites strip when empty
- [ ] Right-click agent → "Add to Favorites" → avatar appears in speed dial
- [ ] Click speed dial avatar → selects agent
- [ ] Refresh page → favorites persist
- [ ] Toggle X-Ray button in chat → single icon, amber glow when on
- [ ] Trigger agent permission request → prompt with options appears in chat
- [ ] Long bash command in chat wraps within viewport
- [ ] Meeting chat messages don't hide behind compose area

🤖 Generated with [Claude Code](https://claude.com/claude-code)