### PR TITLE
fix: mesh host cache desync causing lost agents and broken WebSocket routing (v0.35.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.21] - 2026-05-19
+
+### Fixed
+- **Mesh host cache desync causing lost agents** — The `.mjs` host config module cached hosts forever and filtered disabled hosts at the cache level. When the circuit breaker disabled a host or a host was re-enabled, `server.mjs` never learned about it, causing persistent "Host not found" errors and broken terminal connections for remote agents (e.g., mini-lola).
+- **Cross-module cache invalidation** — When the circuit breaker writes to `hosts.json`, both the TypeScript and ESM host config caches are now cleared via a `globalThis` bridge. Previously only the `.ts` cache was invalidated, leaving `server.mjs` with stale data until restart.
+- **AMP messages silently routing to disabled hosts** — `message-send.ts` now rejects routing to disabled hosts with a clear error instead of silently timing out.
+- **AMP mesh auth trusting disabled hosts** — Disabled forwarding hosts no longer receive automatic authentication trust in `amp-service.ts`.
+- **Dead code in websocket-proxy.mjs** — Replaced `host.type === 'local'` (never triggers, property not set in ESM module) with `isSelf(host.id)`.
+- **Frontend AbortError cascade** — `useAgents.ts` now skips disabled hosts entirely, preventing timeout-triggered React re-render storms.
+
+### Added
+- **TTL cache for host config (30s)** — `hosts-config-server.mjs` re-reads `hosts.json` every 30 seconds instead of caching forever. Hosts re-enabled by sync or manual edit are picked up automatically without server restart.
+- **Disabled host visibility in getHostById** — `getHostById()` now finds disabled hosts so callers can give proper error messages ("host is disabled") instead of generic "host not found". `getHosts()` still returns only enabled hosts for backward compatibility.
+
 ## [Unreleased]
 
 ### Added

--- a/hooks/useAgents.ts
+++ b/hooks/useAgents.ts
@@ -224,8 +224,12 @@ export function useAgents() {
     try {
       setError(null)
 
-      const localHosts = hosts.filter(h => h.isSelf || isLocalhostUrl(h.url))
-      const remoteHosts = hosts.filter(h => !h.isSelf && !isLocalhostUrl(h.url))
+      // Skip disabled hosts entirely — they're offline/unreachable and fetching
+      // from them causes timeouts, AbortErrors, and React re-render cascades
+      const enabledHosts = hosts.filter(h => h.enabled !== false)
+
+      const localHosts = enabledHosts.filter(h => h.isSelf || isLocalhostUrl(h.url))
+      const remoteHosts = enabledHosts.filter(h => !h.isSelf && !isLocalhostUrl(h.url))
 
       // Fetch local host first (fast) so the UI can render immediately
       const localResults = await Promise.all(
@@ -259,7 +263,8 @@ export function useAgents() {
       // Log summary
       const successCount = allResults.filter(r => r.success).length
       const fromCacheCount = allResults.filter(r => r.fromCache).length
-      console.log(`[useAgents] Loaded ${allAgents.length} agent(s) from ${successCount}/${hosts.length} host(s) (${fromCacheCount} from cache)`)
+      const disabledCount = hosts.length - enabledHosts.length
+      console.log(`[useAgents] Loaded ${allAgents.length} agent(s) from ${successCount}/${enabledHosts.length} host(s)${disabledCount > 0 ? ` (${disabledCount} disabled, skipped)` : ''}${fromCacheCount > 0 ? ` (${fromCacheCount} from cache)` : ''}`)
 
     } catch (err) {
       console.error('[useAgents] Failed to load agents:', err)

--- a/lib/hosts-config-server.mjs
+++ b/lib/hosts-config-server.mjs
@@ -157,6 +157,9 @@ function getDefaultSelfHost() {
 }
 
 let cachedHosts = null
+let cacheTimestamp = 0
+let hasLoggedInitialLoad = false
+const CACHE_TTL = 30000 // 30 seconds — re-read hosts.json periodically
 
 /**
  * Migrate and normalize host config
@@ -186,7 +189,8 @@ function migrateHost(host) {
  * Load hosts configuration
  */
 export function loadHostsConfig() {
-  if (cachedHosts !== null) {
+  const now = Date.now()
+  if (cachedHosts !== null && (now - cacheTimestamp) < CACHE_TTL) {
     return cachedHosts
   }
 
@@ -198,7 +202,7 @@ export function loadHostsConfig() {
     try {
       const parsed = JSON.parse(envHosts)
       hosts = validateHosts(parsed)
-      console.log(`[Hosts] Loaded ${hosts.length} host(s) from ${HOSTS_ENV_VAR} environment variable`)
+      if (!hasLoggedInitialLoad) console.log(`[Hosts] Loaded ${hosts.length} host(s) from ${HOSTS_ENV_VAR} environment variable`)
     } catch (error) {
       console.error(`[Hosts] Failed to parse ${HOSTS_ENV_VAR}:`, error)
     }
@@ -210,7 +214,7 @@ export function loadHostsConfig() {
       const fileContent = fs.readFileSync(HOSTS_CONFIG_PATH, 'utf-8')
       const config = JSON.parse(fileContent)
       hosts = validateHosts(config.hosts)
-      console.log(`[Hosts] Loaded ${hosts.length} host(s) from ${HOSTS_CONFIG_PATH}`)
+      if (!hasLoggedInitialLoad) console.log(`[Hosts] Loaded ${hosts.length} host(s) from ${HOSTS_CONFIG_PATH}`)
     } catch (error) {
       console.error(`[Hosts] Failed to load hosts config from file:`, error)
     }
@@ -223,6 +227,8 @@ export function loadHostsConfig() {
   }
 
   cachedHosts = hosts
+  cacheTimestamp = Date.now()
+  hasLoggedInitialLoad = true
   return hosts
 }
 
@@ -230,12 +236,14 @@ export function loadHostsConfig() {
  * Validate and migrate hosts configuration
  */
 function validateHosts(hosts) {
-  // Migrate and filter
+  // Migrate hosts (normalize IDs, etc.) but keep ALL hosts including disabled.
+  // Callers (getHosts, getPeerHosts) filter by enabled status themselves.
+  // This allows getHostById to find disabled hosts and give proper error messages
+  // instead of "Host not found" when a host is temporarily disabled by circuit breaker.
   const migratedHosts = hosts.map(migrateHost)
-  const enabledHosts = migratedHosts.filter(host => host.enabled !== false)
 
   // Validate required fields (type is no longer required)
-  const validHosts = enabledHosts.filter(host => {
+  const validHosts = migratedHosts.filter(host => {
     if (!host.id || !host.name || !host.url) {
       console.warn(`[Hosts] Skipping invalid host config:`, host)
       return false
@@ -243,8 +251,8 @@ function validateHosts(hosts) {
     return true
   })
 
-  // Ensure self host exists
-  const hasSelfHost = validHosts.some(host => isSelf(host.id))
+  // Ensure self host exists (among enabled hosts)
+  const hasSelfHost = validHosts.some(host => isSelf(host.id) && host.enabled !== false)
   if (!hasSelfHost) {
     validHosts.unshift(getDefaultSelfHost())
     console.log('[Hosts] Added default self host')
@@ -254,17 +262,18 @@ function validateHosts(hosts) {
 }
 
 /**
- * Get all hosts
+ * Get all enabled hosts (filters out disabled hosts)
  */
 export function getHosts() {
-  return loadHostsConfig()
+  return loadHostsConfig().filter(h => h.enabled !== false)
 }
 
 /**
- * Get host by ID
+ * Get host by ID (searches ALL hosts including disabled)
+ * Callers should check host.enabled if they need to handle disabled hosts differently
  */
 export function getHostById(hostId) {
-  const hosts = getHosts()
+  const hosts = loadHostsConfig() // All hosts including disabled
   // Also check for legacy 'local' ID
   if (hostId === 'local') {
     return hosts.find(host => isSelf(host.id))
@@ -309,7 +318,15 @@ export function getRemoteHosts() {
  */
 export function clearHostsCache() {
   cachedHosts = null
+  cacheTimestamp = 0
+  hasLoggedInitialLoad = false
 }
+
+// Expose for cross-module cache invalidation.
+// The TypeScript twin (hosts-config.ts) has its own separate cache that gets
+// cleared by saveHosts()/updateHostRaw(). It calls this via globalThis so the
+// .mjs cache also gets invalidated (no stale data window).
+globalThis._clearMjsHostsCache = clearHostsCache
 
 /**
  * Save hosts configuration to file.

--- a/lib/hosts-config.ts
+++ b/lib/hosts-config.ts
@@ -622,6 +622,13 @@ export function getRemoteHosts(): Host[] {
 export function clearHostsCache(): void {
   cachedHosts = null
   loadStoredSelfAliases()
+
+  // Also clear the .mjs twin's cache. Both modules cache hosts.json independently
+  // (different module systems), so when the .ts side writes hosts.json (circuit
+  // breaker, sync, manual edit), the .mjs side must also invalidate.
+  if (typeof (globalThis as any)._clearMjsHostsCache === 'function') {
+    ;(globalThis as any)._clearMjsHostsCache()
+  }
 }
 
 /**

--- a/lib/message-send.ts
+++ b/lib/message-send.ts
@@ -162,7 +162,7 @@ export async function sendFromUI(options: SendFromUIOptions): Promise<{ message:
     isFromVerified = true
   } else if (options.fromHost && !isSelf(options.fromHost)) {
     const remoteFromHost = getHostById(options.fromHost)
-    isFromVerified = !!remoteFromHost
+    isFromVerified = !!remoteFromHost && remoteFromHost.enabled !== false
   } else {
     isFromVerified = false
   }
@@ -245,6 +245,9 @@ export async function sendFromUI(options: SendFromUIOptions): Promise<{ message:
     const remoteHost = getHostById(targetHostId)
     if (!remoteHost) {
       throw new Error(`Target host '${targetHostId}' not found. Ensure the host is registered in ~/.aimaestro/hosts.json`)
+    }
+    if (remoteHost.enabled === false) {
+      throw new Error(`Target host '${targetHostId}' is disabled (${(remoteHost as any).offlineReason || 'circuit breaker'}). Re-enable or wait for it to come back online.`)
     }
     recipientIsRemote = true
     remoteHostUrl = remoteHost.url
@@ -438,6 +441,9 @@ export async function forwardFromUI(options: ForwardFromUIOptions): Promise<{ me
     const remoteHost = getHostById(targetHostId)
     if (!remoteHost) {
       throw new Error(`Target host '${targetHostId}' not found. Ensure the host is registered in ~/.aimaestro/hosts.json`)
+    }
+    if (remoteHost.enabled === false) {
+      throw new Error(`Target host '${targetHostId}' is disabled (${(remoteHost as any).offlineReason || 'circuit breaker'}). Re-enable or wait for it to come back online.`)
     }
     recipientIsRemote = true
     remoteHostUrl = remoteHost.url

--- a/lib/websocket-proxy.mjs
+++ b/lib/websocket-proxy.mjs
@@ -6,7 +6,7 @@
  */
 
 import WebSocket from 'ws'
-import { getHostById } from './hosts-config-server.mjs'
+import { getHostById, isSelf } from './hosts-config-server.mjs'
 
 /**
  * Create a WebSocket proxy connection to a remote host
@@ -24,7 +24,7 @@ export function createRemoteProxy(clientWs, sessionName, hostId) {
     return
   }
 
-  if (host.type === 'local') {
+  if (isSelf(host.id)) {
     console.error(`[WS-Proxy] Attempted to proxy to local host: ${hostId}`)
     clientWs.close(1008, 'Cannot proxy to local host')
     return

--- a/server.mjs
+++ b/server.mjs
@@ -1451,6 +1451,10 @@ async function startServer(handleRequest) {
           return
         }
 
+        if (host.enabled === false) {
+          console.warn(`🌐 [REMOTE] Host disabled, attempting anyway: ${query.host} (${host.offlineReason || 'no reason'})`)
+        }
+
         // Use isSelf() to determine if this is a local or remote host
         // This is more reliable than checking host.type which may be undefined
         if (!isSelf(host.id)) {

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -768,7 +768,7 @@ export async function routeMessage(
 
     if (!auth.authenticated && forwardedFrom) {
       const forwardingHost = getHostById(forwardedFrom)
-      if (forwardingHost) {
+      if (forwardingHost && forwardingHost.enabled !== false) {
         auth = {
           authenticated: true,
           agentId: `mesh-${forwardedFrom}`,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.19",
+  "version": "0.35.21",
   "releaseDate": "2026-05-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

- **Root cause**: `hosts-config-server.mjs` cached hosts forever and filtered disabled hosts at cache level. When circuit breaker disabled a host or a host was re-enabled, `server.mjs` never learned about it — causing "Host not found" errors and broken terminal connections for remote agents.
- Adds 30-second TTL cache to `.mjs` host config module (was infinite)
- Cross-clears `.mjs` cache when `.ts` module writes `hosts.json` via `globalThis` bridge
- `getHostById()` now finds disabled hosts for proper error messages; `getHosts()` still returns only enabled
- AMP message routing rejects disabled hosts with clear error instead of silent timeout
- AMP mesh auth no longer trusts disabled forwarding hosts (security fix)
- `websocket-proxy.mjs`: replaced dead `host.type === 'local'` with `isSelf(host.id)`
- Frontend `useAgents.ts` skips disabled hosts in fetch loop (prevents AbortError + React re-render cascade)

## Test plan
- [x] `yarn test` — 792/792 pass
- [x] `yarn build` — clean production build
- [x] Deployed via `pm2 restart ai-maestro` — server starts, loads 4 hosts (includes disabled), routes remote connections correctly
- [x] mac-mini and mini-lola agents accessible from dashboard
- [x] No "Host not found" errors in server logs for known hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)