### PR TITLE
fix: chat hookState, overflow, and duplicate messages (v0.35.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.26] - 2026-05-20
+
+### Fixed
+- **Chat: hookState/permission prompts not appearing** — The hook's agent resolution used `find()` on `/api/agents` by working directory, which returned the wrong agent when multiple agents share the same cwd. Now uses a 3-tier resolution: (1) `AIM_AGENT_ID`/`AIM_AGENT_NAME` env vars, (2) `/api/sessions` for active tmux sessions, (3) fallback cwd match. Server-side `broadcastActivityUpdate` also tries agentId-based session lookup when the primary sessionName has no chat clients.
+- **Chat: messages overflowing viewport** — Long messages broke out of chat bubbles. Added `min-w-0 overflow-hidden` on bubble containers, `max-w-full` on code blocks, and `overflow-wrap: anywhere` on paragraphs.
+- **Chat: duplicate pending messages** — Sent message appeared twice (pending + real) because the `hadNew` flag was set inside React's deferred `setMessages` callback and was always false when checked synchronously. Fixed by clearing pending unconditionally on new JSONL data.
+
 ## [0.35.24] - 2026-05-20
 
 ### Fixed

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -210,23 +210,17 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               // Incremental new messages from JSONL watcher (only fires on real file changes)
               const newMsgs = data.data || []
               if (newMsgs.length > 0) {
-                let hadNew = false
                 setMessages(prev => {
-                  // Deduplicate by uuid/timestamp
                   const existingUuids = new Set(prev.map(m => m.uuid).filter(Boolean))
                   const uniqueNew = newMsgs.filter((m: Message) =>
                     !m.uuid || !existingUuids.has(m.uuid)
                   )
                   if (uniqueNew.length === 0) return prev
-                  hadNew = true
-                  return [...prev, ...uniqueNew].slice(-200) // Keep last 200
+                  return [...prev, ...uniqueNew].slice(-200)
                 })
-                // Any genuinely new messages means the agent moved past our input.
-                // Safe to clear because chat:messages only fires on JSONL file changes
-                // (no polling), so this won't prematurely wipe pending bubbles.
-                if (hadNew) {
-                  setPendingMessages([])
-                }
+                // New JSONL data means the agent moved past our input — clear pending.
+                // Safe because chat:messages only fires on real file changes (no polling).
+                setPendingMessages([])
               }
               break
             }
@@ -751,7 +745,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               key={message.uuid || index}
               className={`flex ${(isUser || isQueued) ? 'justify-end' : 'justify-start'} ${isGrouped ? '!mt-1' : ''}`}
             >
-              <div className={`max-w-[85%] ${(isUser || isQueued) ? 'order-1' : ''}`}>
+              <div className={`max-w-[85%] min-w-0 overflow-hidden ${(isUser || isQueued) ? 'order-1' : ''}`}>
                 {/* Message bubble */}
                 <div
                   className={`rounded-2xl px-4 py-3 ${

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -73,11 +73,11 @@ function CopyButton({ text, className = '' }: { text: string; className?: string
 // Code block with copy button
 function CodeBlock({ code }: { code: string }) {
   return (
-    <div className="relative group my-1">
+    <div className="relative group my-1 overflow-hidden">
       <div className="absolute top-1 right-1 z-10">
         <CopyButton text={code} />
       </div>
-      <pre className="bg-gray-900 rounded-md px-3 py-2 pr-9 overflow-x-auto text-xs font-mono text-gray-200 select-text">
+      <pre className="bg-gray-900 rounded-md px-3 py-2 pr-9 overflow-x-auto max-w-full text-xs font-mono text-gray-200 select-text">
         {code}
       </pre>
     </div>
@@ -126,7 +126,7 @@ function renderMarkdown(text: string): JSX.Element {
     // Regular line
     if (line.trim()) {
       elements.push(
-        <p key={i} className="whitespace-pre-wrap">
+        <p key={i} className="whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>
           {renderInline(line)}
         </p>
       )
@@ -354,19 +354,15 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
             case 'chat:messages': {
               const newMsgs = data.data || []
               if (newMsgs.length > 0) {
-                let hadNew = false
                 setMessages(prev => {
                   const existingUuids = new Set(prev.map(m => m.uuid).filter(Boolean))
                   const uniqueNew = newMsgs.filter((m: ChatMessage) =>
                     !m.uuid || !existingUuids.has(m.uuid)
                   )
                   if (uniqueNew.length === 0) return prev
-                  hadNew = true
                   return [...prev, ...uniqueNew].slice(-200)
                 })
-                if (hadNew) {
-                  setPendingMessages([])
-                }
+                setPendingMessages([])
               }
               break
             }
@@ -662,8 +658,8 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
                       ))}
                     </div>
                   )}
-                  <div className="max-w-[90%] relative">
-                    <div className="px-3 py-2 rounded-2xl rounded-bl-sm bg-gray-800 text-gray-200 text-sm select-text">
+                  <div className="max-w-[90%] min-w-0 overflow-hidden relative">
+                    <div className="px-3 py-2 rounded-2xl rounded-bl-sm bg-gray-800 text-gray-200 text-sm select-text overflow-hidden">
                       {renderMarkdown(text)}
                     </div>
                     <div className="flex justify-end mt-0.5 mr-1">

--- a/components/chat/MarkdownRenderer.tsx
+++ b/components/chat/MarkdownRenderer.tsx
@@ -43,7 +43,7 @@ function CopyButton({ text, className = '' }: { text: string; className?: string
 
 function CodeBlock({ code, language }: { code: string; language?: string }) {
   return (
-    <div className="relative group my-1">
+    <div className="relative group my-1 overflow-hidden">
       <div className="absolute top-1 right-1 z-10 flex items-center gap-1">
         {language && (
           <span className="text-[10px] text-gray-500 bg-gray-800 px-1.5 py-0.5 rounded">
@@ -52,7 +52,7 @@ function CodeBlock({ code, language }: { code: string; language?: string }) {
         )}
         <CopyButton text={code} />
       </div>
-      <pre className="bg-gray-900 rounded-md px-3 py-2 pr-9 overflow-x-auto text-xs font-mono text-gray-200 select-text">
+      <pre className="bg-gray-900 rounded-md px-3 py-2 pr-9 overflow-x-auto max-w-full text-xs font-mono text-gray-200 select-text">
         {code}
       </pre>
     </div>
@@ -162,7 +162,7 @@ function renderMarkdown(text: string): JSX.Element {
     // Regular line
     if (line.trim()) {
       elements.push(
-        <p key={i} className="whitespace-pre-wrap">
+        <p key={i} className="whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>
           {renderInline(line)}
         </p>
       )
@@ -181,5 +181,5 @@ function renderMarkdown(text: string): JSX.Element {
 }
 
 export function MarkdownContent({ text }: { text: string }) {
-  return <div className="text-sm break-words">{renderMarkdown(text)}</div>
+  return <div className="text-sm break-words overflow-hidden min-w-0">{renderMarkdown(text)}</div>
 }

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -33,7 +33,7 @@ import { getHosts, getSelfHost, isSelf, getHostById } from '@/lib/hosts-config'
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
 import { parseNameForDisplay, isCallSession } from '@/types/agent'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
-import { sessionActivity, agentActivity, broadcastStatusUpdate, broadcastChatEvent } from '@/services/shared-state'
+import { sessionActivity, agentActivity, terminalSessions, broadcastStatusUpdate, broadcastChatEvent } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
 import crypto from 'crypto'
 import { type ServiceResult, missingField, notFound, alreadyExists, invalidField, operationFailed, serviceError } from '@/services/service-errors'
@@ -570,8 +570,26 @@ export function broadcastActivityUpdate(
   broadcastStatusUpdate(sessionName, status, hookStatus, notificationType, agentId)
 
   // Push hookState to chat-subscribed WebSocket clients in real-time
-  if (hookState && sessionName) {
-    broadcastChatEvent(sessionName, 'chat:hookState', { data: hookState })
+  if (hookState) {
+    let delivered = false
+    // Try the provided sessionName first
+    if (sessionName) {
+      const session = terminalSessions.get(sessionName)
+      const chatClients = (session as any)?.chatClients as Set<import('ws').WebSocket> | undefined
+      if (chatClients && chatClients.size > 0) {
+        broadcastChatEvent(sessionName, 'chat:hookState', { data: hookState })
+        delivered = true
+      }
+    }
+    // Fallback: if agentId is provided and sessionName didn't deliver,
+    // resolve the agent's name and try that as the session key
+    if (!delivered && agentId) {
+      const agent = getAgent(agentId)
+      const resolvedName = agent?.name
+      if (resolvedName && resolvedName !== sessionName) {
+        broadcastChatEvent(resolvedName, 'chat:hookState', { data: hookState })
+      }
+    }
   }
 
   return { data: { success: true }, status: 200 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.25",
+  "version": "0.35.26",
   "releaseDate": "2026-05-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **hookState/permission prompts not appearing in chat**: The hook resolved the wrong agent when multiple agents share the same working directory. Now uses 3-tier resolution: AIM env vars → /api/sessions → fallback cwd match. Server also tries agentId-based session lookup as fallback.
- **Messages overflowing viewport**: Long chat messages broke out of bubble bounds. Fixed with `min-w-0 overflow-hidden` on containers, `max-w-full` on code blocks, `overflow-wrap: anywhere` on paragraphs.
- **Duplicate pending messages**: Sent message showed twice (pending + real) because React's deferred `setMessages` callback made the `hadNew` flag always false. Fixed by clearing pending unconditionally on new JSONL data.

## Test plan
- [ ] Chat permission prompts appear when agent asks for permission
- [ ] Long messages stay within viewport bounds
- [ ] Sent messages don't show duplicates while agent is thinking
- [ ] `yarn build` passes
- [ ] `yarn test` passes (792/792)

🤖 Generated with [Claude Code](https://claude.com/claude-code)