### PR TITLE
fix: bash 3.2 compat — aimaestro-agent.sh list works on macOS (v0.35.25)

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.24",
+  "version": "0.35.25",
   "releaseDate": "2026-05-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- Update plugin submodule with `declare -g` → plain assignment fix in `agent-helper.sh`
- `aimaestro-agent.sh list` (and all other commands) now work on macOS default bash 3.2

## Test plan
- [x] `aimaestro-agent.sh list 2>/dev/null` — lists all agents
- [x] `yarn test` — 792/792 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)