### PR TITLE
fix: permission mode descriptions and conditional visibility (v0.35.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- **Call mode session fork** — When a companion voice call starts, the server auto-spawns a temporary `{agentName}__call` tmux session with `--permission-mode bypassPermissions` (full autonomy). Voice transcripts route to this YOLO fork instead of the primary supervised session, so tool-call permission prompts don't block conversational flow. Same agent identity, workdir, and skills — just a disposable autonomous session.
+- **Multi-client call session sharing** — Multiple companion clients connecting to the same agent share a single `__call` session. The session is only killed when the last client disconnects.
+- **`user_message` routing to call session** — Typed text from the companion UI now also routes to the `__call` session when active, matching `voice:transcript` behavior.
+- **Stale call session cleanup** — Orphaned `__call` tmux sessions from server crashes are automatically killed on startup.
+- **`computeCallSessionName()` / `isCallSession()` helpers** — Centralized naming convention (`__call` suffix) in `types/agent.ts`, used across all files.
+- **Call session integration test** — `scripts/test-call-session.sh` validates the full lifecycle: spawn, sidebar hiding, orphan prevention, transcript routing, disconnect cleanup, multi-client.
+- **12 unit tests for call session** — Covers helpers, `parseSessionName` non-collision, `__call` filtering in both `/api/sessions` and `/api/agents` discovery paths.
+
+### Fixed
+- **Command injection risk in companion-ws** — Replaced all `execSync` shell-string tmux commands with `execFileSync`/`execFile` (array args, no shell). Agent names validated against `[a-zA-Z0-9_-]+` before use.
+- **Event loop blocking on transcript delivery** — Transcript routing now uses async `execFile` instead of blocking `execSync`, preventing WebSocket/HTTP stalls during rapid speech.
+- **Voice buffer timing race** — Changed `getBuffer()` to `getOrCreateBuffer()` for voice subsystem attachment, ensuring the buffer exists regardless of PTY observer timing.
+- **`__call` sessions leaking into agent discovery** — Added `isCallSession()` filter to both `fetchLocalSessions()` (sessions-service) and `discoverLocalSessions()` (agents-core-service). Without this, `__call` sessions would auto-register as orphan agents in the registry.
+
+## [0.35.11] - 2026-05-17
+
+### Added
+- **voice:transcript upstream handler** — Mobile companion can now send spoken text to agents via `/companion-ws`. Transcripts route through the same `sendChatMessage()` pipeline as typed /chat messages, so session resolution, copy-mode cancellation, and tmux key sending all work identically.
+- **voice:interrupt upstream handler** — Mobile companion can send barge-in interrupts to cancel in-progress speech generation. The voice subsystem aborts LLM summarization, clears the terminal buffer, and broadcasts a stop signal to all companion clients.
+- **Server-initiated interrupt on web companion** — `useCompanionWebSocket` now handles `{type: 'interrupt'}` messages from the server and calls `tts.stop()`, so the web FaceTime UI stops TTS playback when another client (e.g. mobile) triggers a barge-in.
+- **`cancelCurrentSpeech()` on VoiceSubsystem** — New method for barge-in support: aborts summarization, clears buffer, emits `voice:interrupt` downstream.
+
 ## [0.35.9] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **Call session integration test** — `scripts/test-call-session.sh` validates the full lifecycle: spawn, sidebar hiding, orphan prevention, transcript routing, disconnect cleanup, multi-client.
 - **12 unit tests for call session** — Covers helpers, `parseSessionName` non-collision, `__call` filtering in both `/api/sessions` and `/api/agents` discovery paths.
 
+### Improved
+- **Trust level descriptions** — Each permission mode now shows a clear explanation of what it does (e.g., "Asks before every file edit and shell command") plus a detail blurb when selected explaining when to use it.
+- **Permission mode only for Claude Code** — The trust level selector in the Wake Agent dialog is now hidden when waking non-Claude programs (Aider, Codex, Cursor, Terminal), since `--permission-mode` is a Claude Code-only flag.
+- **Reordered permission modes** — Plan Only now appears second (after Supervised) instead of last, so the list flows from most restrictive to least restrictive.
+
 ### Fixed
 - **Command injection risk in companion-ws** — Replaced all `execSync` shell-string tmux commands with `execFileSync`/`execFile` (array args, no shell). Agent names validated against `[a-zA-Z0-9_-]+` before use.
 - **Event loop blocking on transcript delivery** — Transcript routing now uses async `execFile` instead of blocking `execSync`, preventing WebSocket/HTTP stalls during rapid speech.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -886,25 +886,39 @@ yarn headless:prod   # Production
 6. Kill session: `tmux kill-session -t test1`
 7. Verify: Session removed after refresh
 
-### AMP Messaging Test Suites
+### Unit Tests (CI — runs in GitHub Actions)
 
-Two test scripts exist for validating the Agent Messaging Protocol:
+Unit tests use vitest and run on every push/PR via `.github/workflows/ci.yml`:
 
 ```bash
-# Local routing tests (single host)
+yarn test          # Run all unit tests
+yarn test:watch    # Watch mode
+```
+
+Tests cover: agent utilities, session service, agents-core service, AMP auth/address/canonical-json, task registry, team registry, document registry, container utils, meeting inject, content security. All service tests mock the runtime layer — no tmux/network required.
+
+### Integration Test Suites (Manual — requires running AI Maestro)
+
+These scripts test end-to-end behavior against a live AI Maestro instance with tmux:
+
+```bash
+# AMP local routing tests (single host)
 # Tests: health, registration, internal→internal, external polling, federation, acknowledgment
 ./scripts/test-amp-routing.sh
 
-# Cross-host mesh tests (multi-host via Tailscale)
+# AMP cross-host mesh tests (multi-host via Tailscale)
 # Tests: host health, agent registration on each host, cross-host delivery, replies, inbox counts
 ./scripts/test-amp-cross-host.sh              # Auto-detect hosts from ~/.aimaestro/hosts.json
 ./scripts/test-amp-cross-host.sh --local-only  # Only test local→remote
 ./scripts/test-amp-cross-host.sh --skip-inbox  # Skip inbox verification
+
+# Companion call session fork tests
+# Tests: __call session spawn, sidebar/agent hiding, transcript routing, disconnect cleanup, multi-client
+./scripts/test-call-session.sh               # Auto-picks first online agent
+./scripts/test-call-session.sh <agent-id>    # Specific agent
 ```
 
-**Prerequisites:** AI Maestro running on localhost:23000, jq installed, AMP scripts installed (`./install-plugin.sh -y`).
-
-**No other automated tests yet.** Phase 1 focuses on getting the core working.
+**Prerequisites:** AI Maestro running on localhost:23000, jq installed, tmux installed. AMP tests also require AMP scripts (`./install-plugin.sh -y`).
 
 ## Documentation References
 

--- a/app/api/agents/[id]/wake/route.ts
+++ b/app/api/agents/[id]/wake/route.ts
@@ -25,6 +25,7 @@ export async function POST(
   let program: string | undefined
   let hostUrl: string | undefined
   let projectDirectory: string | undefined
+  let permissionMode: string | undefined
   let allowHostFallback = false
   try {
     const body = await request.json()
@@ -43,6 +44,9 @@ export async function POST(
     }
     if (typeof body.projectDirectory === 'string') {
       projectDirectory = body.projectDirectory
+    }
+    if (typeof body.permissionMode === 'string') {
+      permissionMode = body.permissionMode
     }
     if (body.allowHostFallback === true) {
       allowHostFallback = true
@@ -69,7 +73,7 @@ export async function POST(
       const response = await fetch(`${remoteHostUrl}/api/agents/${id}/wake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ startProgram, sessionIndex, program, projectDirectory, allowHostFallback }),
+        body: JSON.stringify({ startProgram, sessionIndex, program, projectDirectory, permissionMode, allowHostFallback }),
         signal: controller.signal,
       })
       clearTimeout(timeoutId)
@@ -85,6 +89,6 @@ export async function POST(
     }
   }
 
-  const result = await wakeAgent(id, { startProgram, sessionIndex, program, projectDirectory, allowHostFallback })
+  const result = await wakeAgent(id, { startProgram, sessionIndex, program, projectDirectory, permissionMode: permissionMode as any, allowHostFallback })
   return toResponse(result)
 }

--- a/app/companion/page.tsx
+++ b/app/companion/page.tsx
@@ -62,6 +62,7 @@ function CompanionContent() {
   const { send: sendToCompanion } = useCompanionWebSocket({
     agentId: activeAgentId,
     onSpeech: (text) => tts.speak(text),
+    onInterrupt: () => tts.stop(),
   })
 
   // Forward user messages to voice subsystem for conversation context

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -484,7 +484,7 @@ export default function DashboardPage() {
   }
 
   // Performs the actual wake with selected program
-  const handleWakeConfirm = async (program: string) => {
+  const handleWakeConfirm = async (program: string, options?: { permissionMode?: string }) => {
     if (!wakeDialogAgent) return
 
     const agent = wakeDialogAgent
@@ -495,10 +495,14 @@ export default function DashboardPage() {
 
     try {
       // Always call local server — the route proxies to remote hosts server-side
+      const body: Record<string, unknown> = { program, hostUrl: agent.hostUrl }
+      if (options?.permissionMode && options.permissionMode !== 'supervised') {
+        body.permissionMode = options.permissionMode
+      }
       const response = await fetch(`/api/agents/${agent.id}/wake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ program, hostUrl: agent.hostUrl }),
+        body: JSON.stringify(body),
       })
 
       if (!response.ok) {
@@ -1122,6 +1126,7 @@ export default function DashboardPage() {
           onConfirm={handleWakeConfirm}
           agentName={wakeDialogAgent?.name || wakeDialogAgent?.id || ''}
           agentAlias={wakeDialogAgent?.alias}
+          defaultPermissionMode={(wakeDialogAgent as any)?.permissionMode}
         />
 
         {/* Help Panel */}

--- a/components/AgentCreationWizard.tsx
+++ b/components/AgentCreationWizard.tsx
@@ -5,8 +5,10 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { X, ArrowLeft, ChevronRight, Monitor, Server, Cloud, Lock, Wifi, WifiOff, Box } from 'lucide-react'
 import CreateAgentAnimation, { getPreviewAvatarUrl } from './CreateAgentAnimation'
 import DirectoryPicker from './DirectoryPicker'
+import TrustLevelSelector from './TrustLevelSelector'
 import { useHosts } from '@/hooks/useHosts'
 import type { Host } from '@/types/host'
+import type { AgentPermissionMode } from '@/types/agent'
 import { getRandomAlias } from '@/lib/agent-utils'
 
 // --- Types ---
@@ -208,7 +210,7 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
   const [dockerOnWake, setDockerOnWake] = useState('')
   const [dockerOnHibernate, setDockerOnHibernate] = useState('')
   const [dockerGithubToken, setDockerGithubToken] = useState('')
-  const [dockerYolo, setDockerYolo] = useState(false)
+  const [permissionMode, setPermissionMode] = useState<AgentPermissionMode>('supervised')
   const [dockerMeshAware, setDockerMeshAware] = useState(false)
   const [dockerAutoRemove, setDockerAutoRemove] = useState(false)
 
@@ -402,7 +404,7 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
             dockerPayload.hooks = hooks
           }
           if (dockerGithubToken) dockerPayload.githubToken = dockerGithubToken
-          if (dockerYolo) dockerPayload.yolo = true
+          if (permissionMode !== 'supervised') dockerPayload.permissionMode = permissionMode
           if (dockerMeshAware) dockerPayload.meshAware = true
           if (dockerAutoRemove) dockerPayload.autoRemove = true
         }
@@ -440,7 +442,7 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
       setAnimationPhase('error')
       setIsCreating(false)
     }
-  }, [agentName, workingDirectory, hostId, runtime, showAdvanced, dockerCpus, dockerMemory, dockerMounts, dockerEnvVars, dockerOnWake, dockerOnHibernate, dockerGithubToken, dockerYolo, dockerMeshAware, dockerAutoRemove, cloudEcrImageOverride, cloudDomain, cloudSslEmail, cloudKeyName, cloudAwsRegion, cloudInstanceType, cloudEcsCpu, cloudEcsMemory, cloudAnthropicKey, cloudGithubToken])
+  }, [agentName, workingDirectory, hostId, runtime, showAdvanced, dockerCpus, dockerMemory, dockerMounts, dockerEnvVars, dockerOnWake, dockerOnHibernate, dockerGithubToken, permissionMode, dockerMeshAware, dockerAutoRemove, cloudEcrImageOverride, cloudDomain, cloudSslEmail, cloudKeyName, cloudAwsRegion, cloudInstanceType, cloudEcsCpu, cloudEcsMemory, cloudAnthropicKey, cloudGithubToken])
 
   // Animation timer
   const isCloudRuntime = runtime === 'ec2' || runtime === 'ecs'
@@ -608,7 +610,7 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
                         dockerMounts, setDockerMounts, dockerEnvVars, setDockerEnvVars,
                         dockerOnWake, setDockerOnWake, dockerOnHibernate, setDockerOnHibernate,
                         dockerGithubToken, setDockerGithubToken,
-                        dockerYolo, setDockerYolo, dockerMeshAware, setDockerMeshAware,
+                        permissionMode, setPermissionMode, dockerMeshAware, setDockerMeshAware,
                         dockerAutoRemove, setDockerAutoRemove,
                         cloudEcrImageOverride, setCloudEcrImageOverride,
                         cloudDomain, setCloudDomain, cloudSslEmail, setCloudSslEmail,
@@ -688,7 +690,7 @@ interface BubbleState {
   dockerOnWake: string; setDockerOnWake: (v: string) => void
   dockerOnHibernate: string; setDockerOnHibernate: (v: string) => void
   dockerGithubToken: string; setDockerGithubToken: (v: string) => void
-  dockerYolo: boolean; setDockerYolo: (v: boolean) => void
+  permissionMode: AgentPermissionMode; setPermissionMode: (v: AgentPermissionMode) => void
   dockerMeshAware: boolean; setDockerMeshAware: (v: boolean) => void
   dockerAutoRemove: boolean; setDockerAutoRemove: (v: boolean) => void
   cloudEcrImageOverride: string; setCloudEcrImageOverride: (v: string) => void
@@ -1073,12 +1075,14 @@ function SummaryCard({
                     <button onClick={() => state.setDockerEnvVars([...state.dockerEnvVars, { key: '', value: '' }])} className="text-xs text-blue-400 hover:text-blue-300 transition-colors">+ Add variable</button>
                   </div>
 
+                  {/* Trust Level */}
+                  <div className="space-y-1.5">
+                    <label className="text-xs text-gray-500 font-medium">Trust Level</label>
+                    <TrustLevelSelector value={state.permissionMode} onChange={state.setPermissionMode} compact />
+                  </div>
+
                   {/* Toggles */}
                   <div className="space-y-1">
-                    <label className="flex items-center gap-2 text-xs text-gray-300 cursor-pointer">
-                      <input type="checkbox" checked={state.dockerYolo} onChange={(e) => state.setDockerYolo(e.target.checked)} className="rounded border-gray-600" />
-                      Skip permission prompts (yolo)
-                    </label>
                     <label className="flex items-center gap-2 text-xs text-gray-300 cursor-pointer">
                       <input type="checkbox" checked={state.dockerMeshAware} onChange={(e) => state.setDockerMeshAware(e.target.checked)} className="rounded border-gray-600" />
                       Mesh networking

--- a/components/AgentList.tsx
+++ b/components/AgentList.tsx
@@ -544,7 +544,7 @@ export default function AgentList({
     setWakeDialogAgent(agent)
   }
 
-  const handleWakeConfirm = async (program: string) => {
+  const handleWakeConfirm = async (program: string, options?: { permissionMode?: string }) => {
     if (!wakeDialogAgent) return
 
     const agent = wakeDialogAgent
@@ -552,10 +552,14 @@ export default function AgentList({
 
     try {
       // Always call local server — the route proxies to remote hosts server-side
+      const body: Record<string, unknown> = { program, hostUrl: agent.hostUrl }
+      if (options?.permissionMode && options.permissionMode !== 'supervised') {
+        body.permissionMode = options.permissionMode
+      }
       const response = await fetch(`/api/agents/${agent.id}/wake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ program, hostUrl: agent.hostUrl }),
+        body: JSON.stringify(body),
       })
 
       if (!response.ok) {
@@ -1563,6 +1567,7 @@ export default function AgentList({
         onConfirm={handleWakeConfirm}
         agentName={wakeDialogAgent?.name || wakeDialogAgent?.id || ''}
         agentAlias={wakeDialogAgent?.alias}
+        defaultPermissionMode={(wakeDialogAgent as any)?.permissionMode}
       />
     </div>
   )

--- a/components/TrustLevelSelector.tsx
+++ b/components/TrustLevelSelector.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { Shield, FileEdit, Brain, Zap, Eye } from 'lucide-react'
+import type { AgentPermissionMode } from '@/types/agent'
+
+interface TrustLevelSelectorProps {
+  value: AgentPermissionMode
+  onChange: (mode: AgentPermissionMode) => void
+  compact?: boolean
+}
+
+const TRUST_LEVELS: {
+  id: AgentPermissionMode
+  name: string
+  description: string
+  icon: typeof Shield
+  color: string
+}[] = [
+  {
+    id: 'supervised',
+    name: 'Supervised',
+    description: 'Asks permission for all risky actions',
+    icon: Shield,
+    color: 'emerald',
+  },
+  {
+    id: 'trustEdits',
+    name: 'Trust Edits',
+    description: 'Auto-approves file edits, asks for shell commands',
+    icon: FileEdit,
+    color: 'blue',
+  },
+  {
+    id: 'smartAuto',
+    name: 'Smart Auto',
+    description: 'AI reviews and auto-approves safe actions',
+    icon: Brain,
+    color: 'violet',
+  },
+  {
+    id: 'fullAutonomy',
+    name: 'Full Autonomy',
+    description: 'No permission prompts at all',
+    icon: Zap,
+    color: 'amber',
+  },
+  {
+    id: 'planOnly',
+    name: 'Plan Only',
+    description: 'Read-only, no changes allowed',
+    icon: Eye,
+    color: 'gray',
+  },
+]
+
+export default function TrustLevelSelector({ value, onChange, compact }: TrustLevelSelectorProps) {
+  if (compact) {
+    return (
+      <div className="space-y-1">
+        {TRUST_LEVELS.map((level) => {
+          const Icon = level.icon
+          const isSelected = value === level.id
+          return (
+            <label
+              key={level.id}
+              className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer text-xs transition-colors ${
+                isSelected ? 'bg-zinc-700 text-zinc-100' : 'text-zinc-400 hover:text-zinc-300'
+              }`}
+            >
+              <input
+                type="radio"
+                name="trust-level-compact"
+                value={level.id}
+                checked={isSelected}
+                onChange={() => onChange(level.id)}
+                className="sr-only"
+              />
+              <Icon className={`w-3 h-3 ${isSelected ? 'text-zinc-100' : 'text-zinc-500'}`} />
+              <span>{level.name}</span>
+              {level.id === 'fullAutonomy' && <span className="text-amber-400">!</span>}
+            </label>
+          )
+        })}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {TRUST_LEVELS.map((level) => {
+        const Icon = level.icon
+        const isSelected = value === level.id
+
+        return (
+          <button
+            key={level.id}
+            type="button"
+            onClick={() => onChange(level.id)}
+            className={`w-full flex items-center gap-3 p-3 rounded-lg border transition-all ${
+              isSelected
+                ? 'border-emerald-500 bg-emerald-500/10'
+                : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600 hover:bg-zinc-800'
+            }`}
+          >
+            <div
+              className={`p-1.5 rounded-lg ${
+                isSelected ? 'bg-emerald-500/20' : 'bg-zinc-700'
+              }`}
+            >
+              <Icon
+                className={`w-4 h-4 ${
+                  isSelected ? 'text-emerald-400' : 'text-zinc-400'
+                }`}
+              />
+            </div>
+            <div className="flex-1 text-left">
+              <div
+                className={`text-sm font-medium ${
+                  isSelected ? 'text-emerald-400' : 'text-zinc-200'
+                }`}
+              >
+                {level.name}
+                {level.id === 'fullAutonomy' && (
+                  <span className="ml-1 text-amber-400 text-xs">!</span>
+                )}
+              </div>
+              <div className="text-xs text-zinc-500">{level.description}</div>
+            </div>
+            <div
+              className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${
+                isSelected
+                  ? 'border-emerald-500 bg-emerald-500'
+                  : 'border-zinc-600'
+              }`}
+            >
+              {isSelected && (
+                <div className="w-1.5 h-1.5 rounded-full bg-white" />
+              )}
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/TrustLevelSelector.tsx
+++ b/components/TrustLevelSelector.tsx
@@ -13,47 +13,55 @@ const TRUST_LEVELS: {
   id: AgentPermissionMode
   name: string
   description: string
+  detail: string
   icon: typeof Shield
   color: string
 }[] = [
   {
     id: 'supervised',
     name: 'Supervised',
-    description: 'Asks permission for all risky actions',
+    description: 'Asks before every file edit and shell command',
+    detail: 'Safest mode. The agent pauses and asks you to approve each action before it runs. Good for sensitive repos or when you want full control.',
     icon: Shield,
     color: 'emerald',
   },
   {
+    id: 'planOnly',
+    name: 'Plan Only',
+    description: 'Can read and analyze code, but cannot make changes',
+    detail: 'The agent can explore files and answer questions, but cannot edit files or run commands. Use this for code reviews, architecture analysis, or research.',
+    icon: Eye,
+    color: 'gray',
+  },
+  {
     id: 'trustEdits',
     name: 'Trust Edits',
-    description: 'Auto-approves file edits, asks for shell commands',
+    description: 'Auto-approves file edits, still asks for shell commands',
+    detail: 'The agent can freely create and modify files without asking, but will still prompt you before running any terminal commands. A good balance of speed and safety.',
     icon: FileEdit,
     color: 'blue',
   },
   {
     id: 'smartAuto',
     name: 'Smart Auto',
-    description: 'AI reviews and auto-approves safe actions',
+    description: 'Auto-approves safe actions, asks only for risky ones',
+    detail: 'The agent uses its own judgment to auto-approve routine operations (edits, safe shell commands) and only prompts you for potentially destructive actions like deleting files or force-pushing.',
     icon: Brain,
     color: 'violet',
   },
   {
     id: 'fullAutonomy',
     name: 'Full Autonomy',
-    description: 'No permission prompts at all',
+    description: 'No permission prompts. The agent runs everything freely.',
+    detail: 'YOLO mode. The agent executes all actions without asking. Use only in sandboxed environments or when you fully trust the task. Cannot be undone mid-session.',
     icon: Zap,
     color: 'amber',
-  },
-  {
-    id: 'planOnly',
-    name: 'Plan Only',
-    description: 'Read-only, no changes allowed',
-    icon: Eye,
-    color: 'gray',
   },
 ]
 
 export default function TrustLevelSelector({ value, onChange, compact }: TrustLevelSelectorProps) {
+  const selectedLevel = TRUST_LEVELS.find(l => l.id === value)
+
   if (compact) {
     return (
       <div className="space-y-1">
@@ -63,7 +71,7 @@ export default function TrustLevelSelector({ value, onChange, compact }: TrustLe
           return (
             <label
               key={level.id}
-              className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer text-xs transition-colors ${
+              className={`flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer text-xs transition-colors ${
                 isSelected ? 'bg-zinc-700 text-zinc-100' : 'text-zinc-400 hover:text-zinc-300'
               }`}
             >
@@ -75,12 +83,22 @@ export default function TrustLevelSelector({ value, onChange, compact }: TrustLe
                 onChange={() => onChange(level.id)}
                 className="sr-only"
               />
-              <Icon className={`w-3 h-3 ${isSelected ? 'text-zinc-100' : 'text-zinc-500'}`} />
-              <span>{level.name}</span>
-              {level.id === 'fullAutonomy' && <span className="text-amber-400">!</span>}
+              <Icon className={`w-3 h-3 flex-shrink-0 ${isSelected ? 'text-zinc-100' : 'text-zinc-500'}`} />
+              <div className="flex-1 min-w-0">
+                <span className="flex items-center gap-1">
+                  {level.name}
+                  {level.id === 'fullAutonomy' && <span className="text-amber-400">!</span>}
+                </span>
+                <span className="block text-[10px] text-zinc-500 leading-tight mt-0.5">{level.description}</span>
+              </div>
             </label>
           )
         })}
+        {selectedLevel && (
+          <div className="mt-2 px-2 py-2 bg-zinc-800/80 rounded text-[11px] text-zinc-400 leading-relaxed border border-zinc-700/50">
+            {selectedLevel.detail}
+          </div>
+        )}
       </div>
     )
   }
@@ -125,6 +143,9 @@ export default function TrustLevelSelector({ value, onChange, compact }: TrustLe
                 )}
               </div>
               <div className="text-xs text-zinc-500">{level.description}</div>
+              {isSelected && (
+                <div className="text-[11px] text-zinc-400 mt-1 leading-relaxed">{level.detail}</div>
+              )}
             </div>
             <div
               className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${

--- a/components/WakeAgentDialog.tsx
+++ b/components/WakeAgentDialog.tsx
@@ -85,9 +85,18 @@ export default function WakeAgentDialog({
     }
   }, [isOpen, defaultPermissionMode])
 
+  // Reset permission mode when switching away from Claude Code
+  const handleProgramChange = (program: string) => {
+    setSelectedProgram(program)
+    if (program !== 'claude') {
+      setPermissionMode(defaultPermissionMode || 'supervised')
+      setShowAdvanced(false)
+    }
+  }
+
   const handleConfirm = () => {
     setIsWaking(true)
-    onConfirm(selectedProgram, { permissionMode })
+    onConfirm(selectedProgram, selectedProgram === 'claude' ? { permissionMode } : undefined)
     // Dialog will be closed by parent after wake completes
   }
 
@@ -160,7 +169,7 @@ export default function WakeAgentDialog({
                     return (
                       <button
                         key={option.id}
-                        onClick={() => setSelectedProgram(option.id)}
+                        onClick={() => handleProgramChange(option.id)}
                         disabled={isWaking}
                         className={`w-full flex items-center gap-4 p-3 rounded-lg border transition-all ${
                           isSelected
@@ -206,23 +215,24 @@ export default function WakeAgentDialog({
                 </div>
               </div>
 
-              {/* Advanced Options */}
-              <div className="px-6 pb-2">
-                <button
-                  type="button"
-                  onClick={() => setShowAdvanced(!showAdvanced)}
-                  className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
-                >
-                  <ChevronRight className={`w-3 h-3 transition-transform ${showAdvanced ? 'rotate-90' : ''}`} />
-                  Advanced Options
-                </button>
-                {showAdvanced && (
-                  <div className="mt-3">
-                    <p className="text-xs text-zinc-400 mb-2">Trust Level:</p>
-                    <TrustLevelSelector value={permissionMode} onChange={setPermissionMode} compact />
-                  </div>
-                )}
-              </div>
+              {/* Advanced Options — only for Claude Code */}
+              {selectedProgram === 'claude' && (
+                <div className="px-6 pb-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowAdvanced(!showAdvanced)}
+                    className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+                  >
+                    <ChevronRight className={`w-3 h-3 transition-transform ${showAdvanced ? 'rotate-90' : ''}`} />
+                    Permission Mode
+                  </button>
+                  {showAdvanced && (
+                    <div className="mt-3">
+                      <TrustLevelSelector value={permissionMode} onChange={setPermissionMode} compact />
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Footer */}
               <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-zinc-700 bg-zinc-800/50">

--- a/components/WakeAgentDialog.tsx
+++ b/components/WakeAgentDialog.tsx
@@ -3,14 +3,17 @@
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { X, Terminal, Cpu, Code2, Sparkles, Play } from 'lucide-react'
+import { X, Terminal, Cpu, Code2, Sparkles, Play, ChevronRight } from 'lucide-react'
+import TrustLevelSelector from './TrustLevelSelector'
+import type { AgentPermissionMode } from '@/types/agent'
 
 interface WakeAgentDialogProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (program: string) => void
+  onConfirm: (program: string, options?: { permissionMode?: AgentPermissionMode }) => void
   agentName: string
   agentAlias?: string
+  defaultPermissionMode?: AgentPermissionMode
 }
 
 const CLI_OPTIONS = [
@@ -56,9 +59,12 @@ export default function WakeAgentDialog({
   onClose,
   onConfirm,
   agentName,
-  agentAlias
+  agentAlias,
+  defaultPermissionMode
 }: WakeAgentDialogProps) {
   const [selectedProgram, setSelectedProgram] = useState<string>('claude')
+  const [permissionMode, setPermissionMode] = useState<AgentPermissionMode>(defaultPermissionMode || 'supervised')
+  const [showAdvanced, setShowAdvanced] = useState(false)
   const [isWaking, setIsWaking] = useState(false)
   const [mounted, setMounted] = useState(false)
 
@@ -69,17 +75,19 @@ export default function WakeAgentDialog({
     setMounted(true)
   }, [])
 
-  // Reset isWaking state when dialog closes or opens
+  // Reset state when dialog closes or opens
   useEffect(() => {
     if (!isOpen) {
       setIsWaking(false)
       setSelectedProgram('claude')
+      setPermissionMode(defaultPermissionMode || 'supervised')
+      setShowAdvanced(false)
     }
-  }, [isOpen])
+  }, [isOpen, defaultPermissionMode])
 
   const handleConfirm = () => {
     setIsWaking(true)
-    onConfirm(selectedProgram)
+    onConfirm(selectedProgram, { permissionMode })
     // Dialog will be closed by parent after wake completes
   }
 
@@ -196,6 +204,24 @@ export default function WakeAgentDialog({
                     )
                   })}
                 </div>
+              </div>
+
+              {/* Advanced Options */}
+              <div className="px-6 pb-2">
+                <button
+                  type="button"
+                  onClick={() => setShowAdvanced(!showAdvanced)}
+                  className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+                >
+                  <ChevronRight className={`w-3 h-3 transition-transform ${showAdvanced ? 'rotate-90' : ''}`} />
+                  Advanced Options
+                </button>
+                {showAdvanced && (
+                  <div className="mt-3">
+                    <p className="text-xs text-zinc-400 mb-2">Trust Level:</p>
+                    <TrustLevelSelector value={permissionMode} onChange={setPermissionMode} compact />
+                  </div>
+                )}
               </div>
 
               {/* Footer */}

--- a/components/team-meeting/MeetingSidebar.tsx
+++ b/components/team-meeting/MeetingSidebar.tsx
@@ -76,17 +76,21 @@ export default function MeetingSidebar({
     setWakeDialogAgent(agent)
   }
 
-  const handleWakeConfirm = async (program: string) => {
+  const handleWakeConfirm = async (program: string, options?: { permissionMode?: string }) => {
     if (!wakeDialogAgent) return
 
     const agent = wakeDialogAgent
     setWakingAgents(prev => new Set(prev).add(agent.id))
 
     try {
+      const body: Record<string, unknown> = { program, hostUrl: agent.hostUrl }
+      if (options?.permissionMode && options.permissionMode !== 'supervised') {
+        body.permissionMode = options.permissionMode
+      }
       const response = await fetch(`/api/agents/${agent.id}/wake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ program, hostUrl: agent.hostUrl }),
+        body: JSON.stringify(body),
       })
 
       if (!response.ok) {
@@ -393,6 +397,7 @@ export default function MeetingSidebar({
         onConfirm={handleWakeConfirm}
         agentName={wakeDialogAgent?.name || wakeDialogAgent?.id || ''}
         agentAlias={wakeDialogAgent?.label || wakeDialogAgent?.alias}
+        defaultPermissionMode={(wakeDialogAgent as any)?.permissionMode}
       />
     </div>
   )

--- a/hooks/useCompanionWebSocket.ts
+++ b/hooks/useCompanionWebSocket.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef, useCallback } from 'react'
 interface UseCompanionWebSocketOptions {
   agentId: string | null
   onSpeech: (text: string) => void
+  onInterrupt?: () => void
 }
 
 /**
@@ -12,9 +13,11 @@ interface UseCompanionWebSocketOptions {
  * Connects to /companion-ws?agent={agentId}, receives speech events,
  * and can send user messages back to the voice subsystem.
  */
-export function useCompanionWebSocket({ agentId, onSpeech }: UseCompanionWebSocketOptions) {
+export function useCompanionWebSocket({ agentId, onSpeech, onInterrupt }: UseCompanionWebSocketOptions) {
   const onSpeechRef = useRef(onSpeech)
   onSpeechRef.current = onSpeech
+  const onInterruptRef = useRef(onInterrupt)
+  onInterruptRef.current = onInterrupt
 
   const wsRef = useRef<WebSocket | null>(null)
 
@@ -61,6 +64,8 @@ export function useCompanionWebSocket({ agentId, onSpeech }: UseCompanionWebSock
           const data = JSON.parse(event.data)
           if (data.type === 'speech' && data.text) {
             onSpeechRef.current(data.text)
+          } else if (data.type === 'interrupt') {
+            onInterruptRef.current?.()
           }
         } catch {
           // Ignore non-JSON messages

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -450,6 +450,7 @@ export function createAgent(request: CreateAgentRequest): Agent {
     model: request.model,
     taskDescription: request.taskDescription,
     programArgs: request.programArgs || '',
+    permissionMode: request.permissionMode || 'supervised',
     runtime: request.runtime || 'tmux',
     launchCount: 0,
     tags: normalizeTags(request.tags),

--- a/lib/cerebellum/types.ts
+++ b/lib/cerebellum/types.ts
@@ -27,6 +27,7 @@ export interface Subsystem {
   onCompanionConnectionChange?(connected: boolean): void
   addUserMessage?(text: string): void
   repeatLast?(): void
+  cancelCurrentSpeech?(): void
 }
 
 export interface CerebellumEvent {

--- a/lib/cerebellum/voice-subsystem.ts
+++ b/lib/cerebellum/voice-subsystem.ts
@@ -165,6 +165,31 @@ export class VoiceSubsystem implements Subsystem {
     }
   }
 
+  /**
+   * Cancel in-progress speech generation (barge-in support).
+   * Called when mobile sends voice:interrupt.
+   */
+  cancelCurrentSpeech(): void {
+    if (!this.running || !this.context) return
+
+    // Abort in-progress summarization
+    this.isSummarizing = false
+
+    // Clear buffer so no pending output triggers a new speech event
+    if (this.buffer) {
+      this.buffer.clear()
+    }
+
+    // Notify companion clients to stop any in-progress TTS playback
+    this.context.emit({
+      type: 'voice:interrupt',
+      agentId: this.context.agentId,
+      payload: {},
+    })
+
+    console.log('[Cerebellum:Voice] Speech cancelled (barge-in)')
+  }
+
   onActivityStateChange(state: ActivityState): void {
     if (state === 'idle') {
       this.maybeSummarizeAndSpeak()

--- a/scripts/test-call-session.sh
+++ b/scripts/test-call-session.sh
@@ -1,0 +1,394 @@
+#!/bin/bash
+# =============================================================================
+# Call Session Fork Integration Test
+# =============================================================================
+#
+# Tests the full lifecycle of companion call session forks:
+#   1. Prerequisite: AI Maestro is running, test agent exists in registry
+#   2. Connect companion WebSocket → __call tmux session is spawned
+#   3. __call session does NOT appear in /api/sessions (sidebar)
+#   4. __call session does NOT appear as orphan in /api/agents
+#   5. Send voice:transcript → text arrives in __call session (not primary)
+#   6. Disconnect companion WebSocket → __call session is killed
+#   7. Stale cleanup: orphaned __call sessions are killed on connect
+#
+# Prerequisites:
+#   - AI Maestro running on localhost:23000
+#   - At least one registered agent with a tmux session
+#   - node + ws module available (bundled with the project)
+#   - jq installed
+#   - tmux installed
+#
+# Usage:
+#   ./scripts/test-call-session.sh [agent-id]
+#
+# If agent-id is omitted, the first online agent is used.
+#
+# =============================================================================
+
+CURL_TIMEOUT=10
+API_BASE="http://localhost:23000"
+PORT=23000
+NODE_SCRIPT_DIR="/tmp/call-session-test-$$"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $1"; TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); }
+log_fail()    { echo -e "${RED}[FAIL]${NC} $1"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_section() {
+    echo ""
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  $1${NC}"
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo ""
+}
+
+cleanup() {
+    # Kill any background node processes we started
+    if [ -n "$WS_PID" ] && kill -0 "$WS_PID" 2>/dev/null; then
+        kill "$WS_PID" 2>/dev/null
+        wait "$WS_PID" 2>/dev/null
+    fi
+    # Kill stale __call session if we left one
+    if [ -n "$CALL_SESSION_NAME" ]; then
+        tmux kill-session -t "$CALL_SESSION_NAME" 2>/dev/null || true
+    fi
+    rm -rf "$NODE_SCRIPT_DIR"
+}
+trap cleanup EXIT
+
+# =============================================================================
+# Prerequisites
+# =============================================================================
+
+log_section "Prerequisites"
+
+# Check AI Maestro is running
+SESSIONS_RESP=$(curl -s -m $CURL_TIMEOUT "${API_BASE}/api/sessions" 2>/dev/null)
+if [ -z "$SESSIONS_RESP" ]; then
+    echo -e "${RED}ERROR: AI Maestro not running on ${API_BASE}${NC}"
+    echo "Start it with: yarn dev"
+    exit 1
+fi
+log_info "AI Maestro is running"
+
+# Check jq
+if ! command -v jq &>/dev/null; then
+    echo -e "${RED}ERROR: jq is not installed${NC}"
+    exit 1
+fi
+
+# Check tmux
+if ! command -v tmux &>/dev/null; then
+    echo -e "${RED}ERROR: tmux is not installed${NC}"
+    exit 1
+fi
+
+# Find or use specified agent
+if [ -n "$1" ]; then
+    AGENT_ID="$1"
+    log_info "Using specified agent: $AGENT_ID"
+else
+    # Find the first online agent
+    AGENTS_RESP=$(curl -s -m $CURL_TIMEOUT "${API_BASE}/api/agents" 2>/dev/null)
+    AGENT_ID=$(echo "$AGENTS_RESP" | jq -r '.agents[] | select(.session.status == "online") | .id' 2>/dev/null | head -1)
+    if [ -z "$AGENT_ID" ] || [ "$AGENT_ID" = "null" ]; then
+        echo -e "${RED}ERROR: No online agents found. Create one first:${NC}"
+        echo "  tmux new-session -d -s test-agent"
+        echo "  Then register it in AI Maestro"
+        exit 1
+    fi
+    log_info "Auto-selected agent: $AGENT_ID"
+fi
+
+# Get agent details
+AGENT_RESP=$(curl -s -m $CURL_TIMEOUT "${API_BASE}/api/agents/${AGENT_ID}" 2>/dev/null)
+AGENT_NAME=$(echo "$AGENT_RESP" | jq -r '.agent.name // .agent.alias // empty' 2>/dev/null)
+if [ -z "$AGENT_NAME" ]; then
+    echo -e "${RED}ERROR: Could not find agent ${AGENT_ID}${NC}"
+    exit 1
+fi
+
+CALL_SESSION_NAME="${AGENT_NAME}__call"
+log_info "Agent name: $AGENT_NAME"
+log_info "Expected call session: $CALL_SESSION_NAME"
+
+# Make sure no stale call session exists
+tmux kill-session -t "$CALL_SESSION_NAME" 2>/dev/null || true
+
+# Create temp dir for node scripts
+mkdir -p "$NODE_SCRIPT_DIR"
+
+# =============================================================================
+# Test 1: __call session is NOT present before companion connects
+# =============================================================================
+
+log_section "Test 1: No __call session before companion connects"
+
+if tmux has-session -t "$CALL_SESSION_NAME" 2>/dev/null; then
+    log_fail "Call session ${CALL_SESSION_NAME} already exists before test"
+else
+    log_success "No pre-existing call session"
+fi
+
+# =============================================================================
+# Test 2: Companion WS connect spawns __call session
+# =============================================================================
+
+log_section "Test 2: Companion connect spawns __call session"
+
+# Write a node script that connects the companion WS and stays open
+cat > "$NODE_SCRIPT_DIR/connect.mjs" << 'NODESCRIPT'
+import WebSocket from 'ws';
+const agentId = process.argv[2];
+const port = process.argv[3] || '23000';
+const ws = new WebSocket(`ws://localhost:${port}/companion-ws?agent=${agentId}`);
+ws.on('open', () => {
+    process.stdout.write('CONNECTED\n');
+});
+ws.on('error', (err) => {
+    process.stderr.write(`WS ERROR: ${err.message}\n`);
+    process.exit(1);
+});
+ws.on('close', (code) => {
+    process.stdout.write(`CLOSED:${code}\n`);
+    process.exit(0);
+});
+// Handle SIGTERM for clean shutdown
+process.on('SIGTERM', () => { ws.close(); });
+// Keep alive, listen for commands on stdin
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+    const line = chunk.trim();
+    if (line.startsWith('SEND:')) {
+        const payload = line.substring(5);
+        ws.send(payload);
+        process.stdout.write('SENT\n');
+    } else if (line === 'CLOSE') {
+        ws.close();
+    }
+});
+NODESCRIPT
+
+# Start companion WS connection in background
+node "$NODE_SCRIPT_DIR/connect.mjs" "$AGENT_ID" "$PORT" < <(exec cat) &
+WS_PID=$!
+# Create a named pipe for sending commands to the WS process
+WS_INPUT="/tmp/call-session-test-ws-input-$$"
+mkfifo "$WS_INPUT" 2>/dev/null || true
+
+# Wait for connection
+sleep 2
+
+if ! kill -0 "$WS_PID" 2>/dev/null; then
+    log_fail "Companion WS process died immediately"
+else
+    # Check if __call tmux session was created
+    sleep 2  # Give server time to spawn the session
+    if tmux has-session -t "$CALL_SESSION_NAME" 2>/dev/null; then
+        log_success "Call session ${CALL_SESSION_NAME} was spawned"
+    else
+        log_fail "Call session ${CALL_SESSION_NAME} was NOT spawned"
+        log_warn "tmux sessions: $(tmux list-sessions -F '#{session_name}' 2>/dev/null | tr '\n' ' ')"
+    fi
+fi
+
+# =============================================================================
+# Test 3: __call session does NOT appear in /api/sessions
+# =============================================================================
+
+log_section "Test 3: __call session hidden from /api/sessions"
+
+# Bust the cache by waiting
+sleep 4
+
+SESSIONS_LIST=$(curl -s -m $CURL_TIMEOUT "${API_BASE}/api/sessions" 2>/dev/null)
+CALL_IN_SESSIONS=$(echo "$SESSIONS_LIST" | jq -r ".sessions[] | select(.name == \"${CALL_SESSION_NAME}\") | .name" 2>/dev/null)
+
+if [ -z "$CALL_IN_SESSIONS" ]; then
+    log_success "__call session NOT in /api/sessions (sidebar hidden)"
+else
+    log_fail "__call session VISIBLE in /api/sessions — would show in sidebar!"
+fi
+
+# =============================================================================
+# Test 4: __call session does NOT appear as orphan in /api/agents
+# =============================================================================
+
+log_section "Test 4: __call session not registered as orphan agent"
+
+AGENTS_LIST=$(curl -s -m $CURL_TIMEOUT "${API_BASE}/api/agents" 2>/dev/null)
+CALL_ORPHAN=$(echo "$AGENTS_LIST" | jq -r ".agents[] | select(.name == \"${CALL_SESSION_NAME}\") | .name" 2>/dev/null)
+
+if [ -z "$CALL_ORPHAN" ]; then
+    log_success "__call session NOT registered as orphan agent"
+else
+    log_fail "__call session was registered as orphan agent '${CALL_ORPHAN}'!"
+fi
+
+# Verify the real agent is still there and online
+REAL_AGENT_STATUS=$(echo "$AGENTS_LIST" | jq -r ".agents[] | select(.id == \"${AGENT_ID}\") | .session.status" 2>/dev/null)
+if [ "$REAL_AGENT_STATUS" = "online" ]; then
+    log_success "Real agent ${AGENT_NAME} still shows as online"
+else
+    log_warn "Real agent status: ${REAL_AGENT_STATUS} (may be expected if primary session is offline)"
+fi
+
+# =============================================================================
+# Test 5: voice:transcript routes to __call session
+# =============================================================================
+
+log_section "Test 5: Transcript routing to __call session"
+
+# Capture current __call pane content before sending
+BEFORE_CONTENT=$(tmux capture-pane -t "$CALL_SESSION_NAME" -p 2>/dev/null || echo "")
+
+# Send a unique marker via the companion WS
+MARKER="CALLTEST_$(date +%s)_$$"
+
+# Write a one-shot node script to send the transcript
+cat > "$NODE_SCRIPT_DIR/send-transcript.mjs" << NODESCRIPT
+import WebSocket from 'ws';
+const agentId = '${AGENT_ID}';
+const port = '${PORT}';
+const ws = new WebSocket(\`ws://localhost:\${port}/companion-ws?agent=\${agentId}\`);
+ws.on('open', () => {
+    ws.send(JSON.stringify({ type: 'voice:transcript', text: '${MARKER}' }));
+    setTimeout(() => { ws.close(); process.exit(0); }, 500);
+});
+ws.on('error', (err) => { process.exit(1); });
+NODESCRIPT
+
+node "$NODE_SCRIPT_DIR/send-transcript.mjs" 2>/dev/null
+sleep 3  # Give time for send-keys + Claude to receive
+
+# Check if the marker text appears in the __call pane
+AFTER_CONTENT=$(tmux capture-pane -t "$CALL_SESSION_NAME" -p -S -100 2>/dev/null || echo "")
+
+if echo "$AFTER_CONTENT" | grep -q "$MARKER"; then
+    log_success "Transcript '${MARKER}' routed to __call session"
+else
+    log_fail "Transcript '${MARKER}' NOT found in __call session pane"
+    log_warn "Pane content (last 5 lines):"
+    echo "$AFTER_CONTENT" | tail -5 | sed 's/^/    /'
+fi
+
+# Verify it did NOT go to the primary session
+PRIMARY_CONTENT=$(tmux capture-pane -t "$AGENT_NAME" -p -S -100 2>/dev/null || echo "")
+if echo "$PRIMARY_CONTENT" | grep -q "$MARKER"; then
+    log_fail "Transcript ALSO appeared in primary session (should only be in __call)"
+else
+    log_success "Transcript NOT in primary session (correctly isolated)"
+fi
+
+# =============================================================================
+# Test 6: Companion disconnect kills __call session
+# =============================================================================
+
+log_section "Test 6: Disconnect kills __call session"
+
+# Kill the companion WS process
+if [ -n "$WS_PID" ] && kill -0 "$WS_PID" 2>/dev/null; then
+    kill "$WS_PID" 2>/dev/null
+    wait "$WS_PID" 2>/dev/null
+    WS_PID=""
+fi
+
+# Wait for server to process disconnect + 500ms kill delay
+sleep 3
+
+if tmux has-session -t "$CALL_SESSION_NAME" 2>/dev/null; then
+    log_fail "Call session ${CALL_SESSION_NAME} still alive after disconnect"
+    # Clean up
+    tmux kill-session -t "$CALL_SESSION_NAME" 2>/dev/null || true
+else
+    log_success "Call session ${CALL_SESSION_NAME} killed after disconnect"
+fi
+
+# =============================================================================
+# Test 7: Multiple companion clients share the same call session
+# =============================================================================
+
+log_section "Test 7: Multiple companions share one call session"
+
+# Connect first client
+node "$NODE_SCRIPT_DIR/connect.mjs" "$AGENT_ID" "$PORT" &>/dev/null &
+CLIENT1_PID=$!
+sleep 2
+
+# Verify call session exists
+if ! tmux has-session -t "$CALL_SESSION_NAME" 2>/dev/null; then
+    log_fail "Call session not created for first client"
+    kill "$CLIENT1_PID" 2>/dev/null; wait "$CLIENT1_PID" 2>/dev/null
+else
+    # Connect second client
+    node "$NODE_SCRIPT_DIR/connect.mjs" "$AGENT_ID" "$PORT" &>/dev/null &
+    CLIENT2_PID=$!
+    sleep 1
+
+    # Count __call sessions (should be exactly 1, not 2)
+    CALL_COUNT=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -c "^${AGENT_NAME}__call$" || echo 0)
+    if [ "$CALL_COUNT" -eq 1 ]; then
+        log_success "Only 1 call session exists with 2 companion clients"
+    else
+        log_fail "Expected 1 call session, found ${CALL_COUNT}"
+    fi
+
+    # Kill first client — session should survive
+    kill "$CLIENT1_PID" 2>/dev/null; wait "$CLIENT1_PID" 2>/dev/null
+    sleep 2
+
+    if tmux has-session -t "$CALL_SESSION_NAME" 2>/dev/null; then
+        log_success "Call session survives after first client disconnects"
+    else
+        log_fail "Call session killed prematurely when first client disconnected"
+    fi
+
+    # Kill second client — session should die
+    kill "$CLIENT2_PID" 2>/dev/null; wait "$CLIENT2_PID" 2>/dev/null
+    sleep 3
+
+    if tmux has-session -t "$CALL_SESSION_NAME" 2>/dev/null; then
+        log_fail "Call session still alive after ALL clients disconnected"
+        tmux kill-session -t "$CALL_SESSION_NAME" 2>/dev/null || true
+    else
+        log_success "Call session killed after last client disconnects"
+    fi
+fi
+
+# =============================================================================
+# Results
+# =============================================================================
+
+log_section "Results"
+
+echo -e "  Tests run:    ${TESTS_RUN}"
+echo -e "  ${GREEN}Passed:     ${TESTS_PASSED}${NC}"
+if [ "$TESTS_FAILED" -gt 0 ]; then
+    echo -e "  ${RED}Failed:     ${TESTS_FAILED}${NC}"
+fi
+echo ""
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+    echo -e "${RED}SOME TESTS FAILED${NC}"
+    exit 1
+else
+    echo -e "${GREEN}ALL TESTS PASSED${NC}"
+    exit 0
+fi

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,6 @@
 import { createServer } from 'http'
 import { parse } from 'url'
-import { execSync } from 'child_process'
+import { execSync, execFileSync, execFile } from 'child_process'
 import { WebSocketServer } from 'ws'
 import WebSocket from 'ws'
 import pty from 'node-pty'
@@ -10,12 +10,13 @@ import path from 'path'
 import crypto from 'crypto'
 import { getHostById, isSelf } from './lib/hosts-config-server.mjs'
 import { hostHints } from './lib/host-hints-server.mjs'
-import { getOrCreateBuffer } from './lib/cerebellum/session-bridge.mjs'
+import { getOrCreateBuffer, removeBuffer } from './lib/cerebellum/session-bridge.mjs'
 import {
   sessionActivity,
   terminalSessions,
   statusSubscribers,
   companionClients,
+  callSessions,
   broadcastStatusUpdate,
   broadcastChatEvent
 } from './services/shared-state-bridge.mjs'
@@ -989,6 +990,78 @@ async function startServer(handleRequest) {
     }
     clients.add(ws)
 
+    // --- Call Session Fork: spawn a temporary YOLO tmux session for voice ---
+    try {
+      const existingCall = callSessions.get(agentId)
+      if (existingCall) {
+        // Another companion client already created the call session — no-op
+        console.log(`[CALL-SESSION] Reusing call session ${existingCall.callSessionName} (companions: ${clients.size})`)
+      } else {
+        const { getAgent: getRegistryAgent } = await import('./lib/agent-registry.ts')
+        const registryAgent = getRegistryAgent(agentId)
+        if (registryAgent) {
+          const agentName = registryAgent.name || registryAgent.alias
+          // Validate agent name is safe for shell/tmux (should always pass, but defense-in-depth)
+          if (!agentName || !/^[a-zA-Z0-9_-]+$/.test(agentName)) {
+            console.error(`[CALL-SESSION] Refusing to create call session: invalid agent name "${agentName}"`)
+          } else {
+            const { computeCallSessionName } = await import('./types/agent.ts')
+            const callSessionName = computeCallSessionName(agentName)
+            const workdir = registryAgent.workingDirectory || registryAgent.sessions?.[0]?.workingDirectory || os.homedir()
+
+            // Kill stale call session if it exists (safe: callSessionName is validated)
+            try { execFileSync('tmux', ['has-session', '-t', callSessionName], { stdio: 'ignore', timeout: 5000 }) } catch { /* not found — expected */ }
+            try { execFileSync('tmux', ['kill-session', '-t', callSessionName], { stdio: 'ignore', timeout: 5000 }) } catch { /* not found — expected */ }
+
+            // Create new detached tmux session
+            execFileSync('tmux', ['new-session', '-d', '-s', callSessionName, '-c', workdir], { timeout: 5000 })
+
+            // Build launch command with bypassPermissions
+            // Uses single string sent via send-keys -l (literal) to avoid shell interpretation
+            const envParts = [`export AIM_AGENT_NAME='${agentName}' AIM_AGENT_ID='${agentId}'`, 'unset CLAUDECODE']
+            const cmdParts = ['claude', '--permission-mode', 'bypassPermissions']
+            if (registryAgent.model) {
+              const safeModel = registryAgent.model.replace(/[^a-zA-Z0-9._-]/g, '')
+              if (safeModel) cmdParts.push('--model', safeModel)
+            }
+            if (registryAgent.programArgs) {
+              const sanitized = registryAgent.programArgs.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
+              if (sanitized) cmdParts.push(...sanitized.split(/\s+/))
+            }
+            const fullCmd = `${envParts.join('; ')} && ${cmdParts.join(' ')}`
+            execFileSync('tmux', ['send-keys', '-t', callSessionName, '-l', fullCmd], { timeout: 5000 })
+            execFileSync('tmux', ['send-keys', '-t', callSessionName, 'Enter'], { timeout: 5000 })
+
+            // Spawn read-only PTY observer to feed cerebellum voice buffer
+            let ptyObserver = null
+            try {
+              ptyObserver = pty.spawn('tmux', ['attach-session', '-t', callSessionName, '-r'], {
+                name: 'xterm-256color',
+                cols: 120,
+                rows: 40,
+              })
+              const callBuffer = getOrCreateBuffer(callSessionName)
+              ptyObserver.onData((data) => { callBuffer.write(data) })
+            } catch (ptyErr) {
+              console.warn(`[CALL-SESSION] Could not spawn PTY observer for ${callSessionName}:`, ptyErr.message)
+            }
+
+            callSessions.set(agentId, {
+              agentId,
+              agentName,
+              callSessionName,
+              workingDirectory: workdir,
+              createdAt: Date.now(),
+              ptyObserver,
+            })
+            console.log(`[CALL-SESSION] Created call session ${callSessionName} for agent ${agentName}`)
+          }
+        }
+      }
+    } catch (callErr) {
+      console.error('[CALL-SESSION] Error creating call session:', callErr)
+    }
+
     // Notify cerebellum that companion connected
     try {
       const { agentRegistry } = await import('./lib/agent.ts')
@@ -1015,24 +1088,39 @@ async function startServer(handleRequest) {
                   }
                 }
               }
+            } else if (event.type === 'voice:interrupt' && event.agentId === agentId) {
+              const message = JSON.stringify({
+                type: 'interrupt',
+                timestamp: Date.now(),
+              })
+              const agentClients = companionClients.get(agentId)
+              if (agentClients) {
+                for (const client of agentClients) {
+                  if (client.readyState === 1) {
+                    try { client.send(message) } catch { /* ignore */ }
+                  }
+                }
+              }
             }
           }
           cerebellum.on('voice:speak', listener)
+          cerebellum.on('voice:interrupt', listener)
 
-          // Also attach the voice subsystem to the terminal buffer if available
+          // Attach voice subsystem to terminal buffer.
+          // Prefer call session buffer (YOLO fork) over primary session buffer.
+          // Uses getOrCreateBuffer to eliminate timing race — the call session
+          // PTY observer may not have written yet, but the buffer must exist.
           const voiceSub = cerebellum.getSubsystem('voice')
           if (voiceSub && voiceSub.attachBuffer) {
-            const { getBuffer } = await import('./lib/cerebellum/session-bridge.mjs')
-            // Find the session name for this agent
+            const activeCallState = callSessions.get(agentId)
             const { getAgent: getRegistryAgent } = await import('./lib/agent-registry.ts')
             const registryAgent = getRegistryAgent(agentId)
-            const sessionName = registryAgent?.name || registryAgent?.alias
-            if (sessionName) {
-              const buffer = getBuffer(sessionName)
-              if (buffer) {
-                voiceSub.attachBuffer(buffer)
-                console.log(`[COMPANION-WS] Attached voice buffer for session ${sessionName}`)
-              }
+            const primarySessionName = registryAgent?.name || registryAgent?.alias
+            const voiceSessionName = activeCallState ? activeCallState.callSessionName : primarySessionName
+            if (voiceSessionName) {
+              const buffer = getOrCreateBuffer(voiceSessionName)
+              voiceSub.attachBuffer(buffer)
+              console.log(`[COMPANION-WS] Attached voice buffer for session ${voiceSessionName}${activeCallState ? ' (call fork)' : ''}`)
             }
           }
 
@@ -1044,19 +1132,97 @@ async function startServer(handleRequest) {
       console.error('[COMPANION-WS] Error setting up cerebellum connection:', err)
     }
 
+    // Helper: route text to call session via tmux send-keys (non-blocking)
+    function sendToCallSession(callSessionName, text) {
+      // execFile (async, no shell) — does NOT block the event loop
+      execFile('tmux', ['send-keys', '-t', callSessionName, '-l', text], { timeout: 5000 }, (err) => {
+        if (err) {
+          console.warn(`[CALL-SESSION] send-keys -l failed for ${callSessionName}:`, err.message)
+          // Fall back to primary session
+          import('./services/agents-chat-service.ts').then(({ sendChatMessage }) => {
+            sendChatMessage(agentId, text)
+          }).catch(() => {})
+          return
+        }
+        execFile('tmux', ['send-keys', '-t', callSessionName, 'Enter'], { timeout: 5000 }, (enterErr) => {
+          if (enterErr) {
+            console.warn(`[CALL-SESSION] send-keys Enter failed for ${callSessionName}:`, enterErr.message)
+          } else {
+            console.log(`[CALL-SESSION] Routed text to ${callSessionName}`)
+          }
+        })
+      })
+    }
+
     // Handle user messages forwarded from the companion UI
     ws.on('message', (raw) => {
       try {
         const data = JSON.parse(raw.toString())
         if (data.type === 'user_message' && typeof data.text === 'string') {
-          // Forward to voice subsystem's user message buffer
+          const text = data.text.trim()
+          if (!text) return
+
+          // Route typed text to call session if active, otherwise feed voice subsystem only
+          const activeCall = callSessions.get(agentId)
+          if (activeCall) {
+            sendToCallSession(activeCall.callSessionName, text)
+          }
+
+          // Also feed the voice subsystem's user message buffer for context
           import('./lib/agent.ts').then(({ agentRegistry }) => {
             const agent = agentRegistry.getExistingAgent(agentId)
             const cerebellum = agent?.getCerebellum()
             if (cerebellum) {
               const voiceSub = cerebellum.getSubsystem('voice')
               if (voiceSub?.addUserMessage) {
-                voiceSub.addUserMessage(data.text)
+                voiceSub.addUserMessage(text)
+              }
+            }
+          }).catch(() => { /* ignore */ })
+        } else if (data.type === 'voice:transcript' && typeof data.text === 'string') {
+          const text = data.text.trim()
+          if (!text) return // Drop empty transcripts
+
+          console.log(`[COMPANION-WS] voice:transcript from ${agentId.substring(0, 8)}: "${text.substring(0, 60)}"`)
+
+          // Route to call session (YOLO fork) if active, otherwise fall back to primary
+          const activeCall = callSessions.get(agentId)
+          if (activeCall) {
+            sendToCallSession(activeCall.callSessionName, text)
+          } else {
+            // No call session — route through the same pipeline as /chat typed messages
+            import('./services/agents-chat-service.ts').then(({ sendChatMessage }) => {
+              sendChatMessage(agentId, text).then((result) => {
+                if (result.error) {
+                  console.error(`[COMPANION-WS] voice:transcript delivery failed:`, result.error)
+                }
+              })
+            }).catch((err) => {
+              console.error('[COMPANION-WS] voice:transcript error:', err)
+            })
+          }
+
+          // Also feed the voice subsystem's user message buffer for context
+          import('./lib/agent.ts').then(({ agentRegistry }) => {
+            const agent = agentRegistry.getExistingAgent(agentId)
+            const cerebellum = agent?.getCerebellum()
+            if (cerebellum) {
+              const voiceSub = cerebellum.getSubsystem('voice')
+              if (voiceSub?.addUserMessage) {
+                voiceSub.addUserMessage(text)
+              }
+            }
+          }).catch(() => { /* ignore */ })
+        } else if (data.type === 'voice:interrupt') {
+          console.log(`[COMPANION-WS] voice:interrupt from ${agentId.substring(0, 8)}`)
+
+          import('./lib/agent.ts').then(({ agentRegistry }) => {
+            const agent = agentRegistry.getExistingAgent(agentId)
+            const cerebellum = agent?.getCerebellum()
+            if (cerebellum) {
+              const voiceSub = cerebellum.getSubsystem('voice')
+              if (voiceSub?.cancelCurrentSpeech) {
+                voiceSub.cancelCurrentSpeech()
               }
             }
           }).catch(() => { /* ignore */ })
@@ -1085,15 +1251,33 @@ async function startServer(handleRequest) {
         agentClients.delete(ws)
         if (agentClients.size === 0) {
           companionClients.delete(agentId)
+
+          // --- Kill call session fork when last companion disconnects ---
+          const callState = callSessions.get(agentId)
+          if (callState) {
+            console.log(`[CALL-SESSION] Last companion disconnected, killing ${callState.callSessionName}`)
+            // Kill PTY observer
+            try { callState.ptyObserver?.kill() } catch { /* ignore */ }
+            // Graceful shutdown: Ctrl-C then delayed kill (all non-blocking with execFile)
+            execFile('tmux', ['send-keys', '-t', callState.callSessionName, 'C-c'], { timeout: 5000 }, () => {
+              setTimeout(() => {
+                execFile('tmux', ['kill-session', '-t', callState.callSessionName], { timeout: 5000 }, () => { /* ignore */ })
+              }, 500)
+            })
+            removeBuffer(callState.callSessionName)
+            callSessions.delete(agentId)
+          }
+
           // Notify cerebellum no companion connected
           import('./lib/agent.ts').then(({ agentRegistry }) => {
             const agent = agentRegistry.getExistingAgent(agentId)
             const cerebellum = agent?.getCerebellum()
             if (cerebellum) {
               cerebellum.setCompanionConnected(false)
-              // Clean up listener
+              // Clean up listeners
               if (ws._companionCleanup?.listener) {
                 cerebellum.off('voice:speak', ws._companionCleanup.listener)
+                cerebellum.off('voice:interrupt', ws._companionCleanup.listener)
               }
             }
           }).catch(() => { /* ignore */ })
@@ -1640,6 +1824,17 @@ async function startServer(handleRequest) {
 
   server.listen(port, hostname, async () => {
     console.log(`> Ready on http://${hostname}:${port}`)
+
+    // Kill orphaned __call tmux sessions from previous server crashes
+    try {
+      const tmuxOut = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], { encoding: 'utf8', timeout: 5000, stdio: ['pipe', 'pipe', 'ignore'] })
+      for (const name of tmuxOut.trim().split('\n')) {
+        if (name && name.endsWith('__call')) {
+          try { execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'ignore', timeout: 5000 }) } catch { /* ignore */ }
+          console.log(`[CALL-SESSION] Cleaned up orphaned call session: ${name}`)
+        }
+      }
+    } catch { /* tmux not available or no sessions */ }
 
     // Run startup self-diagnostics (non-blocking)
     setTimeout(async () => {

--- a/services/agents-cloud-service.ts
+++ b/services/agents-cloud-service.ts
@@ -54,6 +54,7 @@ export interface CloudCreateRequest {
   label?: string
   avatar?: string
   tags?: string[]
+  permissionMode?: import('@/types/agent').AgentPermissionMode
 }
 
 interface TerraformOutputs {

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -41,6 +41,8 @@ import {
   parseSessionName,
   parseNameForDisplay,
   computeSessionName,
+  isCallSession,
+  PERMISSION_MODE_TO_CLI,
 } from '@/types/agent'
 import {
   loadAgents,
@@ -163,6 +165,7 @@ export interface WakeAgentParams {
   sessionIndex?: number
   program?: string
   projectDirectory?: string  // Runtime: where the agent works (Lane 2)
+  permissionMode?: import('@/types/agent').AgentPermissionMode  // Override trust level for this session
   /**
    * Opt-in: for cloud (containerized) agents, allow falling back to a host-native
    * tmux wake when the container is unavailable (missing / docker daemon down).
@@ -492,7 +495,9 @@ async function discoverLocalSessions(): Promise<DiscoveredSession[]> {
     const runtime = getRuntime()
     const discovered = await runtime.listSessions()
 
-    return discovered.map(disc => {
+    // Filter out temporary call session forks (e.g. "foo__call") —
+    // these are disposable YOLO sessions for companion voice calls
+    return discovered.filter(d => !isCallSession(d.name)).map(disc => {
       const activityTimestamp = sessionActivity.get(disc.name)
 
       let lastActivity: string
@@ -1782,6 +1787,15 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
         }
         if (agent.model) {
           fullCommand = `${fullCommand} --model ${agent.model}`
+        }
+
+        // Inject --permission-mode for claude-based programs
+        if (startCommand === 'claude') {
+          const effectiveMode = params.permissionMode || agent.permissionMode || 'supervised'
+          if (effectiveMode !== 'supervised') {
+            const cliMode = PERMISSION_MODE_TO_CLI[effectiveMode]
+            fullCommand = `${fullCommand} --permission-mode ${cliMode}`
+          }
         }
 
         // Small delay to let the session initialize

--- a/services/agents-docker-service.ts
+++ b/services/agents-docker-service.ts
@@ -17,6 +17,8 @@ import { generateKeyPair, saveKeyPair } from '@/lib/amp-keys'
 import { registerAgent } from '@/services/amp-service'
 import { type ServiceResult, missingField, operationFailed, invalidRequest, invalidState, notFound, gone, serviceError } from '@/services/service-errors'
 import type { Agent, SandboxMount } from '@/types/agent'
+import { PERMISSION_MODE_TO_CLI } from '@/types/agent'
+import type { AgentPermissionMode } from '@/types/agent'
 import { CONTAINER_CWD_GEMINI_PROJECT } from '@/lib/container-utils'
 
 const execAsync = promisify(exec)
@@ -26,7 +28,9 @@ export interface DockerCreateRequest {
   workingDirectory?: string
   hostId?: string
   program?: string
+  /** @deprecated Use permissionMode: 'fullAutonomy' instead */
   yolo?: boolean
+  permissionMode?: import('@/types/agent').AgentPermissionMode
   model?: string
   programArgs?: string
   prompt?: string
@@ -69,6 +73,37 @@ const CONTAINER_HOME = '/home/claude'
 // creation by the dashboard or a host operator). If this ever becomes user-
 // controlled (an agent mutating its own mounts, unprivileged operators), add
 // realpath + prefix-check against an allow-list of host roots before shelling.
+
+/**
+ * Build the AI_TOOL command string for a Docker agent.
+ * Extracted from createDockerAgent for testability.
+ *
+ * Resolution order for permission mode:
+ *   1. body.permissionMode (explicit new field)
+ *   2. body.yolo (legacy backward compat, maps to fullAutonomy)
+ *   3. 'supervised' (default, no flag injected)
+ */
+export function buildAiToolCommand(body: Pick<DockerCreateRequest, 'program' | 'permissionMode' | 'yolo' | 'programArgs' | 'model' | 'prompt'>): string {
+  const program = body.program || 'claude'
+  let aiTool = program
+  const effectivePermMode: AgentPermissionMode = body.permissionMode || (body.yolo ? 'fullAutonomy' : 'supervised')
+  if (effectivePermMode !== 'supervised' && (program === 'claude' || program === 'claude-code')) {
+    aiTool += ` --permission-mode ${PERMISSION_MODE_TO_CLI[effectivePermMode]}`
+  }
+  if (body.programArgs) {
+    const sanitizedArgs = body.programArgs.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
+    if (sanitizedArgs) aiTool += ` ${sanitizedArgs}`
+  }
+  if (body.model) {
+    aiTool += ` --model ${body.model}`
+  }
+  if (body.prompt) {
+    const escapedPrompt = body.prompt.replace(/'/g, "'\\''")
+    aiTool += ` -p '${escapedPrompt}'`
+  }
+  return aiTool
+}
+
 export function validateMounts(mounts: SandboxMount[] | undefined): string | null {
   if (!mounts) return null
   for (const [i, m] of mounts.entries()) {
@@ -1180,22 +1215,8 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
   }
 
   // Build the AI_TOOL environment variable
+  const aiTool = buildAiToolCommand(body)
   const program = body.program || 'claude'
-  let aiTool = program
-  if (body.yolo) {
-    aiTool += ' --dangerously-skip-permissions'
-  }
-  if (body.programArgs) {
-    const sanitizedArgs = body.programArgs.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
-    if (sanitizedArgs) aiTool += ` ${sanitizedArgs}`
-  }
-  if (body.model) {
-    aiTool += ` --model ${body.model}`
-  }
-  if (body.prompt) {
-    const escapedPrompt = body.prompt.replace(/'/g, "'\\''")
-    aiTool += ` -p '${escapedPrompt}'`
-  }
 
   const containerName = `aim-${name}`
   const workDir = body.workingDirectory || '/tmp'
@@ -1441,6 +1462,7 @@ export const RECREATE_PRESERVED_FIELDS = [
   'preferences',
   'meshAware',
   'owner',
+  'permissionMode',
 ] as const
 
 /**

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -31,7 +31,7 @@ import { getAgent, getAgentBySession, getAgentByName, createAgent, deleteAgentBy
 import { loadAgents } from '@/lib/agent-registry'
 import { getHosts, getSelfHost, isSelf, getHostById } from '@/lib/hosts-config'
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
-import { parseNameForDisplay } from '@/types/agent'
+import { parseNameForDisplay, isCallSession } from '@/types/agent'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { sessionActivity, agentActivity, broadcastStatusUpdate, broadcastChatEvent } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
@@ -198,6 +198,9 @@ async function fetchLocalSessions(hostId: string): Promise<Session[]> {
     const sessions: Session[] = []
 
     for (const disc of discovered) {
+      // Skip companion call forks — they are temporary and should not appear in the dashboard
+      if (isCallSession(disc.name)) continue
+
       const activityTimestamp = sessionActivity.get(disc.name)
       let lastActivity: string
       let status: 'active' | 'idle' | 'disconnected'

--- a/services/shared-state-bridge.mjs
+++ b/services/shared-state-bridge.mjs
@@ -17,7 +17,12 @@ if (!globalThis._sharedState) {
     terminalSessions: new Map(),     // sessionName -> { clients, ptyProcess, logStream, ... }
     statusSubscribers: new Set(),    // Set<WebSocket> for /status subscribers
     companionClients: new Map(),     // agentId -> Set<WebSocket> for /companion-ws
+    callSessions: new Map(),         // agentId -> CallSessionState for companion call forks
   }
+}
+// Ensure callSessions exists for hot-reload / late initialization
+if (!globalThis._sharedState.callSessions) {
+  globalThis._sharedState.callSessions = new Map()
 }
 
 const state = globalThis._sharedState
@@ -27,6 +32,7 @@ export const agentActivity = state.agentActivity
 export const terminalSessions = state.terminalSessions
 export const statusSubscribers = state.statusSubscribers
 export const companionClients = state.companionClients
+export const callSessions = state.callSessions
 
 /**
  * Broadcast a chat event to all chat-subscribed WebSocket clients for a session.

--- a/services/shared-state.ts
+++ b/services/shared-state.ts
@@ -34,6 +34,15 @@ export interface StatusUpdate {
   timestamp: string
 }
 
+export interface CallSessionState {
+  agentId: string
+  agentName: string
+  callSessionName: string
+  workingDirectory: string
+  createdAt: number
+  ptyObserver?: any  // node-pty read-only PTY feeding voice buffer
+}
+
 // ---------------------------------------------------------------------------
 // Shared globalThis initialization
 // ---------------------------------------------------------------------------
@@ -46,6 +55,7 @@ declare global {
     terminalSessions: Map<string, PTYSessionState>
     statusSubscribers: Set<WebSocket>
     companionClients: Map<string, Set<WebSocket>>
+    callSessions: Map<string, CallSessionState>
   } | undefined
 }
 
@@ -56,10 +66,15 @@ if (!globalThis._sharedState) {
     terminalSessions: new Map<string, PTYSessionState>(),
     statusSubscribers: new Set<WebSocket>(),
     companionClients: new Map<string, Set<WebSocket>>(),
+    callSessions: new Map<string, CallSessionState>(),
   }
 }
+// Ensure callSessions exists for hot-reload / late initialization
+if (!globalThis._sharedState.callSessions) {
+  globalThis._sharedState.callSessions = new Map()
+}
 
-const state = globalThis._sharedState
+const state = globalThis._sharedState!
 
 // ---------------------------------------------------------------------------
 // Exports — all backed by globalThis._sharedState
@@ -79,6 +94,9 @@ export const statusSubscribers: Set<WebSocket> = state.statusSubscribers
 
 /** agentId -> connected /companion-ws clients. */
 export const companionClients: Map<string, Set<WebSocket>> = state.companionClients
+
+/** agentId -> active call session state. Populated by companion-ws handler in server.mjs. */
+export const callSessions: Map<string, CallSessionState> = state.callSessions
 
 // ---------------------------------------------------------------------------
 // Broadcast a chat event to chat-subscribed WebSocket clients for a session

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -388,6 +388,19 @@ describe('createAgent', () => {
     } as CreateAgentRequest)
     expect(agent.name).toBe('legacy-alias')
   })
+
+  it('stores permissionMode when provided', () => {
+    const agent = createAgent(makeCreateRequest({
+      name: 'perm-mode-agent',
+      permissionMode: 'smartAuto',
+    }))
+    expect(agent.permissionMode).toBe('smartAuto')
+  })
+
+  it('defaults permissionMode to supervised when not provided', () => {
+    const agent = createAgent(makeCreateRequest({ name: 'default-perm-agent' }))
+    expect(agent.permissionMode).toBe('supervised')
+  })
 })
 
 // ============================================================================
@@ -452,6 +465,15 @@ describe('updateAgent', () => {
     const updated = updateAgent(agent.id, { preferences: { notificationLevel: 'urgent' } })
     expect(updated!.preferences?.autoStart).toBe(true)
     expect(updated!.preferences?.notificationLevel).toBe('urgent')
+  })
+
+  it('updates permissionMode', () => {
+    const agent = createAgent(makeCreateRequest({ name: 'perm-update-agent' }))
+    expect(agent.permissionMode).toBe('supervised')
+
+    const updated = updateAgent(agent.id, { permissionMode: 'fullAutonomy' })
+    expect(updated).not.toBeNull()
+    expect(updated!.permissionMode).toBe('fullAutonomy')
   })
 })
 

--- a/tests/agent-utils.test.ts
+++ b/tests/agent-utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { agentToSession } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
-import { parseSessionName, computeSessionName, parseNameForDisplay } from '@/types/agent'
+import { parseSessionName, computeSessionName, computeCallSessionName, isCallSession, parseNameForDisplay, PERMISSION_MODE_TO_CLI } from '@/types/agent'
+import type { AgentPermissionMode } from '@/types/agent'
 
 // ============================================================================
 // agentToSession
@@ -136,6 +137,67 @@ describe('computeSessionName', () => {
 })
 
 // ============================================================================
+// computeCallSessionName
+// ============================================================================
+
+describe('computeCallSessionName', () => {
+  it('appends __call suffix', () => {
+    expect(computeCallSessionName('website')).toBe('website__call')
+  })
+
+  it('handles hyphenated agent names', () => {
+    expect(computeCallSessionName('23blocks-apps-backend')).toBe('23blocks-apps-backend__call')
+  })
+})
+
+// ============================================================================
+// isCallSession
+// ============================================================================
+
+describe('isCallSession', () => {
+  it('returns true for call session names', () => {
+    expect(isCallSession('website__call')).toBe(true)
+    expect(isCallSession('23blocks-apps-backend__call')).toBe(true)
+  })
+
+  it('returns false for regular session names', () => {
+    expect(isCallSession('website')).toBe(false)
+    expect(isCallSession('website_0')).toBe(false)
+    expect(isCallSession('website_1')).toBe(false)
+  })
+
+  it('returns false for names that contain but do not end with __call', () => {
+    expect(isCallSession('__call_agent')).toBe(false)
+  })
+
+  it('is consistent with computeCallSessionName', () => {
+    const names = ['website', 'my-agent', '23blocks-apps-backend']
+    for (const name of names) {
+      expect(isCallSession(computeCallSessionName(name))).toBe(true)
+    }
+  })
+})
+
+// ============================================================================
+// parseSessionName does NOT collide with __call suffix
+// ============================================================================
+
+describe('parseSessionName with __call sessions', () => {
+  it('does not extract agent name "foo" from "foo__call"', () => {
+    const result = parseSessionName('foo__call')
+    // __call is NOT the _N multi-brain pattern, so it should NOT match
+    expect(result.agentName).toBe('foo__call')
+    expect(result.index).toBe(0)
+  })
+
+  it('does not match multi-brain pattern for hyphenated call sessions', () => {
+    const result = parseSessionName('my-agent__call')
+    expect(result.agentName).toBe('my-agent__call')
+    expect(result.index).toBe(0)
+  })
+})
+
+// ============================================================================
 // parseNameForDisplay
 // ============================================================================
 
@@ -158,5 +220,41 @@ describe('parseNameForDisplay', () => {
   it('handles many segments', () => {
     const result = parseNameForDisplay('org-team-service-worker')
     expect(result).toEqual({ tags: ['org', 'team', 'service'], shortName: 'worker' })
+  })
+})
+
+// ============================================================================
+// PERMISSION_MODE_TO_CLI
+// ============================================================================
+
+describe('PERMISSION_MODE_TO_CLI', () => {
+  it('maps supervised to default', () => {
+    expect(PERMISSION_MODE_TO_CLI.supervised).toBe('default')
+  })
+
+  it('maps planOnly to plan', () => {
+    expect(PERMISSION_MODE_TO_CLI.planOnly).toBe('plan')
+  })
+
+  it('maps trustEdits to acceptEdits', () => {
+    expect(PERMISSION_MODE_TO_CLI.trustEdits).toBe('acceptEdits')
+  })
+
+  it('maps smartAuto to auto', () => {
+    expect(PERMISSION_MODE_TO_CLI.smartAuto).toBe('auto')
+  })
+
+  it('maps fullAutonomy to bypassPermissions', () => {
+    expect(PERMISSION_MODE_TO_CLI.fullAutonomy).toBe('bypassPermissions')
+  })
+
+  it('covers all 5 permission modes', () => {
+    const modes: AgentPermissionMode[] = ['supervised', 'planOnly', 'trustEdits', 'smartAuto', 'fullAutonomy']
+    expect(Object.keys(PERMISSION_MODE_TO_CLI).sort()).toEqual(modes.sort())
+  })
+
+  it('has no duplicate CLI values', () => {
+    const cliValues = Object.values(PERMISSION_MODE_TO_CLI)
+    expect(new Set(cliValues).size).toBe(cliValues.length)
   })
 })

--- a/tests/services/agents-core-service.test.ts
+++ b/tests/services/agents-core-service.test.ts
@@ -206,6 +206,36 @@ describe('listAgents', () => {
     expect(mockAgentRegistry.saveAgents).toHaveBeenCalled()
   })
 
+  it('does NOT create orphan agents for __call sessions', async () => {
+    mockAgentRegistry.loadAgents.mockReturnValue([])
+    mockRuntime.listSessions.mockResolvedValue([
+      { name: 'my-agent__call', workingDirectory: '/home', createdAt: '2025-01-01T00:00:00Z', windows: 1 },
+    ])
+
+    const result = await listAgents()
+
+    expect((result.data as any)?.agents).toHaveLength(0)
+    expect((result.data as any)?.stats.orphans).toBe(0)
+    expect(mockAgentRegistry.saveAgents).not.toHaveBeenCalled()
+  })
+
+  it('filters __call sessions while keeping real sessions', async () => {
+    const agent = makeAgent({ name: 'my-agent' })
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+    mockRuntime.listSessions.mockResolvedValue([
+      { name: 'my-agent', workingDirectory: '/home', createdAt: '2025-01-01T00:00:00Z', windows: 1 },
+      { name: 'my-agent__call', workingDirectory: '/home', createdAt: '2025-01-01T00:00:00Z', windows: 1 },
+    ])
+
+    const result = await listAgents()
+
+    // Should only see the real agent, not the call fork
+    expect((result.data as any)?.agents).toHaveLength(1)
+    expect((result.data as any)?.agents[0].name).toBe('my-agent')
+    expect((result.data as any)?.agents[0].status).toBe('active')
+    expect((result.data as any)?.stats.orphans).toBe(0)
+  })
+
   it('marks agents offline when no matching tmux session', async () => {
     const agent = makeAgent({ name: 'offline-agent', sessions: [makeAgentSession()] })
     mockAgentRegistry.loadAgents.mockReturnValue([agent])
@@ -657,6 +687,87 @@ describe('wakeAgent', () => {
     const result = await wakeAgent('agent-1', { startProgram: false })
 
     expect(result.status).toBe(500)
+  })
+
+  it('sends --permission-mode auto when agent.permissionMode is smartAuto', async () => {
+    const agent = makeAgent({ id: 'agent-1', name: 'my-agent', program: 'claude code', permissionMode: 'smartAuto' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockRuntime.sessionExists.mockResolvedValue(false)
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+
+    const result = await wakeAgent('agent-1', {})
+
+    expect(result.status).toBe(200)
+    // Find the sendKeys call that launches the program (the one with { enter: true })
+    const programCall = mockRuntime.sendKeys.mock.calls.find(
+      (call: any[]) => call[2]?.enter === true
+    )
+    expect(programCall).toBeDefined()
+    expect(programCall![1]).toContain('--permission-mode auto')
+  })
+
+  it('does NOT send --permission-mode flag when permissionMode is supervised', async () => {
+    const agent = makeAgent({ id: 'agent-1', name: 'my-agent', program: 'claude code', permissionMode: 'supervised' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockRuntime.sessionExists.mockResolvedValue(false)
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+
+    const result = await wakeAgent('agent-1', {})
+
+    expect(result.status).toBe(200)
+    const programCall = mockRuntime.sendKeys.mock.calls.find(
+      (call: any[]) => call[2]?.enter === true
+    )
+    expect(programCall).toBeDefined()
+    expect(programCall![1]).not.toContain('--permission-mode')
+  })
+
+  it('params.permissionMode overrides agent.permissionMode', async () => {
+    const agent = makeAgent({ id: 'agent-1', name: 'my-agent', program: 'claude code', permissionMode: 'supervised' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockRuntime.sessionExists.mockResolvedValue(false)
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+
+    const result = await wakeAgent('agent-1', { permissionMode: 'trustEdits' })
+
+    expect(result.status).toBe(200)
+    const programCall = mockRuntime.sendKeys.mock.calls.find(
+      (call: any[]) => call[2]?.enter === true
+    )
+    expect(programCall).toBeDefined()
+    expect(programCall![1]).toContain('--permission-mode acceptEdits')
+  })
+
+  it('does NOT inject --permission-mode for non-claude programs', async () => {
+    const agent = makeAgent({ id: 'agent-1', name: 'my-agent', program: 'codex', permissionMode: 'fullAutonomy' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockRuntime.sessionExists.mockResolvedValue(false)
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+
+    const result = await wakeAgent('agent-1', {})
+
+    expect(result.status).toBe(200)
+    const programCall = mockRuntime.sendKeys.mock.calls.find(
+      (call: any[]) => call[2]?.enter === true
+    )
+    expect(programCall).toBeDefined()
+    expect(programCall![1]).not.toContain('--permission-mode')
+  })
+
+  it('sends --permission-mode bypassPermissions for fullAutonomy', async () => {
+    const agent = makeAgent({ id: 'agent-1', name: 'my-agent', program: 'claude code', permissionMode: 'fullAutonomy' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockRuntime.sessionExists.mockResolvedValue(false)
+    mockAgentRegistry.loadAgents.mockReturnValue([agent])
+
+    const result = await wakeAgent('agent-1', {})
+
+    expect(result.status).toBe(200)
+    const programCall = mockRuntime.sendKeys.mock.calls.find(
+      (call: any[]) => call[2]?.enter === true
+    )
+    expect(programCall).toBeDefined()
+    expect(programCall![1]).toContain('--permission-mode bypassPermissions')
   })
 })
 

--- a/tests/services/agents-docker-service.test.ts
+++ b/tests/services/agents-docker-service.test.ts
@@ -34,6 +34,7 @@ import {
   mergeMounts,
   mergeEnv,
   buildRecreateBody,
+  buildAiToolCommand,
   RECREATE_PRESERVED_FIELDS,
 } from '@/services/agents-docker-service'
 import type { Agent, SandboxMount } from '@/types/agent'
@@ -1570,6 +1571,7 @@ describe('RECREATE_PRESERVED_FIELDS', () => {
       'preferences',
       'meshAware',
       'owner',
+      'permissionMode',
     ])
   })
 
@@ -1585,5 +1587,63 @@ describe('RECREATE_PRESERVED_FIELDS', () => {
     for (const field of mustNotInclude) {
       expect(RECREATE_PRESERVED_FIELDS).not.toContain(field)
     }
+  })
+})
+
+// --- buildAiToolCommand --- permission mode → AI_TOOL env var ---
+
+describe('buildAiToolCommand', () => {
+  it('uses --permission-mode auto for permissionMode smartAuto (not --dangerously-skip-permissions)', () => {
+    const result = buildAiToolCommand({ program: 'claude', permissionMode: 'smartAuto' })
+    expect(result).toBe('claude --permission-mode auto')
+    expect(result).not.toContain('--dangerously-skip-permissions')
+  })
+
+  it('maps yolo: true to --permission-mode bypassPermissions (backward compat)', () => {
+    const result = buildAiToolCommand({ program: 'claude', yolo: true })
+    expect(result).toBe('claude --permission-mode bypassPermissions')
+  })
+
+  it('does NOT add --permission-mode for supervised (default behavior)', () => {
+    const result = buildAiToolCommand({ program: 'claude', permissionMode: 'supervised' })
+    expect(result).toBe('claude')
+    expect(result).not.toContain('--permission-mode')
+  })
+
+  it('permissionMode wins over yolo when both are provided', () => {
+    const result = buildAiToolCommand({ program: 'claude', yolo: true, permissionMode: 'trustEdits' })
+    expect(result).toBe('claude --permission-mode acceptEdits')
+    expect(result).not.toContain('bypassPermissions')
+  })
+
+  it('does NOT add --permission-mode for non-claude programs even with permissionMode set', () => {
+    const result = buildAiToolCommand({ program: 'codex', permissionMode: 'fullAutonomy' })
+    expect(result).toBe('codex')
+    expect(result).not.toContain('--permission-mode')
+  })
+
+  it('defaults to claude when no program specified', () => {
+    const result = buildAiToolCommand({ permissionMode: 'planOnly' })
+    expect(result).toBe('claude --permission-mode plan')
+  })
+
+  it('defaults to supervised when neither permissionMode nor yolo are set', () => {
+    const result = buildAiToolCommand({ program: 'claude' })
+    expect(result).toBe('claude')
+  })
+
+  it('appends programArgs after permission-mode flag', () => {
+    const result = buildAiToolCommand({ program: 'claude', permissionMode: 'smartAuto', programArgs: '--continue' })
+    expect(result).toBe('claude --permission-mode auto --continue')
+  })
+
+  it('appends model after programArgs', () => {
+    const result = buildAiToolCommand({ program: 'claude', permissionMode: 'fullAutonomy', model: 'claude-sonnet-4-6' })
+    expect(result).toBe('claude --permission-mode bypassPermissions --model claude-sonnet-4-6')
+  })
+
+  it('treats claude-code program name as claude-compatible (receives permission flags)', () => {
+    const result = buildAiToolCommand({ program: 'claude-code', permissionMode: 'trustEdits' })
+    expect(result).toBe('claude-code --permission-mode acceptEdits')
   })
 })

--- a/tests/services/sessions-service.test.ts
+++ b/tests/services/sessions-service.test.ts
@@ -231,6 +231,28 @@ describe('listLocalSessions', () => {
 
     expect(result.sessions[0].agentId).toBe('uuid-123')
   })
+
+  it('filters out __call sessions from discovery', async () => {
+    mockRuntime.listSessions.mockResolvedValue([
+      { name: 'my-agent', workingDirectory: '/home', createdAt: '2025-01-01T00:00:00Z', windows: 1 },
+      { name: 'my-agent__call', workingDirectory: '/home', createdAt: '2025-01-01T00:00:00Z', windows: 1 },
+    ])
+
+    const result = await listLocalSessions()
+
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0].name).toBe('my-agent')
+  })
+
+  it('returns empty when only __call sessions exist', async () => {
+    mockRuntime.listSessions.mockResolvedValue([
+      { name: 'orphan__call', workingDirectory: '/home', createdAt: '2025-01-01T00:00:00Z', windows: 1 },
+    ])
+
+    const result = await listLocalSessions()
+
+    expect(result.sessions).toHaveLength(0)
+  })
 })
 
 // ============================================================================

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -17,6 +17,28 @@ export type { AgentSkillsConfig, AgentMarketplaceSkill, AgentCustomSkill } from 
 import type { AgentSkillsConfig } from './marketplace'
 
 // ============================================================================
+// Permission Mode (Trust Levels)
+// ============================================================================
+
+/**
+ * Agent permission mode — controls how much autonomy the agent has.
+ * Maps to Claude Code's --permission-mode CLI flag.
+ */
+export type AgentPermissionMode = 'supervised' | 'planOnly' | 'trustEdits' | 'smartAuto' | 'fullAutonomy'
+
+/**
+ * Maps internal permission mode IDs to Claude Code CLI --permission-mode values.
+ * Only applied when the program is 'claude'.
+ */
+export const PERMISSION_MODE_TO_CLI: Record<AgentPermissionMode, string> = {
+  supervised:   'default',
+  planOnly:     'plan',
+  trustEdits:   'acceptEdits',
+  smartAuto:    'auto',
+  fullAutonomy: 'bypassPermissions',
+}
+
+// ============================================================================
 // AMP Identity Types (Cryptographic Identity for Messaging)
 // ============================================================================
 
@@ -134,6 +156,21 @@ export function computeSessionName(agentName: string, index: number): string {
 }
 
 /**
+ * Compute tmux session name for a companion call fork.
+ * Uses double underscore to avoid collision with multi-brain `_N` suffix.
+ */
+export function computeCallSessionName(agentName: string): string {
+  return `${agentName}__call`
+}
+
+/**
+ * Check if a tmux session name is a companion call fork.
+ */
+export function isCallSession(tmuxName: string): boolean {
+  return tmuxName.endsWith('__call')
+}
+
+/**
  * Derive display info from agent name for UI hierarchy
  * Splits on hyphens to create tags + shortName
  * Examples:
@@ -202,6 +239,7 @@ export interface Agent {
   model?: string                // Model version (e.g., "Opus 4.1", "GPT-4")
   taskDescription: string       // What this agent is working on
   programArgs?: string          // CLI arguments passed to the program on launch (e.g., "--continue --chrome")
+  permissionMode?: AgentPermissionMode  // Trust level for agent autonomy (default: 'supervised')
   launchCount?: number          // Number of times agent has been woken/launched (0 = never launched)
   tags?: string[]               // Optional tags (e.g., ["backend", "api", "typescript"])
   capabilities?: string[]       // Technical capabilities (e.g., ["typescript", "postgres"])
@@ -488,6 +526,7 @@ export interface CreateAgentRequest {
   model?: string
   taskDescription: string
   programArgs?: string          // CLI arguments passed to the program on launch
+  permissionMode?: AgentPermissionMode  // Trust level (default: 'supervised')
   tags?: string[]
   workingDirectory?: string
   runtime?: 'tmux' | 'docker' | 'api' | 'direct'
@@ -516,6 +555,7 @@ export interface UpdateAgentRequest {
   model?: string
   taskDescription?: string
   programArgs?: string          // CLI arguments passed to the program on launch
+  permissionMode?: AgentPermissionMode  // Update trust level
   tags?: string[]
   owner?: string
   role?: AgentRole              // Update messaging role

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.9",
-  "releaseDate": "2026-05-16",
+  "version": "0.35.12",
+  "releaseDate": "2026-05-18",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.12",
+  "version": "0.35.13",
   "releaseDate": "2026-05-18",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Add clear descriptions to each trust level explaining what it does and when to use it
- Hide permission mode selector when waking non-Claude programs (Aider, Codex, Cursor, Terminal)
- Reorder modes: Supervised > Plan Only > Trust Edits > Smart Auto > Full Autonomy (most to least restrictive)
- Reset permission state when switching away from Claude Code

## Test plan
- [x] `yarn test` passes (792/792)
- [x] `yarn build` passes
- [ ] Wake dialog: select Claude Code — permission mode section visible
- [ ] Wake dialog: select Aider/Codex/Terminal — permission mode section hidden
- [ ] Click each trust level — detail text appears below the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)