### PR TITLE
fix: remote terminal blank screen - forward proxy query params (v0.35.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **Call session integration test** — `scripts/test-call-session.sh` validates the full lifecycle: spawn, sidebar hiding, orphan prevention, transcript routing, disconnect cleanup, multi-client.
 - **12 unit tests for call session** — Covers helpers, `parseSessionName` non-collision, `__call` filtering in both `/api/sessions` and `/api/agents` discovery paths.
 
+### Fixed (v0.35.14)
+- **Remote terminal blank screen** — Fixed WebSocket proxy not forwarding `cols`, `rows`, and `socket` query parameters to remote hosts. The remote PTY was spawning at default 80x24 instead of the client's actual terminal dimensions, causing blank or broken terminal rendering. Same fix applied to cloud agent container connections.
+
 ### Improved
 - **Trust level descriptions** — Each permission mode now shows a clear explanation of what it does (e.g., "Asks before every file edit and shell command") plus a detail blurb when selected explaining when to use it.
 - **Permission mode only for Claude Code** — The trust level selector in the Wake Agent dialog is now hidden when waking non-Claude programs (Aider, Codex, Cursor, Terminal), since `--permission-mode` is a Claude Code-only flag.

--- a/server.mjs
+++ b/server.mjs
@@ -1454,8 +1454,15 @@ async function startServer(handleRequest) {
         // Use isSelf() to determine if this is a local or remote host
         // This is more reliable than checking host.type which may be undefined
         if (!isSelf(host.id)) {
+          // Forward original query params (cols, rows, socket) so remote PTY
+          // spawns with the correct terminal dimensions
+          const forwardParams = []
+          if (query.cols) forwardParams.push(`cols=${query.cols}`)
+          if (query.rows) forwardParams.push(`rows=${query.rows}`)
+          if (query.socket) forwardParams.push(`socket=${encodeURIComponent(query.socket)}`)
+          const extraParams = forwardParams.length > 0 ? `&${forwardParams.join('&')}` : ''
           console.log(`🌐 [REMOTE] Routing ${sessionName} to host ${host.id} (${host.url})`)
-          handleRemoteWorker(ws, sessionName, host.url)
+          handleRemoteWorker(ws, sessionName, host.url, extraParams)
           return
         }
         // If isSelf(host.id) is true, fall through to local tmux handling
@@ -1492,8 +1499,14 @@ async function startServer(handleRequest) {
           .replace(/^ws:/, 'http:')
           .replace(/^wss:/, 'https:')
         const containerSessionName = cloudAgent.name || sessionName
+        // Forward terminal dimensions to cloud container
+        const cloudParams = []
+        if (query.cols) cloudParams.push(`cols=${query.cols}`)
+        if (query.rows) cloudParams.push(`rows=${query.rows}`)
+        if (query.socket) cloudParams.push(`socket=${encodeURIComponent(query.socket)}`)
+        const cloudExtraParams = cloudParams.length > 0 ? `&${cloudParams.join('&')}` : ''
         console.log(`☁️  [CLOUD] Routing ${sessionName} (resolved to ${containerSessionName}) to container at ${containerBaseUrl}`)
-        handleRemoteWorker(ws, containerSessionName, containerBaseUrl)
+        handleRemoteWorker(ws, containerSessionName, containerBaseUrl, cloudExtraParams)
         return
       }
     } catch (error) {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.13",
+  "version": "0.35.14",
   "releaseDate": "2026-05-18",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Forward `cols`, `rows`, and `socket` query parameters when proxying terminal WebSocket connections to remote hosts and cloud agent containers
- Without this, remote PTY spawns at default 80x24 instead of the client's actual terminal dimensions, causing blank or broken terminal rendering

## Test plan
- [x] `yarn test` passes (792/792)
- [x] `yarn build` passes
- [ ] Connect to remote agent terminal — content renders correctly
- [ ] Connect to cloud agent terminal — content renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)