### PR TITLE
feat: Agent Actions Protocol (AAP) — canvas interactions, spec, and docs (v0.35.16)

### DIFF
--- a/app/api/agents/[id]/canvas/interactions/route.ts
+++ b/app/api/agents/[id]/canvas/interactions/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Canvas Interactions API
+ *
+ * POST /api/agents/:id/canvas/interactions — Submit a canvas interaction
+ * GET  /api/agents/:id/canvas/interactions — List canvas interactions
+ *
+ * Thin wrapper — business logic in services/agents-canvas-service.ts
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { submitInteraction, listInteractions } from '@/services/agents-canvas-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const body = await request.json()
+    const result = await submitInteraction(id, body)
+    return toResponse(result)
+  } catch (error) {
+    console.error('[Canvas Interactions API] Error:', error)
+    return NextResponse.json(
+      { error: 'internal_error', message: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const limit = parseInt(request.nextUrl.searchParams.get('limit') || '50', 10)
+    const result = listInteractions(id, limit)
+    return toResponse(result)
+  } catch (error) {
+    console.error('[Canvas Interactions API] Error:', error)
+    return NextResponse.json(
+      { error: 'internal_error', message: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/agents/[id]/canvas/route.ts
+++ b/app/api/agents/[id]/canvas/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Agent Canvas API
+ *
+ * GET /api/agents/:id/canvas         — List canvas HTML files
+ * GET /api/agents/:id/canvas?file=X  — Serve raw HTML file
+ *
+ * Thin wrapper — business logic in services/agents-canvas-service.ts
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { listCanvasFiles, getCanvasFile } from '@/services/agents-canvas-service'
+import { toResponse } from '@/app/api/_helpers'
+import { isServiceError } from '@/services/service-errors'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: agentId } = await params
+    const file = request.nextUrl.searchParams.get('file')
+
+    if (file) {
+      // Serve raw HTML file
+      const result = getCanvasFile(agentId, file)
+      if (result.status !== 200 || !result.data || isServiceError(result.data)) {
+        return toResponse(result)
+      }
+
+      const { content, fileName } = result.data as { content: string; fileName: string; size: number }
+      return new Response(content, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'X-Canvas-File': fileName,
+        },
+      })
+    }
+
+    // List canvas files
+    const result = listCanvasFiles(agentId)
+    return toResponse(result)
+  } catch (error) {
+    console.error('[Canvas API] Error:', error)
+    return NextResponse.json(
+      { error: 'internal_error', message: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import AgentPlayback from '@/components/AgentPlayback'
 import { useAgents } from '@/hooks/useAgents'
 import { TerminalProvider } from '@/contexts/TerminalContext'
 import { useToast } from '@/contexts/ToastContext'
-import { Terminal, Mail, User, GitBranch, MessageSquare, Share2, FileText, Moon, Power, Loader2, Brain, Plus, Search, Download, Play, ExternalLink } from 'lucide-react'
+import { Terminal, Mail, User, GitBranch, MessageSquare, Share2, FileText, Moon, Power, Loader2, Brain, Plus, Search, Download, Play, ExternalLink, PanelTop } from 'lucide-react'
 import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 
@@ -82,6 +82,12 @@ const DocumentationPanel = dynamic(
   { ssr: false }
 )
 
+// Only shown on canvas tab
+const CanvasPanel = dynamic(
+  () => import('@/components/CanvasPanel'),
+  { ssr: false }
+)
+
 export default function DashboardPage() {
   const { addToast } = useToast()
   // Agent-centric: Primary hook is useAgents
@@ -111,7 +117,7 @@ export default function DashboardPage() {
     setLayoutOverride(next)
     localStorage.setItem('aimaestro-layout-mode', next)
   }
-  const [activeTab, setActiveTab] = useState<'terminal' | 'chat' | 'messages' | 'worktree' | 'graph' | 'memory' | 'docs' | 'search' | 'export' | 'playback'>(() => {
+  const [activeTab, setActiveTab] = useState<'terminal' | 'chat' | 'messages' | 'worktree' | 'graph' | 'memory' | 'docs' | 'canvas' | 'search' | 'export' | 'playback'>(() => {
     if (typeof window === 'undefined') return 'chat'
     return (localStorage.getItem('aimaestro-active-tab') as any) || 'chat'
   })
@@ -832,6 +838,17 @@ export default function DashboardPage() {
                       Docs
                     </button>
                     <button
+                      onClick={() => setActiveTab('canvas')}
+                      className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
+                        activeTab === 'canvas'
+                          ? 'text-blue-400 border-b-2 border-blue-400 bg-gray-800/50'
+                          : 'text-gray-400 hover:text-gray-300 hover:bg-gray-800/30'
+                      }`}
+                    >
+                      <PanelTop className="w-4 h-4" />
+                      Canvas
+                    </button>
+                    <button
                       onClick={() => setActiveTab('search')}
                       className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
                         activeTab === 'search'
@@ -1025,6 +1042,12 @@ export default function DashboardPage() {
                         sessionName={session.id}
                         agentId={agent.id}
                         workingDirectory={session.workingDirectory}
+                        hostUrl={getAgentBaseUrl(agent)}
+                        isActive={true}
+                      />
+                    ) : activeTab === 'canvas' ? (
+                      <CanvasPanel
+                        agentId={agent.id}
                         hostUrl={getAgentBaseUrl(agent)}
                         isActive={true}
                       />

--- a/components/CanvasPanel.tsx
+++ b/components/CanvasPanel.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import React, { useEffect, useState, useCallback, useRef } from 'react'
+import {
+  PanelTop,
+  RefreshCw,
+  FileCode2,
+  AlertCircle,
+  Clock,
+} from 'lucide-react'
+
+interface CanvasFile {
+  name: string
+  path: string
+  size: number
+  modifiedAt: string
+}
+
+interface CanvasPanelProps {
+  agentId: string
+  hostUrl?: string
+  isActive?: boolean
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  const now = new Date()
+  const diff = now.getTime() - d.getTime()
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return d.toLocaleDateString()
+}
+
+export default function CanvasPanel({ agentId, hostUrl, isActive = false }: CanvasPanelProps) {
+  const [files, setFiles] = useState<CanvasFile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedFile, setSelectedFile] = useState<CanvasFile | null>(null)
+  const [iframeUrl, setIframeUrl] = useState<string | null>(null)
+  const [loadingFile, setLoadingFile] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const prevBlobUrl = useRef<string | null>(null)
+  const baseUrl = hostUrl || ''
+
+  const fetchFiles = useCallback(async () => {
+    if (!agentId) return
+
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(`${baseUrl}/api/agents/${agentId}/canvas`)
+      const data = await response.json()
+      if (data.files) {
+        setFiles(data.files)
+      } else if (data.error) {
+        setError(data.message || 'Failed to load canvas files')
+      }
+    } catch (err) {
+      setError('Failed to connect to server')
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId, baseUrl])
+
+  useEffect(() => {
+    if (!agentId || !isActive) return
+    fetchFiles()
+  }, [agentId, isActive, fetchFiles])
+
+  // Cleanup blob URLs
+  useEffect(() => {
+    return () => {
+      if (prevBlobUrl.current) {
+        URL.revokeObjectURL(prevBlobUrl.current)
+      }
+    }
+  }, [])
+
+  // Listen for canvas interaction postMessages from the iframe
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (!event.data || event.data.type !== 'canvas:interaction') return
+      if (!selectedFile || !agentId) return
+
+      const { action, element, data } = event.data
+      fetch(`${baseUrl}/api/agents/${agentId}/canvas/interactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ canvasFile: selectedFile.path, action, element, data }),
+      }).catch(() => {
+        // Fire-and-forget
+      })
+    }
+
+    window.addEventListener('message', handler)
+    return () => window.removeEventListener('message', handler)
+  }, [agentId, selectedFile, baseUrl])
+
+  const openFile = useCallback(async (file: CanvasFile) => {
+    setSelectedFile(file)
+    setLoadingFile(true)
+    setError(null)
+
+    try {
+      const response = await fetch(
+        `${baseUrl}/api/agents/${agentId}/canvas?file=${encodeURIComponent(file.path)}`
+      )
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        setError(data?.message || `Failed to load file (${response.status})`)
+        setLoadingFile(false)
+        return
+      }
+
+      const html = await response.text()
+
+      // Revoke previous blob URL
+      if (prevBlobUrl.current) {
+        URL.revokeObjectURL(prevBlobUrl.current)
+      }
+
+      // Inject maestro bridge script for canvas interactions
+      const bridgeScript = `<script>
+window.maestro = {
+  send: function(action, element, data) {
+    window.parent.postMessage({
+      type: 'canvas:interaction',
+      action: action,
+      element: element || null,
+      data: data || null
+    }, '*');
+  }
+};
+</script>`
+      const injectedHtml = html.includes('<head>')
+        ? html.replace('<head>', '<head>' + bridgeScript)
+        : bridgeScript + html
+
+      const blob = new Blob([injectedHtml], { type: 'text/html' })
+      const url = URL.createObjectURL(blob)
+      prevBlobUrl.current = url
+      setIframeUrl(url)
+    } catch (err) {
+      setError('Failed to load file')
+    } finally {
+      setLoadingFile(false)
+    }
+  }, [agentId, baseUrl])
+
+  if (!agentId) {
+    return (
+      <div className="h-full flex items-center justify-center text-gray-500">
+        <div className="text-center">
+          <AlertCircle className="w-12 h-12 mx-auto mb-4 opacity-50" />
+          <p>No agent selected</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 h-full w-full flex flex-col bg-gray-900 text-gray-100 overflow-hidden">
+      {/* Header */}
+      <div className="flex-shrink-0 border-b border-gray-800 px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <PanelTop className="w-5 h-5 text-cyan-400" />
+          <h2 className="text-lg font-semibold">Canvas</h2>
+          {files.length > 0 && (
+            <span className="text-xs text-gray-500 bg-gray-800 px-2 py-0.5 rounded">
+              {files.length} file{files.length !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={fetchFiles}
+          className="p-1.5 hover:bg-gray-800 rounded transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="flex-shrink-0 mx-4 mt-3 p-3 bg-red-900/30 border border-red-800 rounded-lg flex items-center gap-2 text-red-400 text-sm">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Main Content */}
+      <div className="flex-1 overflow-hidden flex min-h-0">
+        {loading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="flex items-center gap-2 text-gray-400">
+              <RefreshCw className="w-5 h-5 animate-spin" />
+              <span>Loading canvas files...</span>
+            </div>
+          </div>
+        ) : files.length === 0 ? (
+          /* Empty state */
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-center max-w-md">
+              <PanelTop className="w-16 h-16 mx-auto mb-4 text-gray-600" />
+              <h3 className="text-lg font-medium mb-2">No canvas files yet</h3>
+              <p className="text-gray-400 text-sm">
+                Agents can write self-contained HTML files to their canvas directory for viewing here.
+              </p>
+              <code className="block mt-3 text-xs text-gray-500 bg-gray-800 px-3 py-2 rounded">
+                ~/.aimaestro/agents/$AIM_AGENT_ID/canvas/
+              </code>
+              <p className="text-gray-500 text-xs mt-3">
+                HTML must be self-contained (inline styles, base64 images). Relative asset paths are not supported.
+              </p>
+            </div>
+          </div>
+        ) : (
+          /* Split view: file list + iframe */
+          <>
+            {/* File list sidebar */}
+            <div className="w-60 flex-shrink-0 border-r border-gray-800 overflow-y-auto">
+              {files.map((file) => (
+                <button
+                  key={file.path}
+                  onClick={() => openFile(file)}
+                  className={`w-full flex items-start gap-2 px-3 py-2.5 text-left hover:bg-gray-800 transition-colors ${
+                    selectedFile?.path === file.path ? 'bg-gray-800 border-l-2 border-cyan-500' : ''
+                  }`}
+                >
+                  <FileCode2 className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm truncate">{file.name}</div>
+                    {file.path !== file.name && (
+                      <div className="text-xs text-gray-500 truncate">{file.path}</div>
+                    )}
+                    <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                      <span>{formatFileSize(file.size)}</span>
+                      <span className="flex items-center gap-0.5">
+                        <Clock className="w-3 h-3" />
+                        {formatDate(file.modifiedAt)}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            {/* Iframe area */}
+            <div className="flex-1 flex items-center justify-center min-w-0">
+              {loadingFile ? (
+                <div className="flex items-center gap-2 text-gray-400">
+                  <RefreshCw className="w-5 h-5 animate-spin" />
+                  <span>Loading...</span>
+                </div>
+              ) : iframeUrl ? (
+                <iframe
+                  src={iframeUrl}
+                  sandbox="allow-scripts"
+                  className="w-full h-full border-0 bg-white rounded"
+                />
+              ) : (
+                <div className="text-center text-gray-500">
+                  <FileCode2 className="w-12 h-12 mx-auto mb-4 opacity-50" />
+                  <p>Select a file to preview</p>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/docs/AGENT-ACTIONS-PROTOCOL.md
+++ b/docs/AGENT-ACTIONS-PROTOCOL.md
@@ -1,0 +1,316 @@
+# Agent Actions Protocol (AAP) v1.0
+
+**Status**: v1.0 — Ratified
+**Date**: 2026-05-18
+**Authors**: Juan Pelaez
+**Website**: [agentactions.org](https://agentactions.org)
+
+---
+
+## Abstract
+
+The Agent Actions Protocol (AAP) defines a standard for delivering structured user interactions from agent-rendered UIs back to AI agents. When an agent produces an HTML canvas, users interact with it — clicking buttons, submitting forms, selecting options. AAP captures those interactions as structured JSON records, stores them immutably, and notifies the agent.
+
+---
+
+## 1. Introduction
+
+AI agents increasingly render rich HTML interfaces — dashboards, forms, reports, interactive tools. Users interact with these UIs, but the interactions have no standard way to flow back to the agent. AAP solves this with a minimal, open protocol.
+
+**Design principles:**
+- **Minimal** — One bridge script, one message format, one storage pattern
+- **Structured** — Every interaction is a typed JSON record, not raw DOM events
+- **Immutable** — Interactions are append-only files, never modified
+- **Agent-notified** — The agent is told when something happens, in real time
+
+---
+
+## 2. Terminology
+
+| Term | Definition |
+|------|-----------|
+| **Canvas** | Agent-authored HTML rendered in a sandboxed iframe |
+| **Action** | A discrete user interaction (click, submit, change, etc.) |
+| **Element** | Identifier of the UI element acted upon |
+| **Interaction** | The complete record of an action (action + element + data + metadata) |
+| **Bridge** | JavaScript injected into canvas HTML that provides `maestro.send()` |
+| **Provider** | The system that receives, stores, and delivers interactions (e.g., AI Maestro) |
+
+---
+
+## 3. How It Works
+
+```
+Agent writes HTML  -->  Dashboard renders in iframe  -->  User clicks button
+                                                              |
+Agent reads JSON   <--  File written + notification   <--  postMessage to parent
+                                                              |
+                                                         HTTP POST to API
+```
+
+### Step-by-step:
+
+1. **Agent creates HTML** with `maestro.send()` calls on interactive elements
+2. **Dashboard injects the bridge script** and renders HTML in a sandboxed iframe
+3. **User interacts** — click, submit, select, toggle, etc.
+4. **Bridge calls `postMessage`** with structured action data
+5. **Parent window catches it**, POSTs to `/api/agents/:id/canvas/interactions`
+6. **Server stores interaction** as a JSON file and notifies the agent via terminal
+7. **Agent reads the interaction** file and processes it
+
+---
+
+## 4. Bridge Script
+
+The bridge MUST be injected into canvas HTML by the provider. It provides a single global function:
+
+```javascript
+window.maestro = {
+  send: function(action, element, data) {
+    window.parent.postMessage({
+      type: 'canvas:interaction',
+      action: action,
+      element: element || null,
+      data: data || null
+    }, '*');
+  }
+};
+```
+
+Canvas authors use `maestro.send(action, element, data)` — never raw `postMessage`.
+
+### Example usage in canvas HTML:
+
+```html
+<button onclick="maestro.send('click', 'approve-btn', { approved: true })">
+  Approve
+</button>
+
+<form onsubmit="event.preventDefault(); maestro.send('submit', 'feedback-form', {
+  rating: document.getElementById('rating').value,
+  comment: document.getElementById('comment').value
+})">
+  <input id="rating" type="number" min="1" max="5" />
+  <textarea id="comment"></textarea>
+  <button type="submit">Submit</button>
+</form>
+```
+
+---
+
+## 5. Action Message Format
+
+The `postMessage` payload sent from iframe to parent:
+
+```json
+{
+  "type": "canvas:interaction",
+  "action": "submit",
+  "element": "approve-button",
+  "data": { "comments": "Looks good", "rating": 5 }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Always `"canvas:interaction"` |
+| `action` | string | Yes | Action verb (see Standard Actions) |
+| `element` | string | No | Element identifier (id, name, label) |
+| `data` | object | No | Arbitrary key-value payload |
+
+---
+
+## 6. Standard Action Vocabulary
+
+| Action | Use case |
+|--------|----------|
+| `click` | Button press, link activation |
+| `submit` | Form submission |
+| `change` | Input value changed |
+| `select` | Option selected from dropdown/list |
+| `toggle` | Boolean switch toggled |
+| `dismiss` | Modal/notification dismissed |
+| `navigate` | In-canvas navigation (tab switch, page change) |
+| `custom` | Application-specific action (use `data` for details) |
+
+Custom actions beyond this vocabulary are allowed — the `action` field is freeform.
+
+---
+
+## 7. Interaction Record Format
+
+The stored interaction (server-side):
+
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "timestamp": "2026-05-18T15:30:00.000Z",
+  "canvasFile": "reports/dashboard.html",
+  "action": "submit",
+  "element": "approve-button",
+  "data": { "comments": "Looks good" },
+  "summary": "User submit 'approve-button' on reports/dashboard.html with data: {comments: Looks good}"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Unique interaction identifier |
+| `timestamp` | ISO 8601 | Yes | When the interaction occurred |
+| `canvasFile` | string | Yes | Relative path of the canvas HTML file |
+| `action` | string | Yes | The action verb |
+| `element` | string | No | Element identifier |
+| `data` | object | No | Arbitrary payload |
+| `summary` | string | Yes | Human-readable summary for the agent |
+
+---
+
+## 8. Storage
+
+- **Path**: `~/.aimaestro/agents/<agentId>/canvas/interactions/`
+- **Filename**: `<ISO-timestamp>-<UUID>.json` (with `:` and `.` replaced by `-`)
+- **One file per interaction** (append-only, immutable)
+- **Sorted by filename** = sorted by time
+
+Example filename:
+```
+2026-05-18T15-30-00-000Z-a1b2c3d4-e5f6-7890-abcd-ef1234567890.json
+```
+
+---
+
+## 9. Transport
+
+```
+Canvas iframe
+  | window.parent.postMessage()
+  v
+Parent window (Dashboard)
+  | POST /api/agents/:id/canvas/interactions
+  v
+Provider API
+  | Write JSON file + tmux notification
+  v
+Agent
+```
+
+---
+
+## 10. API Endpoints
+
+### Submit Interaction
+
+```
+POST /api/agents/:id/canvas/interactions
+Content-Type: application/json
+
+{
+  "action": "submit",
+  "element": "approve-button",
+  "canvasFile": "reports/dashboard.html",
+  "data": { "comments": "Looks good" }
+}
+```
+
+**Responses:**
+
+```
+201 Created
+{ "id": "a1b2c3d4-...", "summary": "User submit 'approve-button' on reports/dashboard.html" }
+
+400 Bad Request
+{ "error": "missing_field", "message": "action is required" }
+
+404 Not Found
+{ "error": "not_found", "message": "Agent 'xyz' not found" }
+```
+
+### List Interactions
+
+```
+GET /api/agents/:id/canvas/interactions?limit=50
+```
+
+**Response:**
+
+```json
+{
+  "interactions": [
+    {
+      "id": "a1b2c3d4-...",
+      "timestamp": "2026-05-18T15:30:00.000Z",
+      "action": "submit",
+      "element": "approve-button",
+      "canvasFile": "reports/dashboard.html",
+      "data": { "comments": "Looks good" },
+      "summary": "User submit 'approve-button' on reports/dashboard.html with data: {comments: Looks good}"
+    }
+  ]
+}
+```
+
+---
+
+## 11. Agent Notification
+
+When an interaction is stored, the provider SHOULD notify the agent:
+
+```
+[CANVAS] reports/dashboard.html: User submit 'approve-button' on reports/dashboard.html with data: {comments: Looks good}
+```
+
+Notification is fire-and-forget. Failure to notify does not affect interaction storage.
+
+---
+
+## 12. Security Considerations
+
+- Canvas HTML runs in `sandbox="allow-scripts"` iframe (no same-origin, no forms, no popups)
+- Bridge uses `postMessage('*')` — parent validates `event.data.type` before processing
+- No credentials, tokens, or authentication data should be sent via `data` payload
+- `data` is stored as-is — providers SHOULD sanitize before displaying
+- Canvas files are read-only to the user — only the agent can write them
+- Path traversal protection: canvas file paths must not contain `..` or be absolute
+
+---
+
+## 13. Implementer Checklist
+
+For building an AAP-compatible provider:
+
+- [ ] Inject bridge script into canvas HTML before rendering
+- [ ] Listen for `postMessage` with `type: 'canvas:interaction'`
+- [ ] Validate `action` field is present
+- [ ] Generate UUID and ISO timestamp
+- [ ] Build human-readable summary
+- [ ] Store interaction as JSON (recommended: file-per-interaction)
+- [ ] Notify agent (optional, provider-specific mechanism)
+- [ ] Expose API for listing interactions (optional)
+
+---
+
+## 14. Relationship to AMP & AID
+
+- **AAP is independent** — does not require AMP or AID
+- **Complementary**: AAP handles user-to-agent UI actions; AMP handles agent-to-agent messaging; AID handles agent authentication
+- All three use the same agent directory structure (`~/.aimaestro/agents/<id>/`)
+- AAP interactions can trigger AMP messages (e.g., "user approved the report" -> send notification to another agent)
+
+---
+
+## 15. Roadmap
+
+| Version | Scope |
+|---------|-------|
+| **v1.0** (current) | One-way canvas interactions (user -> agent) |
+| **v1.1** | Bidirectional — agents push updates back to canvas (refresh, replace content) |
+| **v1.2** | Interaction acknowledgment — agent confirms receipt |
+| **v2.0** | Agent-defined UI components (widgets, forms, controls beyond raw HTML) |
+
+---
+
+## License
+
+This specification is released under the MIT License.
+
+Copyright 2026 Juan Pelaez / 23blocks.

--- a/docs/agent-actions.html
+++ b/docs/agent-actions.html
@@ -1,0 +1,859 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-W72WHGDW');</script>
+    <!-- End Google Tag Manager -->
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agent Actions Protocol (AAP) &mdash; Structured UI-to-Agent Interactions | agentactions.org</title>
+    <meta name="description" content="Open protocol for delivering structured user interactions from agent-rendered UIs back to AI agents. Canvas clicks, form submissions, and custom actions — captured, stored, and delivered.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://agentactions.org">
+    <meta property="og:title" content="Agent Actions Protocol (AAP) — Structured UI-to-Agent Interactions">
+    <meta property="og:description" content="Open protocol for delivering structured user interactions from agent-rendered UIs back to AI agents. Canvas clicks, forms, and custom actions.">
+    <meta property="og:image" content="https://ai-maestro.23blocks.com/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Agent Actions Protocol (AAP)">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:site_name" content="Agent Actions Protocol">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Agent Actions Protocol (AAP) — UI-to-Agent Interactions">
+    <meta name="twitter:description" content="Open protocol for structured user interactions from agent-rendered UIs back to AI agents.">
+    <meta name="twitter:image" content="https://ai-maestro.23blocks.com/og-image.png">
+    <meta name="twitter:creator" content="@jkpelaez">
+
+    <!-- Additional SEO -->
+    <meta name="author" content="Juan Pel&aacute;ez">
+    <meta name="keywords" content="agent actions protocol, AAP, canvas interactions, agent UI, AI agent actions, user-to-agent communication, agent-rendered UI, structured interactions">
+    <link rel="canonical" href="https://agentactions.org">
+
+    <!-- Favicon & Icons -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="apple-touch-icon-120x120.png">
+    <link rel="manifest" href="site.webmanifest">
+    <link rel="mask-icon" href="safari-pinned-tab.svg" color="#10b981">
+
+    <!-- Theme Colors -->
+    <meta name="theme-color" content="#10b981">
+    <meta name="msapplication-TileColor" content="#10b981">
+    <meta name="msapplication-config" content="browserconfig.xml">
+
+    <!-- Apple Mobile Web App -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="AAP">
+
+    <!-- Application Info -->
+    <meta name="application-name" content="Agent Actions Protocol">
+    <meta name="format-detection" content="telephone=no">
+
+    <!-- Schema.org Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareFeature",
+      "name": "Agent Actions Protocol (AAP)",
+      "description": "Open protocol for delivering structured user interactions from agent-rendered UIs back to AI agents",
+      "featureList": [
+        "Structured canvas interactions via postMessage",
+        "Standard action vocabulary (click, submit, change, select, toggle, dismiss, navigate)",
+        "Immutable JSON interaction records",
+        "File-per-interaction storage",
+        "Real-time agent notification via terminal",
+        "REST API for submitting and listing interactions",
+        "Sandboxed iframe security model",
+        "Bridge script injection pattern"
+      ],
+      "isPartOf": {
+        "@type": "SoftwareApplication",
+        "name": "AI Maestro",
+        "url": "https://ai-maestro.23blocks.com"
+      }
+    }
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": "Agent Actions Protocol (AAP) v1.0 Specification",
+      "description": "Open protocol specification for structured UI-to-agent interactions in AI agent systems",
+      "author": {
+        "@type": "Person",
+        "name": "Juan Pel\u00e1ez",
+        "url": "https://x.com/jkpelaez"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "23blocks"
+      },
+      "datePublished": "2026-05-18",
+      "dateModified": "2026-05-18",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://agentactions.org"
+      }
+    }
+    </script>
+
+    <!-- Typography: Syne (display) + DM Sans (body) + JetBrains Mono (code) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <!-- Tailwind CSS CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        display: ['Syne', 'system-ui', 'sans-serif'],
+                        sans: ['DM Sans', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        slate: {
+                            950: '#020617',
+                            900: '#0f172a',
+                            850: '#131c31',
+                            800: '#1e293b',
+                        },
+                        emerald: {
+                            400: '#34d399',
+                            500: '#10b981',
+                            600: '#059669',
+                        },
+                        cyan: {
+                            400: '#22d3ee',
+                            500: '#00d4ff',
+                        },
+                        amber: {
+                            400: '#fbbf24',
+                            500: '#f59e0b',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+
+    <!-- GSAP CDN -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
+
+    <style>
+        html {
+            scroll-behavior: smooth;
+            scroll-padding-top: 80px;
+        }
+
+        body {
+            background-color: #0f172a;
+            color: #e2e8f0;
+        }
+
+        /* Noise texture overlay */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            opacity: 0.03;
+            pointer-events: none;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+            z-index: 9999;
+        }
+
+        /* Gradient text - emerald theme */
+        .gradient-text {
+            background: linear-gradient(135deg, #10b981 0%, #34d399 50%, #fbbf24 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        /* Hamburger menu */
+        .hamburger span {
+            display: block;
+            width: 24px;
+            height: 2px;
+            background: #e2e8f0;
+            transition: all 0.3s ease;
+        }
+        .hamburger.active span:nth-child(1) {
+            transform: rotate(45deg) translate(5px, 5px);
+        }
+        .hamburger.active span:nth-child(2) {
+            opacity: 0;
+        }
+        .hamburger.active span:nth-child(3) {
+            transform: rotate(-45deg) translate(7px, -6px);
+        }
+        .mobile-menu {
+            opacity: 0;
+            transform: translateY(-10px);
+            transition: all 0.3s ease;
+            pointer-events: none;
+        }
+        .mobile-menu.active {
+            opacity: 1;
+            transform: translateY(0);
+            display: block !important;
+            pointer-events: auto;
+        }
+
+        /* Code blocks */
+        .code-block {
+            background: #0d1117;
+            border: 1px solid #1e293b;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+
+        /* Flow diagram */
+        .flow-step {
+            transition: all 0.3s ease;
+        }
+        .flow-step:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 30px rgba(16, 185, 129, 0.1);
+        }
+
+        /* Spec table */
+        .spec-table th {
+            background: #131c31;
+        }
+        .spec-table td, .spec-table th {
+            border: 1px solid #1e293b;
+            padding: 10px 14px;
+        }
+    </style>
+</head>
+<body class="font-sans antialiased">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W72WHGDW"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    <!-- Copy for AI Button -->
+    <button
+        onclick="copyForAI()"
+        class="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-slate-800 border border-slate-700 text-emerald-400 font-mono text-sm rounded hover:bg-slate-700 hover:border-emerald-500/50 transition-all duration-200"
+        title="Copy this page for AI assistants">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+        COPY FOR AI
+    </button>
+
+    <!-- Navigation -->
+    <nav class="sticky top-0 bg-slate-900/95 backdrop-blur-lg border-b border-slate-800 z-[100]">
+        <div class="max-w-7xl mx-auto px-4 md:px-8">
+            <div class="flex justify-between items-center py-4">
+                <a href="index.html" class="flex items-center gap-3 text-white no-underline hover:opacity-80 transition-opacity duration-200">
+                    <img src="logo-constellation.svg" alt="AI Maestro" class="w-8 h-8 md:w-10 md:h-10">
+                    <span class="font-display font-bold text-lg md:text-xl tracking-tight">AAP</span>
+                </a>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex gap-8 items-center">
+                    <a href="#why" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">WHY</a>
+                    <a href="#how-it-works" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">HOW IT WORKS</a>
+                    <a href="#specification" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">SPECIFICATION</a>
+                    <a href="#implementers" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">FOR IMPLEMENTERS</a>
+                    <a href="https://github.com/agentmessaging/agent-actions" target="_blank" class="text-slate-400 no-underline hover:text-emerald-400 transition-colors duration-200" title="View on GitHub">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    </a>
+                    <a href="https://github.com/agentmessaging/agent-actions#readme" class="inline-flex items-center gap-2 px-5 py-2.5 rounded bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200" target="_blank">
+                        START FREE
+                    </a>
+                </div>
+
+                <!-- Mobile Navigation -->
+                <div class="flex md:hidden items-center gap-3">
+                    <a href="https://github.com/agentmessaging/agent-actions#readme" class="px-3 py-2 rounded bg-emerald-500 text-slate-900 font-bold text-xs tracking-wide" target="_blank">START</a>
+                    <button class="hamburger bg-transparent border-0 cursor-pointer p-2 flex flex-col gap-1.5 z-[1001]" id="hamburger" aria-label="Toggle menu">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </button>
+                </div>
+            </div>
+
+            <!-- Mobile Menu -->
+            <div class="mobile-menu hidden absolute top-full left-0 right-0 bg-slate-900 border-b border-slate-800 py-4" id="mobile-menu">
+                <a href="#why" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">Why AAP</a>
+                <a href="#how-it-works" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">How It Works</a>
+                <a href="#specification" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">Specification</a>
+                <a href="#implementers" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">For Implementers</a>
+                <a href="https://github.com/agentmessaging/agent-actions" target="_blank" class="flex items-center gap-3 px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    GitHub
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <script>
+        const hamburger = document.getElementById('hamburger');
+        const mobileMenu = document.getElementById('mobile-menu');
+
+        hamburger.addEventListener('click', () => {
+            hamburger.classList.toggle('active');
+            mobileMenu.classList.toggle('active');
+        });
+
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                hamburger.classList.remove('active');
+                mobileMenu.classList.remove('active');
+            });
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!hamburger.contains(e.target) && !mobileMenu.contains(e.target)) {
+                hamburger.classList.remove('active');
+                mobileMenu.classList.remove('active');
+            }
+        });
+    </script>
+
+    <!-- Hero Section -->
+    <section class="relative py-20 md:py-32 px-4 md:px-8 overflow-hidden">
+        <div class="max-w-7xl mx-auto text-center">
+            <div class="inline-block px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/30 mb-6">
+                <span class="font-mono text-xs text-emerald-400 tracking-widest">AAP v1.0</span>
+            </div>
+            <h1 class="font-display text-4xl md:text-6xl lg:text-7xl font-bold mb-6 leading-tight">
+                Actions for <span class="gradient-text">AI Agents</span>
+            </h1>
+            <p class="text-slate-400 text-lg md:text-xl max-w-3xl mx-auto mb-10">
+                Your agents render UIs. Your users interact with them. AAP delivers those interactions &mdash; structured, stored, and ready to process.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="#specification" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200 no-underline">
+                    READ THE SPEC
+                </a>
+                <a href="https://github.com/agentmessaging/agent-actions" target="_blank" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-slate-800 text-white font-bold text-sm tracking-wide hover:bg-slate-700 transition-all duration-200 no-underline border border-slate-700">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    GITHUB
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Why AAP Section -->
+    <section id="why" class="py-16 md:py-24 px-4 md:px-8 bg-slate-950/50">
+        <div class="max-w-7xl mx-auto">
+            <p class="font-mono text-xs text-emerald-400 tracking-widest mb-4 text-center">THE PROBLEM</p>
+            <h2 class="font-display text-3xl md:text-5xl font-bold mb-6 text-center">Why AAP?</h2>
+            <p class="text-slate-400 text-lg max-w-2xl mx-auto mb-12 text-center">
+                Agents render rich HTML. Users click things. How do those clicks get back to the agent?
+            </p>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                <!-- console.log scraping -->
+                <div class="bg-slate-900 border border-slate-800 rounded-xl p-6">
+                    <div class="text-3xl mb-4">📋</div>
+                    <h3 class="font-display font-bold text-white text-lg mb-2">console.log scraping</h3>
+                    <p class="text-slate-400 text-sm">Fragile, no structure, lost on refresh. Depends on browser dev tools being open.</p>
+                    <span class="inline-block mt-3 text-xs text-red-400 font-mono">Brittle</span>
+                </div>
+
+                <!-- Polling the DOM -->
+                <div class="bg-slate-900 border border-slate-800 rounded-xl p-6">
+                    <div class="text-3xl mb-4">🔄</div>
+                    <h3 class="font-display font-bold text-white text-lg mb-2">Polling the DOM</h3>
+                    <p class="text-slate-400 text-sm">Complex, race conditions, not sandboxed. Breaks when the HTML changes.</p>
+                    <span class="inline-block mt-3 text-xs text-red-400 font-mono">Fragile</span>
+                </div>
+
+                <!-- Custom WebSocket -->
+                <div class="bg-slate-900 border border-slate-800 rounded-xl p-6">
+                    <div class="text-3xl mb-4">🔌</div>
+                    <h3 class="font-display font-bold text-white text-lg mb-2">Custom WebSocket</h3>
+                    <p class="text-slate-400 text-sm">Over-engineered for button clicks. Security nightmare with open socket per page.</p>
+                    <span class="inline-block mt-3 text-xs text-red-400 font-mono">Overkill</span>
+                </div>
+
+                <!-- AAP -->
+                <div class="bg-emerald-500/5 border border-emerald-500/30 rounded-xl p-6">
+                    <div class="text-3xl mb-4">🎯</div>
+                    <h3 class="font-display font-bold text-emerald-400 text-lg mb-2">AAP</h3>
+                    <p class="text-slate-300 text-sm">Structured actions via postMessage. Stored as JSON. Agent notified instantly.</p>
+                    <span class="inline-block mt-3 text-xs text-emerald-400 font-mono">Just right</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How It Works Section -->
+    <section id="how-it-works" class="py-16 md:py-24 px-4 md:px-8">
+        <div class="max-w-7xl mx-auto">
+            <p class="font-mono text-xs text-emerald-400 tracking-widest mb-4 text-center">THE FLOW</p>
+            <h2 class="font-display text-3xl md:text-5xl font-bold mb-6 text-center">How It Works</h2>
+            <p class="text-slate-400 text-lg max-w-2xl mx-auto mb-12 text-center">
+                Seven steps from agent HTML to structured interaction record.
+            </p>
+
+            <!-- Flow diagram -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <div class="code-block p-6 font-mono text-sm text-slate-300 leading-relaxed">
+<pre class="text-emerald-400">Agent writes HTML  &rarr;  Dashboard renders in iframe  &rarr;  User clicks button
+                                                              &darr;
+Agent reads JSON   &larr;  File written + notification   &larr;  postMessage to parent
+                                                              &darr;
+                                                         HTTP POST to API</pre>
+                </div>
+            </div>
+
+            <!-- Steps -->
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+                <div class="flow-step bg-slate-850 border border-slate-800 rounded-xl p-5">
+                    <div class="flex items-center gap-3 mb-3">
+                        <span class="w-8 h-8 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 font-bold text-sm">1</span>
+                        <h4 class="font-display font-bold text-white text-sm">Agent creates HTML</h4>
+                    </div>
+                    <p class="text-slate-400 text-xs">Writes an HTML page with <code class="text-emerald-400 bg-slate-800 px-1 rounded">maestro.send()</code> calls on interactive elements.</p>
+                </div>
+                <div class="flow-step bg-slate-850 border border-slate-800 rounded-xl p-5">
+                    <div class="flex items-center gap-3 mb-3">
+                        <span class="w-8 h-8 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 font-bold text-sm">2</span>
+                        <h4 class="font-display font-bold text-white text-sm">Bridge injected</h4>
+                    </div>
+                    <p class="text-slate-400 text-xs">Dashboard injects the AAP bridge script and renders in a sandboxed iframe.</p>
+                </div>
+                <div class="flow-step bg-slate-850 border border-slate-800 rounded-xl p-5">
+                    <div class="flex items-center gap-3 mb-3">
+                        <span class="w-8 h-8 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 font-bold text-sm">3</span>
+                        <h4 class="font-display font-bold text-white text-sm">User interacts</h4>
+                    </div>
+                    <p class="text-slate-400 text-xs">Click, submit, select, toggle. Bridge calls <code class="text-emerald-400 bg-slate-800 px-1 rounded">postMessage</code> with structured data.</p>
+                </div>
+                <div class="flow-step bg-slate-850 border border-slate-800 rounded-xl p-5">
+                    <div class="flex items-center gap-3 mb-3">
+                        <span class="w-8 h-8 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 font-bold text-sm">4</span>
+                        <h4 class="font-display font-bold text-white text-sm">Stored &amp; notified</h4>
+                    </div>
+                    <p class="text-slate-400 text-xs">Server stores interaction as JSON file and notifies agent via terminal.</p>
+                </div>
+            </div>
+
+            <!-- Bridge script example -->
+            <div class="max-w-4xl mx-auto">
+                <h3 class="font-display text-xl font-bold text-white mb-4">The Bridge Script</h3>
+                <div class="code-block p-6">
+                    <p class="font-mono text-xs text-slate-500 mb-3">// Injected into every canvas HTML by the provider</p>
+<pre class="font-mono text-sm text-slate-300"><span class="text-emerald-400">window</span>.maestro = {
+  <span class="text-amber-400">send</span>: <span class="text-slate-500">function</span>(action, element, data) {
+    <span class="text-emerald-400">window</span>.parent.<span class="text-amber-400">postMessage</span>({
+      type: <span class="text-emerald-300">'canvas:interaction'</span>,
+      action: action,
+      element: element || <span class="text-slate-500">null</span>,
+      data: data || <span class="text-slate-500">null</span>
+    }, <span class="text-emerald-300">'*'</span>);
+  }
+};</pre>
+                </div>
+
+                <h3 class="font-display text-xl font-bold text-white mb-4 mt-8">Usage in Canvas HTML</h3>
+                <div class="code-block p-6">
+<pre class="font-mono text-sm text-slate-300"><span class="text-slate-500">&lt;</span><span class="text-emerald-400">button</span> <span class="text-amber-400">onclick</span>=<span class="text-emerald-300">"maestro.send('click', 'approve-btn', { approved: true })"</span><span class="text-slate-500">&gt;</span>
+  Approve
+<span class="text-slate-500">&lt;/</span><span class="text-emerald-400">button</span><span class="text-slate-500">&gt;</span></pre>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Specification Section -->
+    <section id="specification" class="py-16 md:py-24 px-4 md:px-8 bg-slate-950/50">
+        <div class="max-w-7xl mx-auto">
+            <p class="font-mono text-xs text-emerald-400 tracking-widest mb-4 text-center">THE PROTOCOL</p>
+            <h2 class="font-display text-3xl md:text-5xl font-bold mb-12 text-center">Specification</h2>
+
+            <!-- Version -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Version</h3>
+                <p class="text-slate-400"><code class="text-emerald-400 bg-slate-800 px-2 py-1 rounded">aap/1.0</code></p>
+            </div>
+
+            <!-- Action Message Format -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Action Message Format</h3>
+                <p class="text-slate-400 mb-4">The postMessage payload sent from the canvas iframe to the parent window:</p>
+                <div class="code-block p-6 mb-6">
+<pre class="font-mono text-sm text-slate-300">{
+  <span class="text-emerald-300">"type"</span>: <span class="text-emerald-300">"canvas:interaction"</span>,
+  <span class="text-emerald-300">"action"</span>: <span class="text-emerald-300">"submit"</span>,
+  <span class="text-emerald-300">"element"</span>: <span class="text-emerald-300">"approve-button"</span>,
+  <span class="text-emerald-300">"data"</span>: { <span class="text-emerald-300">"comments"</span>: <span class="text-emerald-300">"Looks good"</span>, <span class="text-emerald-300">"rating"</span>: <span class="text-amber-400">5</span> }
+}</pre>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="spec-table w-full text-sm text-left">
+                        <thead>
+                            <tr>
+                                <th class="font-mono text-emerald-400">Field</th>
+                                <th class="font-mono text-emerald-400">Type</th>
+                                <th class="font-mono text-emerald-400">Required</th>
+                                <th class="font-mono text-emerald-400">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody class="text-slate-300">
+                            <tr><td class="font-mono">type</td><td>string</td><td>Yes</td><td>Always <code class="text-emerald-400">"canvas:interaction"</code></td></tr>
+                            <tr><td class="font-mono">action</td><td>string</td><td>Yes</td><td>Action verb (see Standard Actions)</td></tr>
+                            <tr><td class="font-mono">element</td><td>string</td><td>No</td><td>Element identifier (id, name, label)</td></tr>
+                            <tr><td class="font-mono">data</td><td>object</td><td>No</td><td>Arbitrary key-value payload</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Standard Action Vocabulary -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Standard Action Vocabulary</h3>
+                <div class="overflow-x-auto">
+                    <table class="spec-table w-full text-sm text-left">
+                        <thead>
+                            <tr>
+                                <th class="font-mono text-emerald-400">Action</th>
+                                <th class="font-mono text-emerald-400">Use case</th>
+                            </tr>
+                        </thead>
+                        <tbody class="text-slate-300">
+                            <tr><td class="font-mono">click</td><td>Button press, link activation</td></tr>
+                            <tr><td class="font-mono">submit</td><td>Form submission</td></tr>
+                            <tr><td class="font-mono">change</td><td>Input value changed</td></tr>
+                            <tr><td class="font-mono">select</td><td>Option selected from dropdown/list</td></tr>
+                            <tr><td class="font-mono">toggle</td><td>Boolean switch toggled</td></tr>
+                            <tr><td class="font-mono">dismiss</td><td>Modal/notification dismissed</td></tr>
+                            <tr><td class="font-mono">navigate</td><td>In-canvas navigation (tab switch, page change)</td></tr>
+                            <tr><td class="font-mono">custom</td><td>Application-specific (use <code class="text-emerald-400">data</code> for details)</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p class="text-slate-500 text-sm mt-3">Custom actions beyond this vocabulary are allowed &mdash; the <code class="text-emerald-400">action</code> field is freeform.</p>
+            </div>
+
+            <!-- Interaction Record Format -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Interaction Record Format</h3>
+                <p class="text-slate-400 mb-4">The stored interaction (server-side):</p>
+                <div class="code-block p-6 mb-6">
+<pre class="font-mono text-sm text-slate-300">{
+  <span class="text-emerald-300">"id"</span>: <span class="text-emerald-300">"a1b2c3d4-e5f6-7890-abcd-ef1234567890"</span>,
+  <span class="text-emerald-300">"timestamp"</span>: <span class="text-emerald-300">"2026-05-18T15:30:00.000Z"</span>,
+  <span class="text-emerald-300">"canvasFile"</span>: <span class="text-emerald-300">"reports/dashboard.html"</span>,
+  <span class="text-emerald-300">"action"</span>: <span class="text-emerald-300">"submit"</span>,
+  <span class="text-emerald-300">"element"</span>: <span class="text-emerald-300">"approve-button"</span>,
+  <span class="text-emerald-300">"data"</span>: { <span class="text-emerald-300">"comments"</span>: <span class="text-emerald-300">"Looks good"</span> },
+  <span class="text-emerald-300">"summary"</span>: <span class="text-emerald-300">"User submit 'approve-button' on reports/dashboard.html with data: {comments: Looks good}"</span>
+}</pre>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="spec-table w-full text-sm text-left">
+                        <thead>
+                            <tr>
+                                <th class="font-mono text-emerald-400">Field</th>
+                                <th class="font-mono text-emerald-400">Type</th>
+                                <th class="font-mono text-emerald-400">Required</th>
+                                <th class="font-mono text-emerald-400">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody class="text-slate-300">
+                            <tr><td class="font-mono">id</td><td>UUID</td><td>Yes</td><td>Unique interaction identifier</td></tr>
+                            <tr><td class="font-mono">timestamp</td><td>ISO 8601</td><td>Yes</td><td>When the interaction occurred</td></tr>
+                            <tr><td class="font-mono">canvasFile</td><td>string</td><td>Yes</td><td>Relative path of the canvas HTML file</td></tr>
+                            <tr><td class="font-mono">action</td><td>string</td><td>Yes</td><td>The action verb</td></tr>
+                            <tr><td class="font-mono">element</td><td>string</td><td>No</td><td>Element identifier</td></tr>
+                            <tr><td class="font-mono">data</td><td>object</td><td>No</td><td>Arbitrary payload</td></tr>
+                            <tr><td class="font-mono">summary</td><td>string</td><td>Yes</td><td>Human-readable summary for the agent</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Storage -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Storage</h3>
+                <div class="bg-slate-850 border border-slate-800 rounded-xl p-6">
+                    <ul class="space-y-3 text-slate-300 text-sm">
+                        <li><span class="text-emerald-400 font-mono">Path:</span> <code class="bg-slate-800 px-2 py-0.5 rounded text-xs">~/.aimaestro/agents/&lt;agentId&gt;/canvas/interactions/</code></li>
+                        <li><span class="text-emerald-400 font-mono">Filename:</span> <code class="bg-slate-800 px-2 py-0.5 rounded text-xs">&lt;ISO-timestamp&gt;-&lt;UUID&gt;.json</code> (with <code class="text-amber-400">:</code> and <code class="text-amber-400">.</code> replaced by <code class="text-amber-400">-</code>)</li>
+                        <li><span class="text-emerald-400 font-mono">Strategy:</span> One file per interaction (append-only, immutable)</li>
+                        <li><span class="text-emerald-400 font-mono">Ordering:</span> Sorted by filename = sorted by time</li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Transport -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Transport</h3>
+                <div class="code-block p-6">
+<pre class="font-mono text-sm text-slate-300"><span class="text-emerald-400">Canvas iframe</span>
+  | window.parent.postMessage()
+  v
+<span class="text-amber-400">Parent window</span> (Dashboard)
+  | POST /api/agents/:id/canvas/interactions
+  v
+<span class="text-emerald-400">Provider API</span>
+  | Write JSON file + tmux notification
+  v
+<span class="text-amber-400">Agent</span></pre>
+                </div>
+            </div>
+
+            <!-- API Endpoints -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">API Endpoints</h3>
+
+                <!-- Submit -->
+                <div class="mb-6">
+                    <h4 class="font-mono text-lg text-emerald-400 mb-3">Submit Interaction</h4>
+                    <div class="code-block p-6 mb-4">
+<pre class="font-mono text-sm text-slate-300"><span class="text-amber-400">POST</span> /api/agents/:id/canvas/interactions
+<span class="text-slate-500">Content-Type: application/json</span>
+
+{ <span class="text-emerald-300">"action"</span>: <span class="text-emerald-300">"submit"</span>, <span class="text-emerald-300">"element"</span>: <span class="text-emerald-300">"btn"</span>, <span class="text-emerald-300">"canvasFile"</span>: <span class="text-emerald-300">"page.html"</span>, <span class="text-emerald-300">"data"</span>: {} }
+
+<span class="text-emerald-400">&rarr; 201</span> { <span class="text-emerald-300">"id"</span>: <span class="text-emerald-300">"uuid"</span>, <span class="text-emerald-300">"summary"</span>: <span class="text-emerald-300">"User submit 'btn' on page.html"</span> }
+<span class="text-red-400">&rarr; 400</span> { <span class="text-emerald-300">"error"</span>: <span class="text-emerald-300">"missing_field"</span>, <span class="text-emerald-300">"message"</span>: <span class="text-emerald-300">"action is required"</span> }
+<span class="text-red-400">&rarr; 404</span> { <span class="text-emerald-300">"error"</span>: <span class="text-emerald-300">"not_found"</span>, <span class="text-emerald-300">"message"</span>: <span class="text-emerald-300">"Agent 'xyz' not found"</span> }</pre>
+                    </div>
+                </div>
+
+                <!-- List -->
+                <div>
+                    <h4 class="font-mono text-lg text-emerald-400 mb-3">List Interactions</h4>
+                    <div class="code-block p-6">
+<pre class="font-mono text-sm text-slate-300"><span class="text-amber-400">GET</span> /api/agents/:id/canvas/interactions?limit=50
+
+<span class="text-emerald-400">&rarr; 200</span> { <span class="text-emerald-300">"interactions"</span>: [ { ... }, { ... } ] }</pre>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Agent Notification -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Agent Notification</h3>
+                <p class="text-slate-400 mb-4">When an interaction is stored, the provider SHOULD notify the agent:</p>
+                <div class="code-block p-6">
+<pre class="font-mono text-sm text-emerald-400">[CANVAS] reports/dashboard.html: User submit 'approve-button' on reports/dashboard.html with data: {comments: Looks good}</pre>
+                </div>
+                <p class="text-slate-500 text-sm mt-3">Notification is fire-and-forget. Failure does not affect interaction storage.</p>
+            </div>
+
+            <!-- Security -->
+            <div class="max-w-4xl mx-auto mb-12">
+                <h3 class="font-display text-2xl font-bold text-white mb-4">Security Considerations</h3>
+                <div class="bg-slate-850 border border-slate-800 rounded-xl p-6">
+                    <ul class="space-y-3 text-slate-300 text-sm">
+                        <li>Canvas HTML runs in <code class="text-emerald-400 bg-slate-800 px-1 rounded">sandbox="allow-scripts"</code> iframe (no same-origin, no forms, no popups)</li>
+                        <li>Bridge uses <code class="text-emerald-400 bg-slate-800 px-1 rounded">postMessage('*')</code> &mdash; parent validates <code class="text-emerald-400 bg-slate-800 px-1 rounded">event.data.type</code> before processing</li>
+                        <li>No credentials, tokens, or authentication data should be sent via <code class="text-emerald-400 bg-slate-800 px-1 rounded">data</code> payload</li>
+                        <li><code class="text-emerald-400 bg-slate-800 px-1 rounded">data</code> is stored as-is &mdash; providers SHOULD sanitize before displaying</li>
+                        <li>Canvas files are read-only to the user &mdash; only the agent can write them</li>
+                        <li>Path traversal protection: canvas file paths must not contain <code class="text-emerald-400 bg-slate-800 px-1 rounded">..</code> or be absolute</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- For Implementers Section -->
+    <section id="implementers" class="py-16 md:py-24 px-4 md:px-8">
+        <div class="max-w-7xl mx-auto">
+            <p class="font-mono text-xs text-emerald-400 tracking-widest mb-4 text-center">BUILD IT</p>
+            <h2 class="font-display text-3xl md:text-5xl font-bold mb-6 text-center">For Implementers</h2>
+            <p class="text-slate-400 text-lg max-w-2xl mx-auto mb-12 text-center">
+                Building an AAP-compatible provider? Here is what you need.
+            </p>
+
+            <div class="max-w-4xl mx-auto">
+                <!-- Checklist -->
+                <div class="bg-slate-850 border border-slate-800 rounded-xl p-8 mb-12">
+                    <h3 class="font-display text-xl font-bold text-white mb-6">Implementation Checklist</h3>
+                    <div class="space-y-4">
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">1</span>
+                            <p class="text-slate-300 text-sm">Inject bridge script into canvas HTML before rendering in iframe</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">2</span>
+                            <p class="text-slate-300 text-sm">Listen for <code class="text-emerald-400 bg-slate-800 px-1 rounded">postMessage</code> with <code class="text-emerald-400 bg-slate-800 px-1 rounded">type: 'canvas:interaction'</code></p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">3</span>
+                            <p class="text-slate-300 text-sm">Validate <code class="text-emerald-400 bg-slate-800 px-1 rounded">action</code> field is present and non-empty</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">4</span>
+                            <p class="text-slate-300 text-sm">Generate UUID and ISO 8601 timestamp for each interaction</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">5</span>
+                            <p class="text-slate-300 text-sm">Build human-readable summary string</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">6</span>
+                            <p class="text-slate-300 text-sm">Store interaction as JSON (recommended: file-per-interaction, append-only)</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">7</span>
+                            <p class="text-slate-300 text-sm">Notify agent (optional, provider-specific mechanism)</p>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="w-6 h-6 rounded border border-emerald-500/40 bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5 text-emerald-400 text-xs">8</span>
+                            <p class="text-slate-300 text-sm">Expose API for listing interactions (optional)</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Relationship to AMP & AID -->
+                <div class="bg-slate-850 border border-slate-800 rounded-xl p-8 mb-12">
+                    <h3 class="font-display text-xl font-bold text-white mb-4">Relationship to AMP &amp; AID</h3>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div class="text-center">
+                            <div class="text-3xl mb-2">🎯</div>
+                            <h4 class="font-display font-bold text-emerald-400 mb-1">AAP</h4>
+                            <p class="text-slate-400 text-xs">User &rarr; Agent<br>UI interactions</p>
+                        </div>
+                        <div class="text-center">
+                            <div class="text-3xl mb-2">📬</div>
+                            <h4 class="font-display font-bold text-purple-400 mb-1">AMP</h4>
+                            <p class="text-slate-400 text-xs">Agent &rarr; Agent<br>Signed messages</p>
+                        </div>
+                        <div class="text-center">
+                            <div class="text-3xl mb-2">🔑</div>
+                            <h4 class="font-display font-bold text-green-400 mb-1">AID</h4>
+                            <p class="text-slate-400 text-xs">Agent identity<br>Cryptographic auth</p>
+                        </div>
+                    </div>
+                    <p class="text-slate-400 text-sm mt-6 text-center">All three are independent but complementary. They share the same agent directory structure.</p>
+                </div>
+
+                <!-- Roadmap -->
+                <div class="bg-slate-850 border border-slate-800 rounded-xl p-8">
+                    <h3 class="font-display text-xl font-bold text-white mb-4">Roadmap</h3>
+                    <div class="space-y-4">
+                        <div class="flex items-center gap-4">
+                            <span class="px-3 py-1 rounded-full bg-emerald-500/20 border border-emerald-500/40 text-emerald-400 font-mono text-xs font-bold">v1.0</span>
+                            <p class="text-slate-300 text-sm">One-way canvas interactions (user &rarr; agent) <span class="text-emerald-400">&mdash; current</span></p>
+                        </div>
+                        <div class="flex items-center gap-4">
+                            <span class="px-3 py-1 rounded-full bg-slate-800 border border-slate-700 text-slate-400 font-mono text-xs font-bold">v1.1</span>
+                            <p class="text-slate-400 text-sm">Bidirectional &mdash; agents push updates back to canvas</p>
+                        </div>
+                        <div class="flex items-center gap-4">
+                            <span class="px-3 py-1 rounded-full bg-slate-800 border border-slate-700 text-slate-400 font-mono text-xs font-bold">v1.2</span>
+                            <p class="text-slate-400 text-sm">Interaction acknowledgment &mdash; agent confirms receipt</p>
+                        </div>
+                        <div class="flex items-center gap-4">
+                            <span class="px-3 py-1 rounded-full bg-slate-800 border border-slate-700 text-slate-400 font-mono text-xs font-bold">v2.0</span>
+                            <p class="text-slate-400 text-sm">Agent-defined UI components (widgets, forms, controls)</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA Section -->
+    <section class="py-20 md:py-28 px-4 md:px-8 text-center bg-slate-950/50">
+        <div class="max-w-3xl mx-auto">
+            <h2 class="font-display text-3xl md:text-5xl font-bold mb-6">
+                Let Your Agents <span class="gradient-text">See the Clicks</span>
+            </h2>
+            <p class="text-slate-400 text-lg mb-10">
+                Open protocol. MIT licensed. Works with any agent dashboard.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="https://github.com/agentmessaging/agent-actions#readme" target="_blank" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200 no-underline">
+                    GET STARTED FREE
+                </a>
+                <a href="index.html" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-slate-800 text-white font-bold text-sm tracking-wide hover:bg-slate-700 transition-all duration-200 no-underline border border-slate-700">
+                    BACK TO AI MAESTRO
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="py-16 pb-8 bg-slate-950 border-t border-slate-800 px-4 md:px-8">
+        <div class="max-w-7xl mx-auto">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-12 mb-12">
+                <div>
+                    <div class="flex items-center gap-3 mb-4">
+                        <img src="logo-constellation.svg" alt="AI Maestro" class="w-8 h-8">
+                        <span class="font-display font-bold text-lg text-white">AI MAESTRO</span>
+                    </div>
+                    <p class="text-slate-400 text-sm">The OS for AI-first organizations. Orchestrate any AI agent with persistent memory, messaging, and multi-machine support.</p>
+                </div>
+                <div>
+                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">PROTOCOLS</h4>
+                    <a href="https://agentactions.org" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">AAP &mdash; Agent Actions Protocol</a>
+                    <a href="https://agentmessaging.org" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">AMP &mdash; Agent Messaging Protocol</a>
+                    <a href="https://agentids.org" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">AID &mdash; Agent Identity Protocol</a>
+                    <a href="https://github.com/agentmessaging/agent-actions" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">GitHub</a>
+                </div>
+                <div>
+                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">BUILT BY</h4>
+                    <p class="text-slate-400 text-sm mb-2">
+                        <a href="https://x.com/jkpelaez" target="_blank" class="text-white hover:text-emerald-400 transition-colors">Juan Pel&aacute;ez</a> @ <a href="https://23blocks.com" target="_blank" class="text-white hover:text-emerald-400 transition-colors">23blocks</a>
+                    </p>
+                    <p class="text-slate-500 text-xs">Made with <span class="text-red-500">&#9829;</span> in Boulder, Colorado</p>
+                    <p class="text-slate-500 text-xs mt-1">Coded with Claude</p>
+                </div>
+            </div>
+            <div class="pt-8 border-t border-slate-800 text-center">
+                <p class="text-slate-500 text-sm">&copy; 2026 Juan Pel&aacute;ez / 23blocks. MIT License.</p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- GSAP Animations -->
+    <script>
+        gsap.registerPlugin(ScrollTrigger);
+
+        // Fade in sections on scroll
+        gsap.utils.toArray("section").forEach((section) => {
+            gsap.from(section, {
+                opacity: 0,
+                y: 50,
+                duration: 0.8,
+                ease: "power2.out",
+                scrollTrigger: {
+                    trigger: section,
+                    start: "top 80%",
+                    end: "top 50%",
+                    toggleActions: "play none none none"
+                }
+            });
+        });
+    </script>
+
+    <!-- Copy for AI functionality -->
+    <script src="copy-for-ai.js"></script>
+</body>
+</html>

--- a/docs/ecosystem.html
+++ b/docs/ecosystem.html
@@ -553,6 +553,10 @@
                     <h3 class="font-display text-lg font-bold text-white mb-2">AID</h3>
                     <p class="text-slate-400 text-sm">Agent Identity. Cryptographic keys, OAuth 2.0, passwordless auth.</p>
                 </a>
+                <a href="https://agentactions.org" target="_blank" class="block bg-slate-850 border border-slate-800 rounded-xl p-6 no-underline hover:border-emerald-400/30 transition-colors">
+                    <h3 class="font-display text-lg font-bold text-white mb-2">AAP</h3>
+                    <p class="text-slate-400 text-sm">Agent Actions Protocol. Structured UI interactions, canvas events, agent notifications.</p>
+                </a>
             </div>
         </div>
     </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -880,6 +880,16 @@
                         <h4 class="font-bold text-white text-lg mb-2 group-hover:text-amber-400 transition-colors">Plugin Builder</h4>
                         <p class="text-slate-400 text-sm leading-relaxed">Build custom skill sets for each agent. Pick from GitHub, mix your own, assemble the perfect plugin.</p>
                     </a>
+                    <a href="agent-actions.html" class="group relative bg-slate-900/80 border border-slate-700 rounded-xl p-6 hover:border-amber-500/50 hover:bg-slate-900 transition-all duration-300 no-underline overflow-hidden">
+                        <div class="absolute top-3 right-3">
+                            <span class="px-2 py-1 bg-gradient-to-r from-emerald-500 to-teal-500 text-white text-xs font-bold rounded-full shadow-lg shadow-emerald-500/25">NEW</span>
+                        </div>
+                        <div class="w-12 h-12 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                            <span class="text-2xl">🎯</span>
+                        </div>
+                        <h4 class="font-bold text-white text-lg mb-2 group-hover:text-amber-400 transition-colors">Agent Actions (AAP)</h4>
+                        <p class="text-slate-400 text-sm leading-relaxed">Open protocol for structured UI-to-agent interactions. Canvas clicks, forms, and custom actions — delivered to your agents.</p>
+                    </a>
                     <a href="#" class="group relative bg-slate-900/80 border border-slate-700 rounded-xl p-6 hover:border-amber-500/50 hover:bg-slate-900 transition-all duration-300 no-underline overflow-hidden feature-card">
                         <div class="absolute top-3 right-3">
                             <span class="px-2 py-1 bg-gradient-to-r from-cyan-500 to-blue-500 text-white text-xs font-bold rounded-full shadow-lg shadow-cyan-500/25">NEW</span>

--- a/services/agents-canvas-service.ts
+++ b/services/agents-canvas-service.ts
@@ -1,0 +1,246 @@
+/**
+ * Agents Canvas Service
+ *
+ * Business logic for listing and serving HTML files from agent canvas directories.
+ * Canvas dir: ~/.aimaestro/agents/<id>/canvas/
+ *
+ * Routes are thin wrappers that call these functions.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+import { getAgent, getAgentByName, getAgentByAlias } from '@/lib/agent-registry'
+import { type ServiceResult, invalidRequest, notFound, missingField } from '@/services/service-errors'
+import type { Agent } from '@/types/agent'
+import { computeSessionName } from '@/types/agent'
+import { getRuntime } from '@/lib/agent-runtime'
+
+export interface CanvasInteraction {
+  id: string
+  timestamp: string
+  canvasFile: string
+  action: string
+  element?: string
+  data?: Record<string, unknown>
+  summary: string
+}
+
+export interface CanvasFile {
+  name: string       // "report.html"
+  path: string       // "reports/report.html" (relative to canvas dir)
+  size: number
+  modifiedAt: string // ISO timestamp
+}
+
+const AIMAESTRO_DIR = path.join(os.homedir(), '.aimaestro')
+
+function resolveAgent(idOrName: string): Agent | null {
+  return getAgent(idOrName) || getAgentByName(idOrName) || getAgentByAlias(idOrName) || null
+}
+
+function getCanvasDir(agentId: string): string {
+  return path.join(AIMAESTRO_DIR, 'agents', agentId, 'canvas')
+}
+
+/**
+ * Recursively scan for HTML files in a directory.
+ */
+function scanHtmlFiles(dir: string, baseDir: string): CanvasFile[] {
+  const files: CanvasFile[] = []
+
+  if (!fs.existsSync(dir)) return files
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...scanHtmlFiles(fullPath, baseDir))
+    } else if (entry.isFile() && /\.html?$/i.test(entry.name)) {
+      const stat = fs.statSync(fullPath)
+      files.push({
+        name: entry.name,
+        path: path.relative(baseDir, fullPath),
+        size: stat.size,
+        modifiedAt: stat.mtime.toISOString(),
+      })
+    }
+  }
+
+  return files
+}
+
+// ── Public Functions ────────────────────────────────────────────────────────
+
+/**
+ * List HTML files in an agent's canvas directory.
+ */
+export function listCanvasFiles(
+  agentIdOrName: string
+): ServiceResult<{ files: CanvasFile[] }> {
+  const agent = resolveAgent(agentIdOrName)
+  if (!agent) {
+    return notFound('Agent', agentIdOrName)
+  }
+
+  const canvasDir = getCanvasDir(agent.id)
+  const files = scanHtmlFiles(canvasDir, canvasDir)
+
+  // Sort by modifiedAt descending (newest first)
+  files.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime())
+
+  return { data: { files }, status: 200 }
+}
+
+/**
+ * Get a canvas file's raw HTML content.
+ */
+export function getCanvasFile(
+  agentIdOrName: string,
+  filePath: string
+): ServiceResult<{ content: string; fileName: string; size: number }> {
+  const agent = resolveAgent(agentIdOrName)
+  if (!agent) {
+    return notFound('Agent', agentIdOrName)
+  }
+
+  // Path traversal protection
+  if (filePath.includes('..') || path.isAbsolute(filePath)) {
+    return invalidRequest('Invalid file path')
+  }
+
+  // Only allow HTML files
+  if (!/\.html?$/i.test(filePath)) {
+    return invalidRequest('Only .html and .htm files are supported')
+  }
+
+  const canvasDir = getCanvasDir(agent.id)
+  const resolvedPath = path.resolve(canvasDir, filePath)
+
+  // Defense in depth: ensure resolved path is within canvas dir
+  if (!resolvedPath.startsWith(canvasDir + path.sep) && resolvedPath !== canvasDir) {
+    return invalidRequest('Invalid file path')
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
+    return notFound('Canvas file', filePath)
+  }
+
+  const content = fs.readFileSync(resolvedPath, 'utf-8')
+  const stat = fs.statSync(resolvedPath)
+
+  return {
+    data: {
+      content,
+      fileName: path.basename(filePath),
+      size: stat.size,
+    },
+    status: 200,
+  }
+}
+
+// ── Canvas Interactions ───────────────────────────────────────────────────────
+
+function getInteractionsDir(agentId: string): string {
+  return path.join(AIMAESTRO_DIR, 'agents', agentId, 'canvas', 'interactions')
+}
+
+function buildSummary(action: string, element?: string, canvasFile?: string, data?: Record<string, unknown>): string {
+  let summary = `User ${action}`
+  if (element) summary += ` '${element}'`
+  if (canvasFile) summary += ` on ${canvasFile}`
+  if (data && Object.keys(data).length > 0) {
+    const preview = JSON.stringify(data)
+    summary += ` with data: ${preview.length > 200 ? preview.slice(0, 200) + '...' : preview}`
+  }
+  return summary
+}
+
+async function notifyCanvasInteraction(agent: Agent, summary: string): Promise<void> {
+  try {
+    if (!agent.sessions || agent.sessions.length === 0) return
+    const primarySession = agent.sessions.find(s => s.index === 0) || agent.sessions[0]
+    const sessionName = computeSessionName(agent.name, primarySession.index)
+    const runtime = getRuntime()
+    const exists = await runtime.sessionExists(sessionName)
+    if (!exists) return
+
+    const escaped = summary.replace(/'/g, "'\\''")
+    const target = `${sessionName}:0.0`
+    await runtime.sendKeys(target, `echo '${escaped}'`, { literal: true })
+    await new Promise(resolve => setTimeout(resolve, 150))
+    await runtime.sendKeys(target, 'Enter')
+  } catch {
+    // Fire-and-forget — notification failure is non-fatal
+  }
+}
+
+/**
+ * Submit a canvas interaction from the UI.
+ */
+export async function submitInteraction(
+  agentIdOrName: string,
+  input: { action?: string; element?: string; canvasFile?: string; data?: Record<string, unknown> }
+): Promise<ServiceResult<{ id: string; summary: string }>> {
+  const agent = resolveAgent(agentIdOrName)
+  if (!agent) return notFound('Agent', agentIdOrName)
+
+  if (!input.action) return missingField('action')
+  if (!input.canvasFile) return missingField('canvasFile')
+
+  const id = crypto.randomUUID()
+  const timestamp = new Date().toISOString()
+  const summary = buildSummary(input.action, input.element, input.canvasFile, input.data)
+
+  const interaction: CanvasInteraction = {
+    id,
+    timestamp,
+    canvasFile: input.canvasFile,
+    action: input.action,
+    element: input.element,
+    data: input.data,
+    summary,
+  }
+
+  const dir = getInteractionsDir(agent.id)
+  fs.mkdirSync(dir, { recursive: true })
+  const fileName = `${timestamp.replace(/[:.]/g, '-')}-${id}.json`
+  fs.writeFileSync(path.join(dir, fileName), JSON.stringify(interaction, null, 2))
+
+  // Notify agent via tmux (fire-and-forget)
+  const notification = `[CANVAS] ${input.canvasFile}: ${summary}`
+  notifyCanvasInteraction(agent, notification)
+
+  return { data: { id, summary }, status: 201 }
+}
+
+/**
+ * List canvas interactions for an agent.
+ */
+export function listInteractions(
+  agentIdOrName: string,
+  limit = 50
+): ServiceResult<{ interactions: CanvasInteraction[] }> {
+  const agent = resolveAgent(agentIdOrName)
+  if (!agent) return notFound('Agent', agentIdOrName)
+
+  const dir = getInteractionsDir(agent.id)
+  if (!fs.existsSync(dir)) {
+    return { data: { interactions: [] }, status: 200 }
+  }
+
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.json')).sort().reverse()
+  const interactions: CanvasInteraction[] = []
+
+  for (const file of files.slice(0, limit)) {
+    try {
+      const raw = fs.readFileSync(path.join(dir, file), 'utf-8')
+      interactions.push(JSON.parse(raw))
+    } catch {
+      // Skip malformed files
+    }
+  }
+
+  return { data: { interactions }, status: 200 }
+}

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -113,6 +113,13 @@ import {
 } from '@/services/agents-docs-service'
 
 import {
+  listCanvasFiles,
+  getCanvasFile,
+  submitInteraction,
+  listInteractions,
+} from '@/services/agents-canvas-service'
+
+import {
   getSkillsConfig,
   updateSkills,
   addSkill,
@@ -772,6 +779,35 @@ const routes: Route[] = [
   }},
   { method: 'DELETE', pattern: /^\/api\/agents\/([^/]+)\/docs$/, paramNames: ['id'], handler: async (_req, res, params, query) => {
     sendServiceResult(res, await clearDocs(params.id, query.project))
+  }},
+
+  // Canvas interactions (must come before /canvas catch-all)
+  { method: 'POST', pattern: /^\/api\/agents\/([^/]+)\/canvas\/interactions$/, paramNames: ['id'], handler: async (req, res, params) => {
+    const body = await readJsonBody(req)
+    sendServiceResult(res, await submitInteraction(params.id, body))
+  }},
+  { method: 'GET', pattern: /^\/api\/agents\/([^/]+)\/canvas\/interactions$/, paramNames: ['id'], handler: async (_req, res, params, query) => {
+    sendServiceResult(res, listInteractions(params.id, parseInt(query.limit || '50', 10)))
+  }},
+
+  // Canvas
+  { method: 'GET', pattern: /^\/api\/agents\/([^/]+)\/canvas$/, paramNames: ['id'], handler: async (_req, res, params, query) => {
+    if (query.file) {
+      const result = getCanvasFile(params.id, query.file)
+      if (result.status !== 200 || !result.data || ('error' in result.data && 'message' in result.data)) {
+        sendServiceResult(res, result)
+        return
+      }
+      const { content, fileName } = result.data as { content: string; fileName: string; size: number }
+      const buf = Buffer.from(content, 'utf-8')
+      sendBinary(res, 200, buf, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Content-Length': String(buf.length),
+        'X-Canvas-File': fileName,
+      })
+    } else {
+      sendServiceResult(res, listCanvasFiles(params.id))
+    }
   }},
 
   // Skills

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.14",
+  "version": "0.35.16",
   "releaseDate": "2026-05-18",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,18 @@
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@anthropic-ai/sdk@^0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.82.0.tgz#68e993d75bdf03a8d8b6c2896464bf460d735fbf"
+  integrity sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==
+  dependencies:
+    json-schema-to-ts "^3.1.1"
+
+"@babel/runtime@^7.18.3":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@emnapi/core@^1.4.3":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
@@ -3586,6 +3598,14 @@ json-buffer@3.0.1:
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-schema-to-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
@@ -5372,6 +5392,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
 
 ts-api-utils@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary
- **AAP v1.0** — Open protocol for structured UI-to-agent interactions (user clicks in canvas iframe -> JSON delivered to agent)
- Full implementation: service layer, API routes, CanvasPanel component, headless router
- Protocol spec as markdown + standalone HTML page (agentactions.org)
- canvas-actions skill in `agentmessaging/agent-actions` repo (follows AMP/AID pattern)

## What's included

### Implementation
- `services/agents-canvas-service.ts` — submitInteraction, listInteractions, listCanvasFiles, getCanvasFile
- `app/api/agents/[id]/canvas/route.ts` — List/serve canvas HTML files
- `app/api/agents/[id]/canvas/interactions/route.ts` — Submit/list interactions
- `components/CanvasPanel.tsx` — Sandboxed iframe, maestro bridge injection, postMessage listener
- `services/headless-router.ts` — Canvas routes for headless mode

### Documentation
- `docs/AGENT-ACTIONS-PROTOCOL.md` — Full protocol specification
- `docs/agent-actions.html` — Standalone spec page (serves agentactions.org)
- `docs/ecosystem.html` — AAP card added to protocol grid
- `docs/index.html` — AAP feature card in Tier 3

### External repos (already pushed)
- `agentmessaging/agent-actions` — Protocol spec + canvas-actions skill
- `agentmessaging/aap-website` — GitHub Pages site (agentactions.org live)
- `23blocks-OS/ai-maestro-plugins` PR #24 — Plugin manifest update

## Test plan
- [x] `yarn test` — 792/792 passed
- [x] `yarn build` — clean build with canvas routes
- [x] End-to-end test: form submit in canvas -> JSON stored -> agent notified
- [x] API: POST returns 201, GET lists interactions
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)