### PR TITLE
fix: remove chat polling, restore clean WebSocket push architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.23] - 2026-05-19
+
+### Fixed
+- **Chat: remove 3s polling, restore pure WebSocket push** — Eliminated the `chat:requestHistory` polling interval that was causing pending message flicker, unnecessary server load, and premature clearing of sent message bubbles. Chat now relies entirely on the server's JSONL watcher push (`chat:messages`) and hook state broadcast (`chat:hookState`).
+- **Chat: smart pending message clearing** — Pending "sent" bubbles are no longer blindly wiped on every WebSocket event. `chat:messages` only clears pending when the incoming JSONL data contains a user message matching the pending text. `chat:hookState` no longer clears pending at all. `chat:history` only clears on initial load.
+- **Chat: auto-scroll tracking** — Fixed auto-scroll using UUID-based tracking instead of message count (which was always 200 after the server cap, making `hasNewMessages` permanently false).
+
 ## [0.35.21] - 2026-05-19
 
 ### Fixed

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -121,8 +121,8 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
 
   // Track if we've done initial load
   const hasLoadedRef = useRef(false)
-  // Track previous message count for scroll behavior
-  const prevMessageCountRef = useRef(0)
+  // Track last message ID for scroll behavior
+  const prevLastMsgIdRef = useRef<string | null>(null)
 
   // Persist chat mode
   const toggleChatMode = () => {
@@ -191,10 +191,14 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
           switch (data.type) {
             case 'chat:history': {
               const history = data.data || {}
-              setMessages(history.messages || [])
+              const newMessages = history.messages || []
+              setMessages(newMessages)
               setHookState(history.hookState || null)
               setLastModified(history.lastModified || null)
-              setPendingMessages([]) // Clear pending — full history includes sent messages
+              // Only clear pending on initial load (server history includes sent msgs)
+              if (!hasLoadedRef.current) {
+                setPendingMessages([])
+              }
               hasLoadedRef.current = true
               setIsLoading(false)
               break
@@ -213,8 +217,22 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                   if (uniqueNew.length === 0) return prev
                   return [...prev, ...uniqueNew].slice(-200) // Keep last 200
                 })
-                // Clear pending messages when new activity arrives
-                setPendingMessages([])
+                // Only clear pending when a user message appears that matches what we sent
+                const incomingUserMsgs = newMsgs.filter((m: Message) => m.type === 'user')
+                if (incomingUserMsgs.length > 0) {
+                  setPendingMessages(prev => {
+                    if (prev.length === 0) return prev
+                    const lastUserText = (() => {
+                      const last = incomingUserMsgs[incomingUserMsgs.length - 1]
+                      const content = last?.message?.content
+                      if (typeof content === 'string') return content
+                      if (Array.isArray(content)) return content.map((b: any) => b.text || '').join('')
+                      return ''
+                    })()
+                    const matched = prev.some(p => lastUserText.includes(p.text))
+                    return matched ? [] : prev
+                  })
+                }
               }
               break
             }
@@ -223,8 +241,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               // Real-time hook state update (permission requests, status changes)
               const newState = data.data || null
               setHookState(newState)
-              // Clear pending when hookState changes (message was processed)
-              setPendingMessages([])
+              // Don't clear pending here — let chat:messages confirm with content match
               break
             }
 
@@ -306,31 +323,15 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
   }, [isActive])
 
-  // Poll for updates every 3s while on the chat tab.
-  // The WebSocket push (JSONL watcher + hookState broadcast) is unreliable in
-  // the browser — connections silently drop. Polling chat:requestHistory through
-  // the existing WS is lightweight (server re-reads the JSONL) and guarantees
-  // both new messages and permission prompts arrive.
-  useEffect(() => {
-    if (!isActive) return
-
-    const interval = setInterval(() => {
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify({ type: 'chat:requestHistory', agentId: agent.id }))
-      }
-    }, 3000)
-
-    return () => clearInterval(interval)
-  }, [isActive, agent.id])
-
   // Auto-scroll to bottom when new messages or pending messages arrive
   useEffect(() => {
     if (messages.length === 0 && pendingMessages.length === 0) return
 
-    const hasNewMessages = messages.length > prevMessageCountRef.current
-    const isInitialLoad = prevMessageCountRef.current === 0
-
-    prevMessageCountRef.current = messages.length
+    const lastMsg = messages[messages.length - 1]
+    const lastId = lastMsg?.uuid || lastMsg?.timestamp || null
+    const isInitialLoad = prevLastMsgIdRef.current === null
+    const hasNewMessages = lastId !== prevLastMsgIdRef.current
+    prevLastMsgIdRef.current = lastId
 
     // Scroll on initial load (instant) or new messages/pending messages (smooth)
     if (isInitialLoad) {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.22",
-  "releaseDate": "2026-05-19",
+  "version": "0.35.23",
+  "releaseDate": "2026-05-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- **Removed 3s chat polling** — the `chat:requestHistory` interval was a bandaid that caused pending message flicker and unnecessary server load
- **Smart pending message clearing** — sent bubbles only clear when JSONL confirms the user's message text, not on every WS event
- **Fixed auto-scroll** — UUID-based tracking instead of message count (which was always 200 after server cap)

The chat now relies entirely on the server's JSONL watcher push (`chat:messages`) and hook state broadcast (`chat:hookState`), which is the architecturally sound approach.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — 792/792 pass
- [ ] Send message in chat — pending bubble stays until response appears
- [ ] Agent response appears via WebSocket push (no polling)
- [ ] Auto-scroll works when new messages arrive
- [ ] Permission prompts still appear in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)