### PR TITLE
fix: chat not refreshing — polling fallback + duplicate fix (v0.35.22)

### DIFF
--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -194,6 +194,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               setMessages(history.messages || [])
               setHookState(history.hookState || null)
               setLastModified(history.lastModified || null)
+              setPendingMessages([]) // Clear pending — full history includes sent messages
               hasLoadedRef.current = true
               setIsLoading(false)
               break
@@ -304,6 +305,23 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
   }, [isActive])
+
+  // Poll for updates every 3s while on the chat tab.
+  // The WebSocket push (JSONL watcher + hookState broadcast) is unreliable in
+  // the browser — connections silently drop. Polling chat:requestHistory through
+  // the existing WS is lightweight (server re-reads the JSONL) and guarantees
+  // both new messages and permission prompts arrive.
+  useEffect(() => {
+    if (!isActive) return
+
+    const interval = setInterval(() => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify({ type: 'chat:requestHistory', agentId: agent.id }))
+      }
+    }, 3000)
+
+    return () => clearInterval(interval)
+  }, [isActive, agent.id])
 
   // Auto-scroll to bottom when new messages or pending messages arrive
   useEffect(() => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.21",
+  "version": "0.35.22",
   "releaseDate": "2026-05-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Chat was not auto-refreshing: messages and permission prompts only appeared after switching tabs
- Root cause: WebSocket push from server (JSONL watcher + hookState broadcast) silently fails to reach the browser
- Added 3-second polling of `chat:requestHistory` through the existing WebSocket as a reliable fallback
- Fixed duplicate messages: pending messages weren't cleared when full history arrived via polling

## Test plan
- [ ] Send a chat message — response should appear within 3s without tab switching
- [ ] Verify sent messages appear only once (no duplicates)
- [ ] Test permission prompts appear in chat when Claude requests approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)