### PR TITLE
fix: replace AAP branding with AI Maestro branding on agent-actions page

### DIFF
--- a/docs/agent-actions.html
+++ b/docs/agent-actions.html
@@ -11,32 +11,32 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Agent Actions Protocol (AAP) &mdash; Structured UI-to-Agent Interactions | agentactions.org</title>
+    <title>Agent Canvas Interactions: Structured UI-to-Agent Actions | AI Maestro</title>
     <meta name="description" content="Open protocol for delivering structured user interactions from agent-rendered UIs back to AI agents. Canvas clicks, form submissions, and custom actions — captured, stored, and delivered.">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agentactions.org">
-    <meta property="og:title" content="Agent Actions Protocol (AAP) — Structured UI-to-Agent Interactions">
+    <meta property="og:url" content="https://ai-maestro.23blocks.com/agent-actions.html">
+    <meta property="og:title" content="Agent Canvas Interactions: Structured UI-to-Agent Actions - AI Maestro">
     <meta property="og:description" content="Open protocol for delivering structured user interactions from agent-rendered UIs back to AI agents. Canvas clicks, forms, and custom actions.">
     <meta property="og:image" content="https://ai-maestro.23blocks.com/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="Agent Actions Protocol (AAP)">
+    <meta property="og:image:alt" content="AI Maestro - Orchestrate your AI coding agents">
     <meta property="og:locale" content="en_US">
-    <meta property="og:site_name" content="Agent Actions Protocol">
+    <meta property="og:site_name" content="AI Maestro">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Agent Actions Protocol (AAP) — UI-to-Agent Interactions">
+    <meta name="twitter:title" content="Agent Canvas Interactions: Structured UI-to-Agent Actions - AI Maestro">
     <meta name="twitter:description" content="Open protocol for structured user interactions from agent-rendered UIs back to AI agents.">
     <meta name="twitter:image" content="https://ai-maestro.23blocks.com/og-image.png">
     <meta name="twitter:creator" content="@jkpelaez">
 
     <!-- Additional SEO -->
     <meta name="author" content="Juan Pel&aacute;ez">
-    <meta name="keywords" content="agent actions protocol, AAP, canvas interactions, agent UI, AI agent actions, user-to-agent communication, agent-rendered UI, structured interactions">
-    <link rel="canonical" href="https://agentactions.org">
+    <meta name="keywords" content="agent actions protocol, AAP, canvas interactions, agent UI, AI agent actions, user-to-agent communication, agent-rendered UI, structured interactions, AI Maestro">
+    <link rel="canonical" href="https://ai-maestro.23blocks.com/agent-actions.html">
 
     <!-- Favicon & Icons -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -53,10 +53,10 @@
     <!-- Apple Mobile Web App -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="apple-mobile-web-app-title" content="AAP">
+    <meta name="apple-mobile-web-app-title" content="AI Maestro">
 
     <!-- Application Info -->
-    <meta name="application-name" content="Agent Actions Protocol">
+    <meta name="application-name" content="AI Maestro">
     <meta name="format-detection" content="telephone=no">
 
     <!-- Schema.org Structured Data -->
@@ -105,7 +105,7 @@
       "dateModified": "2026-05-18",
       "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": "https://agentactions.org"
+        "@id": "https://ai-maestro.23blocks.com/agent-actions.html"
       }
     }
     </script>
@@ -255,7 +255,7 @@
     <!-- Copy for AI Button -->
     <button
         onclick="copyForAI()"
-        class="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-slate-800 border border-slate-700 text-emerald-400 font-mono text-sm rounded hover:bg-slate-700 hover:border-emerald-500/50 transition-all duration-200"
+        class="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-slate-800 border border-slate-700 text-cyan-400 font-mono text-sm rounded hover:bg-slate-700 hover:border-cyan-500/50 transition-all duration-200"
         title="Copy this page for AI assistants">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
@@ -264,33 +264,32 @@
         COPY FOR AI
     </button>
 
-    <!-- Navigation -->
+    <!-- Navigation (AI Maestro standard) -->
     <nav class="sticky top-0 bg-slate-900/95 backdrop-blur-lg border-b border-slate-800 z-[100]">
         <div class="max-w-7xl mx-auto px-4 md:px-8">
             <div class="flex justify-between items-center py-4">
-                <a href="/" class="flex items-center gap-3 text-white no-underline hover:opacity-80 transition-opacity duration-200">
-                    <span class="text-2xl">🎯</span>
-                    <span class="font-display font-bold text-lg md:text-xl tracking-tight">AAP</span>
+                <a href="index.html" class="flex items-center gap-3 text-white no-underline hover:opacity-80 transition-opacity duration-200">
+                    <img src="logo-constellation.svg" alt="AI Maestro" class="w-8 h-8 md:w-10 md:h-10">
+                    <span class="font-display font-bold text-lg md:text-xl tracking-tight">AI MAESTRO</span>
                 </a>
 
                 <!-- Desktop Navigation -->
                 <div class="hidden md:flex gap-8 items-center">
-                    <a href="#why" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">WHY</a>
-                    <a href="#how-it-works" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">HOW IT WORKS</a>
-                    <a href="#data-driven" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">DATA-DRIVEN</a>
-                    <a href="#specification" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">SPEC</a>
-                    <a href="#plugin" class="text-slate-400 no-underline font-medium hover:text-emerald-400 transition-colors duration-200 text-sm tracking-wide">PLUGIN</a>
-                    <a href="https://github.com/agentmessaging/agent-actions" target="_blank" class="text-slate-400 no-underline hover:text-emerald-400 transition-colors duration-200" title="View on GitHub">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    <a href="index.html#personas" class="text-slate-400 no-underline font-medium hover:text-cyan-400 transition-colors duration-200 text-sm tracking-wide">WHO IT'S FOR</a>
+                    <a href="index.html#features" class="text-slate-400 no-underline font-medium hover:text-cyan-400 transition-colors duration-200 text-sm tracking-wide">FEATURES</a>
+                    <a href="security.html" class="text-slate-400 no-underline font-medium hover:text-cyan-400 transition-colors duration-200 text-sm tracking-wide">SECURITY</a>
+                    <a href="index.html#quick-start" class="text-slate-400 no-underline font-medium hover:text-cyan-400 transition-colors duration-200 text-sm tracking-wide">GET STARTED</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro" target="_blank" class="text-slate-400 no-underline hover:text-cyan-400 transition-colors duration-200" title="View on GitHub">
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
                     </a>
-                    <a href="https://github.com/agentmessaging/agent-actions#readme" class="inline-flex items-center gap-2 px-5 py-2.5 rounded bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200" target="_blank">
+                    <a href="https://github.com/23blocks-OS/ai-maestro#readme" class="inline-flex items-center gap-2 px-5 py-2.5 rounded bg-cyan-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-cyan-400 transition-all duration-200" target="_blank">
                         START FREE
                     </a>
                 </div>
 
                 <!-- Mobile Navigation -->
                 <div class="flex md:hidden items-center gap-3">
-                    <a href="https://github.com/agentmessaging/agent-actions#readme" class="px-3 py-2 rounded bg-emerald-500 text-slate-900 font-bold text-xs tracking-wide" target="_blank">START</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro#readme" class="px-3 py-2 rounded bg-cyan-500 text-slate-900 font-bold text-xs tracking-wide" target="_blank">START</a>
                     <button class="hamburger bg-transparent border-0 cursor-pointer p-2 flex flex-col gap-1.5 z-[1001]" id="hamburger" aria-label="Toggle menu">
                         <span></span>
                         <span></span>
@@ -301,13 +300,12 @@
 
             <!-- Mobile Menu -->
             <div class="mobile-menu hidden absolute top-full left-0 right-0 bg-slate-900 border-b border-slate-800 py-4" id="mobile-menu">
-                <a href="#why" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">Why AAP</a>
-                <a href="#how-it-works" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">How It Works</a>
-                <a href="#data-driven" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">Data-Driven Canvas</a>
-                <a href="#specification" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">Specification</a>
-                <a href="#plugin" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">Claude Code Plugin</a>
-                <a href="https://github.com/agentmessaging/agent-actions" target="_blank" class="flex items-center gap-3 px-8 py-3 text-slate-300 no-underline font-medium hover:text-emerald-400 hover:bg-slate-800/50">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                <a href="index.html#personas" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-cyan-400 hover:bg-slate-800/50">Who It's For</a>
+                <a href="index.html#features" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-cyan-400 hover:bg-slate-800/50">Features</a>
+                <a href="security.html" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-cyan-400 hover:bg-slate-800/50">Security</a>
+                <a href="index.html#quick-start" class="block px-8 py-3 text-slate-300 no-underline font-medium hover:text-cyan-400 hover:bg-slate-800/50">Get Started</a>
+                <a href="https://github.com/23blocks-OS/ai-maestro" target="_blank" class="flex items-center gap-3 px-8 py-3 text-slate-300 no-underline font-medium hover:text-cyan-400 hover:bg-slate-800/50">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
                     GitHub
                 </a>
             </div>
@@ -350,7 +348,7 @@
             <p class="text-slate-400 text-lg md:text-xl max-w-3xl mx-auto mb-10">
                 Your agents render UIs. Your users interact with them. AAP delivers those interactions &mdash; structured, stored, and ready to process.
             </p>
-            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+            <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">
                 <a href="#specification" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200 no-underline">
                     READ THE SPEC
                 </a>
@@ -359,6 +357,7 @@
                     GITHUB
                 </a>
             </div>
+            <p class="text-slate-500 text-sm">View the full spec at <a href="https://agentactions.org" target="_blank" class="text-emerald-400 hover:text-emerald-300 transition-colors">agentactions.org</a></p>
         </div>
     </section>
 
@@ -374,7 +373,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <!-- console.log scraping -->
                 <div class="bg-slate-900 border border-slate-800 rounded-xl p-6">
-                    <div class="text-3xl mb-4">📋</div>
+                    <div class="text-3xl mb-4">&#x1F4CB;</div>
                     <h3 class="font-display font-bold text-white text-lg mb-2">console.log scraping</h3>
                     <p class="text-slate-400 text-sm">Fragile, no structure, lost on refresh. Depends on browser dev tools being open.</p>
                     <span class="inline-block mt-3 text-xs text-red-400 font-mono">Brittle</span>
@@ -382,7 +381,7 @@
 
                 <!-- Polling the DOM -->
                 <div class="bg-slate-900 border border-slate-800 rounded-xl p-6">
-                    <div class="text-3xl mb-4">🔄</div>
+                    <div class="text-3xl mb-4">&#x1F504;</div>
                     <h3 class="font-display font-bold text-white text-lg mb-2">Polling the DOM</h3>
                     <p class="text-slate-400 text-sm">Complex, race conditions, not sandboxed. Breaks when the HTML changes.</p>
                     <span class="inline-block mt-3 text-xs text-red-400 font-mono">Fragile</span>
@@ -390,7 +389,7 @@
 
                 <!-- Custom WebSocket -->
                 <div class="bg-slate-900 border border-slate-800 rounded-xl p-6">
-                    <div class="text-3xl mb-4">🔌</div>
+                    <div class="text-3xl mb-4">&#x1F50C;</div>
                     <h3 class="font-display font-bold text-white text-lg mb-2">Custom WebSocket</h3>
                     <p class="text-slate-400 text-sm">Over-engineered for button clicks. Security nightmare with open socket per page.</p>
                     <span class="inline-block mt-3 text-xs text-red-400 font-mono">Overkill</span>
@@ -398,7 +397,7 @@
 
                 <!-- AAP -->
                 <div class="bg-emerald-500/5 border border-emerald-500/30 rounded-xl p-6">
-                    <div class="text-3xl mb-4">🎯</div>
+                    <div class="text-3xl mb-4">&#x1F3AF;</div>
                     <h3 class="font-display font-bold text-emerald-400 text-lg mb-2">AAP</h3>
                     <p class="text-slate-300 text-sm">Structured actions via postMessage. Stored as JSON. Agent notified instantly.</p>
                     <span class="inline-block mt-3 text-xs text-emerald-400 font-mono">Just right</span>
@@ -819,17 +818,17 @@ Agent reads JSON   &larr;  File written + notification   &larr;  postMessage to 
                     <h3 class="font-display text-xl font-bold text-white mb-4">Relationship to AMP &amp; AID</h3>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                         <div class="text-center">
-                            <div class="text-3xl mb-2">🎯</div>
+                            <div class="text-3xl mb-2">&#x1F3AF;</div>
                             <h4 class="font-display font-bold text-emerald-400 mb-1">AAP</h4>
                             <p class="text-slate-400 text-xs">User &rarr; Agent<br>UI interactions</p>
                         </div>
                         <div class="text-center">
-                            <div class="text-3xl mb-2">📬</div>
+                            <div class="text-3xl mb-2">&#x1F4EC;</div>
                             <h4 class="font-display font-bold text-purple-400 mb-1">AMP</h4>
                             <p class="text-slate-400 text-xs">Agent &rarr; Agent<br>Signed messages</p>
                         </div>
                         <div class="text-center">
-                            <div class="text-3xl mb-2">🔑</div>
+                            <div class="text-3xl mb-2">&#x1F511;</div>
                             <h4 class="font-display font-bold text-green-400 mb-1">AID</h4>
                             <p class="text-slate-400 text-xs">Agent identity<br>Cryptographic auth</p>
                         </div>
@@ -951,38 +950,39 @@ git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
                 Open protocol. MIT licensed. Works with any agent dashboard.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                <a href="https://github.com/agentmessaging/agent-actions#readme" target="_blank" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200 no-underline">
-                    GET STARTED FREE
+                <a href="https://agentactions.org" target="_blank" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-emerald-500 text-slate-900 font-bold text-sm tracking-wide hover:bg-emerald-400 transition-all duration-200 no-underline">
+                    FULL SPEC AT AGENTACTIONS.ORG
                 </a>
-                <a href="https://ai-maestro.23blocks.com" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-slate-800 text-white font-bold text-sm tracking-wide hover:bg-slate-700 transition-all duration-200 no-underline border border-slate-700">
-                    AI MAESTRO
+                <a href="https://github.com/23blocks-OS/ai-maestro#readme" target="_blank" class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-lg bg-slate-800 text-white font-bold text-sm tracking-wide hover:bg-slate-700 transition-all duration-200 no-underline border border-slate-700">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    AI MAESTRO ON GITHUB
                 </a>
             </div>
         </div>
     </section>
 
-    <!-- Footer -->
+    <!-- Footer (AI Maestro standard) -->
     <footer class="py-16 pb-8 bg-slate-950 border-t border-slate-800 px-4 md:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-12 mb-12">
                 <div>
                     <div class="flex items-center gap-3 mb-4">
-                        <span class="text-2xl">🎯</span>
+                        <img src="logo-constellation.svg" alt="AI Maestro" class="w-8 h-8">
                         <span class="font-display font-bold text-lg text-white">AI MAESTRO</span>
                     </div>
-                    <p class="text-slate-400 text-sm">The OS for AI-first organizations. Orchestrate any AI agent with persistent memory, messaging, and multi-machine support.</p>
+                    <p class="text-slate-400 text-sm">The future of work is here. Orchestrate multiple AI coding agents from one dashboard.</p>
                 </div>
                 <div>
-                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">PROTOCOLS</h4>
-                    <a href="https://agentactions.org" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">AAP &mdash; Agent Actions Protocol</a>
-                    <a href="https://agentmessaging.org" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">AMP &mdash; Agent Messaging Protocol</a>
-                    <a href="https://agentids.org" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">AID &mdash; Agent Identity Protocol</a>
-                    <a href="https://github.com/agentmessaging/agent-actions" class="block text-slate-400 no-underline mb-2 hover:text-emerald-400 transition-colors text-sm">GitHub</a>
+                    <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">LINKS</h4>
+                    <a href="https://github.com/23blocks-OS/ai-maestro" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">GitHub</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro/issues" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">Issues</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro/blob/main/CONTRIBUTING.md" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">Contributing</a>
+                    <a href="https://github.com/23blocks-OS/ai-maestro/blob/main/LICENSE" class="block text-slate-400 no-underline mb-2 hover:text-cyan-400 transition-colors text-sm">License (MIT)</a>
                 </div>
                 <div>
                     <h4 class="font-mono text-xs text-slate-500 tracking-widest mb-4">BUILT BY</h4>
                     <p class="text-slate-400 text-sm mb-2">
-                        <a href="https://x.com/jkpelaez" target="_blank" class="text-white hover:text-emerald-400 transition-colors">Juan Pel&aacute;ez</a> @ <a href="https://23blocks.com" target="_blank" class="text-white hover:text-emerald-400 transition-colors">23blocks</a>
+                        <a href="https://x.com/jkpelaez" target="_blank" class="text-white hover:text-cyan-400 transition-colors">Juan Pel&aacute;ez</a> @ <a href="https://23blocks.com" target="_blank" class="text-white hover:text-cyan-400 transition-colors">23blocks</a>
                     </p>
                     <p class="text-slate-500 text-xs">Made with <span class="text-red-500">&#9829;</span> in Boulder, Colorado</p>
                     <p class="text-slate-500 text-xs mt-1">Coded with Claude</p>
@@ -1016,16 +1016,6 @@ git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
     </script>
 
     <!-- Copy for AI functionality -->
-    <script>
-    function copyForAI() {
-        const text = document.body.innerText;
-        navigator.clipboard.writeText(text).then(() => {
-            const btn = document.querySelector('[onclick="copyForAI()"]');
-            const original = btn.innerHTML;
-            btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> COPIED';
-            setTimeout(() => { btn.innerHTML = original; }, 2000);
-        });
-    }
-    </script>
+    <script src="copy-for-ai.js"></script>
 </body>
 </html>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.18",
+  "version": "0.35.19",
   "releaseDate": "2026-05-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Rewrote `docs/agent-actions.html` to use AI Maestro standard nav/footer instead of standalone AAP branding
- Nav now matches messaging.html: AI Maestro logo, cyan accent, standard site links (WHO IT'S FOR, FEATURES, SECURITY, GET STARTED)
- Footer replaced with AI Maestro standard footer (GitHub, Issues, Contributing, License, Juan Pelaez @ 23blocks)
- Meta tags updated: canonical URL, OG, Twitter cards all point to ai-maestro.23blocks.com

## Test plan
- [ ] Open ai-maestro.23blocks.com/agent-actions.html — nav and footer match other pages
- [ ] Mobile hamburger menu works
- [ ] All nav links resolve correctly
- [ ] `yarn test` passes (792/792)
- [ ] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)