### PR TITLE
feat: update AI Maestro website and installer with AAP protocol references (v0.35.18)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -97,6 +97,8 @@
         "Terminal agent management",
         "Real-time WebSocket streaming",
         "Agent Messaging Protocol (AMP) for secure inter-agent communication",
+        "Agent Actions Protocol (AAP) for structured UI-to-agent canvas interactions",
+        "Agent Identity Protocol (AID) for OAuth 2.0 authentication",
         "Ed25519 cryptographic signatures for message authenticity",
         "Federation with external AMP providers (CrabMail, etc.)",
         "Email identity management with domain control",

--- a/install-plugin.sh
+++ b/install-plugin.sh
@@ -42,10 +42,11 @@ while [[ $# -gt 0 ]]; do
             echo "  --migrate          Migrate from old messaging system only"
             echo "  -h, --help         Show this help message"
             echo ""
-            echo "This installer sets up the Agent Messaging Protocol (AMP) which provides:"
-            echo "  - Local messaging between agents (works immediately)"
-            echo "  - Federation with external providers (CrabMail, etc.)"
-            echo "  - Cryptographic message signing (Ed25519)"
+            echo "This installer sets up the AI Maestro plugin which provides:"
+            echo "  - Agent Messaging Protocol (AMP) — local + federated messaging"
+            echo "  - Agent Identity Protocol (AID) — OAuth 2.0 with Ed25519 keys"
+            echo "  - Agent Actions Protocol (AAP) — canvas interactions and UI actions"
+            echo "  - Memory search, code graph, docs search, agent management tools"
             echo ""
             exit 0
             ;;
@@ -892,16 +893,18 @@ fi
 if [ "$INSTALL_SKILL" = true ]; then
     echo "5️⃣  Or use natural language with Claude Code:"
     echo ""
-    echo "   > \"Check my messages\""
-    echo "   > \"Send a message to backend-api about the deployment\""
-    echo "   > \"Reply to the last message\""
+    echo "   > \"Check my messages\"              (AMP messaging)"
+    echo "   > \"Show me a test results dashboard\" (AAP canvas)"
+    echo "   > \"Visualize the API coverage\"       (AAP canvas)"
     echo ""
 fi
 
 echo "📖 Documentation:"
 echo ""
+echo "   AI Maestro:   https://ai-maestro.23blocks.com"
 echo "   AMP Protocol: https://agentmessaging.org"
-echo "   AI Maestro:   https://github.com/23blocks-OS/ai-maestro"
+echo "   AID Protocol: https://agentids.org"
+echo "   AAP Protocol: https://agentactions.org"
 echo ""
 
 # External provider registration (optional)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.17",
+  "version": "0.35.18",
   "releaseDate": "2026-05-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Add AAP and AID to Schema.org featureList in `docs/index.html`
- Update `install-plugin.sh` help text to mention all three protocols (AMP, AID, AAP)
- Add AAP/canvas examples to installer Getting Started tips
- Add all three protocol URLs (AMP, AID, AAP) to installer documentation section

## Test plan
- [x] `yarn test` — 792/792 pass
- [x] `yarn build` — passes
- [ ] `./install-plugin.sh --help` shows updated description
- [ ] After install, completion message shows all protocol URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)