### PR TITLE
fix: auto-recovering circuit breaker + container hardening + docker stats (v0.35.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.28] - 2026-05-27
+
+### Fixed
+- **Circuit breaker permanently disabling remote hosts** — When a remote host became temporarily unreachable, the circuit breaker tripped after 3 failures and set `enabled: false` in `hosts.json`, permanently disabling the host until manual config editing + server restart. Replaced with a proper half-open circuit breaker pattern: state is now in-memory with exponential backoff (30s → 60s → 120s → 240s → 5min cap). When cooldown expires, the next UI poll probes the host automatically. Success resets everything. `hosts.json` is never modified by the circuit breaker.
+- **Reactivate endpoint rejecting circuit-broken hosts** — `/api/hosts/[id]/reactivate` only handled `enabled: false` hosts. Now also handles in-memory circuit-broken hosts (enabled but with open circuit).
+
+### Added
+- **Container hardening flags** — Agent Docker containers now launch with `--cap-drop=ALL` (selective `--cap-add` for 6 required capabilities), `--security-opt no-new-privileges`, and `--tmpfs /tmp:noexec,nosuid,size=100m`. Existing containers get these on next `/recreate`.
+- **`GET /api/docker/stats`** — New endpoint returning real-time CPU %, memory usage/limit/%, network I/O, and PID count for all running agent containers, mapped to agent IDs.
+
 ## [0.35.26] - 2026-05-20
 
 ### Fixed

--- a/app/api/docker/stats/route.ts
+++ b/app/api/docker/stats/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { getDockerStats } from '@/services/agents-docker-service'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const result = await getDockerStats()
+  return NextResponse.json(result.data, { status: result.status })
+}

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -77,36 +77,67 @@ import type { Host } from '@/types/host'
 import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed, gone, timeout } from '@/services/service-errors'
 
 // ---------------------------------------------------------------------------
-// Circuit breaker — auto-disable hosts after consecutive failures
+// Circuit breaker — half-open pattern with exponential backoff
 // ---------------------------------------------------------------------------
 
-const hostFailureCounts = new Map<string, number>()
+interface CircuitBreakerState {
+  failureCount: number
+  openUntil: number    // timestamp (ms) when to allow next probe; 0 = closed
+  backoffMs: number    // current backoff duration
+}
+
+const circuitStates = new Map<string, CircuitBreakerState>()
 const CIRCUIT_BREAKER_THRESHOLD = parseInt(process.env.CIRCUIT_BREAKER_THRESHOLD || '3', 10)
+const INITIAL_BACKOFF_MS = 30_000   // 30 seconds
+const MAX_BACKOFF_MS = 300_000      // 5 minutes
+
+export function isCircuitOpen(hostId: string): boolean {
+  const state = circuitStates.get(hostId)
+  if (!state || state.openUntil === 0) return false
+  // If cooldown expired → half-open, allow one probe
+  if (Date.now() >= state.openUntil) return false
+  return true
+}
 
 function recordHostSuccess(hostId: string): void {
-  hostFailureCounts.delete(hostId)
+  const had = circuitStates.has(hostId)
+  circuitStates.delete(hostId)
+  if (had) {
+    // Clear error metadata when recovering from circuit-broken state
+    updateHostRaw(hostId, {
+      offlineReason: undefined,
+      offlineSince: undefined,
+      lastSyncError: undefined,
+    })
+    console.log(`[Circuit Breaker] Host '${hostId}' recovered — circuit closed`)
+  }
 }
 
 function recordHostFailure(host: Host): void {
   if (isSelf(host.id)) return
 
-  const count = (hostFailureCounts.get(host.id) || 0) + 1
-  hostFailureCounts.set(host.id, count)
+  const prev = circuitStates.get(host.id) || { failureCount: 0, openUntil: 0, backoffMs: INITIAL_BACKOFF_MS }
+  const failureCount = prev.failureCount + 1
 
-  if (count >= CIRCUIT_BREAKER_THRESHOLD) {
-    console.warn(`[Circuit Breaker] Host '${host.id}' hit ${count} consecutive failures — disabling`)
+  if (failureCount >= CIRCUIT_BREAKER_THRESHOLD) {
+    const backoffMs = Math.min(prev.backoffMs * (prev.openUntil > 0 ? 2 : 1), MAX_BACKOFF_MS)
+    const openUntil = Date.now() + backoffMs
+    circuitStates.set(host.id, { failureCount, openUntil, backoffMs })
+
+    const retryInSec = Math.round(backoffMs / 1000)
+    console.warn(`[Circuit Breaker] Host '${host.id}' hit ${failureCount} consecutive failures — open for ${retryInSec}s`)
     updateHostRaw(host.id, {
-      enabled: false,
-      offlineReason: `circuit-breaker: ${count} consecutive failures`,
-      offlineSince: new Date().toISOString(),
-      lastSyncError: `Disabled after ${count} consecutive failures`,
+      offlineReason: `circuit-breaker: ${failureCount} consecutive failures (retry in ${retryInSec}s)`,
+      offlineSince: prev.openUntil > 0 ? undefined : new Date().toISOString(),
+      lastSyncError: `${failureCount} consecutive failures — auto-retry in ${retryInSec}s`,
     })
-    hostFailureCounts.delete(host.id)
+  } else {
+    circuitStates.set(host.id, { ...prev, failureCount })
   }
 }
 
 export function resetCircuitBreaker(hostId: string): void {
-  hostFailureCounts.delete(hostId)
+  circuitStates.delete(hostId)
 }
 
 interface DiscoveredSession {
@@ -1187,6 +1218,19 @@ export async function getUnifiedAgents(params: UnifiedAgentsParams): Promise<Ser
 
   // Fetch agents from all hosts in parallel
   const fetchPromises: Promise<HostFetchResult>[] = hosts.map(async (host) => {
+    // Skip hosts with open circuit breaker (cooldown not yet expired)
+    if (!isSelf(host.id) && isCircuitOpen(host.id)) {
+      const state = circuitStates.get(host.id)
+      const retryInSec = state ? Math.max(0, Math.round((state.openUntil - Date.now()) / 1000)) : 0
+      return {
+        host,
+        success: false,
+        agents: [],
+        stats: null,
+        error: `Circuit breaker open — retry in ${retryInSec}s`,
+      }
+    }
+
     try {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), timeout)

--- a/services/agents-docker-service.ts
+++ b/services/agents-docker-service.ts
@@ -1334,6 +1334,10 @@ export async function createDockerAgent(body: DockerCreateRequest): Promise<Serv
     'docker run -d',
     `--name "${containerName}"`,
     '--add-host=host.docker.internal:host-gateway',
+    '--cap-drop=ALL',
+    '--cap-add=NET_BIND_SERVICE --cap-add=SETGID --cap-add=SETUID --cap-add=CHOWN --cap-add=DAC_OVERRIDE --cap-add=FOWNER',
+    '--security-opt no-new-privileges',
+    '--tmpfs /tmp:noexec,nosuid,size=100m',
     body.autoRemove ? '' : '--restart unless-stopped',
     ...buildEnvFlags(mergedEnv),
     `-v "${workDir}:/workspace"`,
@@ -1595,5 +1599,84 @@ export async function recreateDockerAgent(
       preservedFields: RECREATE_PRESERVED_FIELDS.filter(f => (oldAgent as unknown as Record<string, unknown>)[f] !== undefined),
     },
     status: result.status,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/docker/stats — resource usage for all running agent containers
+// ---------------------------------------------------------------------------
+
+export interface ContainerStats {
+  containerName: string
+  agentId?: string
+  cpu: number         // percentage (0-100+)
+  memoryUsageMb: number
+  memoryLimitMb: number
+  memoryPercent: number
+  netInputMb: number
+  netOutputMb: number
+  pids: number
+}
+
+export async function getDockerStats(): Promise<ServiceResult<{ containers: ContainerStats[] }>> {
+  try {
+    const { stdout } = await execAsync(
+      'docker stats --no-stream --format \'{"name":"{{.Name}}","cpu":"{{.CPUPerc}}","memUsage":"{{.MemUsage}}","memPerc":"{{.MemPerc}}","netIO":"{{.NetIO}}","pids":"{{.PIDs}}"}\'',
+      { timeout: 10000 }
+    )
+
+    if (!stdout.trim()) {
+      return { data: { containers: [] }, status: 200 }
+    }
+
+    const agents = loadAgents()
+    const agentByContainer = new Map<string, string>()
+    for (const a of agents) {
+      const cn = a.deployment?.cloud?.containerName
+      if (cn) agentByContainer.set(cn, a.id)
+    }
+
+    const containers: ContainerStats[] = []
+
+    for (const line of stdout.trim().split('\n')) {
+      try {
+        const raw = JSON.parse(line)
+        if (!raw.name?.startsWith('aim-')) continue
+
+        const parseMb = (s: string): number => {
+          const m = s.match(/([\d.]+)\s*(GiB|MiB|KiB|GB|MB|KB|B)/i)
+          if (!m) return 0
+          const val = parseFloat(m[1])
+          const unit = m[2].toLowerCase()
+          if (unit === 'gib' || unit === 'gb') return val * 1024
+          if (unit === 'mib' || unit === 'mb') return val
+          if (unit === 'kib' || unit === 'kb') return val / 1024
+          return val / (1024 * 1024)
+        }
+
+        const memParts = raw.memUsage.split('/')
+        containers.push({
+          containerName: raw.name,
+          agentId: agentByContainer.get(raw.name),
+          cpu: parseFloat(raw.cpu) || 0,
+          memoryUsageMb: parseMb(memParts[0] || ''),
+          memoryLimitMb: parseMb(memParts[1] || ''),
+          memoryPercent: parseFloat(raw.memPerc) || 0,
+          netInputMb: parseMb((raw.netIO.split('/')[0]) || ''),
+          netOutputMb: parseMb((raw.netIO.split('/')[1]) || ''),
+          pids: parseInt(raw.pids, 10) || 0,
+        })
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    return { data: { containers }, status: 200 }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Unknown error'
+    if (msg.includes('not found') || msg.includes('Cannot connect')) {
+      return { data: { containers: [] }, status: 200 }
+    }
+    return operationFailed('get docker stats', msg)
   }
 }

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -144,7 +144,7 @@ import {
   controlPlayback,
 } from '@/services/agents-playback-service'
 
-import { createDockerAgent, recreateDockerAgent } from '@/services/agents-docker-service'
+import { createDockerAgent, recreateDockerAgent, getDockerStats } from '@/services/agents-docker-service'
 import { createCloudAgent, destroyCloudAgent, getCloudAgentStatus } from '@/services/agents-cloud-service'
 
 import {
@@ -427,6 +427,9 @@ const routes: Route[] = [
   }},
   { method: 'GET', pattern: /^\/api\/docker\/info$/, paramNames: [], handler: async (_req, res) => {
     sendServiceResult(res, await getDockerInfo())
+  }},
+  { method: 'GET', pattern: /^\/api\/docker\/stats$/, paramNames: [], handler: async (_req, res) => {
+    sendServiceResult(res, await getDockerStats())
   }},
   { method: 'POST', pattern: /^\/api\/conversations\/parse$/, paramNames: [], handler: async (req, res) => {
     const body = await readJsonBody(req)

--- a/services/hosts-service.ts
+++ b/services/hosts-service.ts
@@ -52,7 +52,7 @@ import type {
   HostIdentityResponse,
 } from '@/types/host-sync'
 import { type ServiceResult, missingField, invalidField, notFound, operationFailed, invalidRequest } from '@/services/service-errors'
-import { resetCircuitBreaker } from '@/services/agents-core-service'
+import { resetCircuitBreaker, isCircuitOpen } from '@/services/agents-core-service'
 
 const execAsync = promisify(exec)
 
@@ -885,6 +885,8 @@ export async function registerPeer(body: PeerRegistrationRequest): Promise<Servi
     const existingHostById = getHostById(body.host.id)
     if (existingHostById) {
       console.log(`[Host Sync] Peer ${body.host.name} (${body.host.id}) already known by ID`)
+      // Peer is alive — reset circuit breaker if it was tripped
+      resetCircuitBreaker(body.host.id)
       return {
         data: {
           success: true,
@@ -1003,26 +1005,37 @@ export async function reactivateHost(id: string): Promise<ServiceResult<{ succes
       return notFound('Host', id)
     }
 
-    if (host.enabled !== false) {
-      return invalidRequest(`Host '${id}' is already enabled`)
+    const isDisabled = host.enabled === false
+    const isCircuitBroken = isCircuitOpen(host.id)
+
+    if (!isDisabled && !isCircuitBroken) {
+      return invalidRequest(`Host '${id}' is already enabled and circuit is closed`)
     }
 
-    const result = updateHostRaw(id, {
-      enabled: true,
-      offlineReason: undefined,
-      offlineSince: undefined,
-      lastSyncError: undefined,
-    })
-
-    if (!result.success) {
-      return operationFailed('reactivate host', result.error)
+    if (isDisabled) {
+      const result = updateHostRaw(id, {
+        enabled: true,
+        offlineReason: undefined,
+        offlineSince: undefined,
+        lastSyncError: undefined,
+      })
+      if (!result.success) {
+        return operationFailed('reactivate host', result.error)
+      }
+    } else {
+      // Host is enabled but circuit-broken — just clear error metadata
+      updateHostRaw(id, {
+        offlineReason: undefined,
+        offlineSince: undefined,
+        lastSyncError: undefined,
+      })
     }
 
     resetCircuitBreaker(id)
     clearHostsCache()
 
-    console.log(`[Hosts] Reactivated circuit-broken host: ${id}`)
-    return { data: { success: true, host: result.host }, status: 200 }
+    console.log(`[Hosts] Reactivated host: ${id} (was ${isDisabled ? 'disabled' : 'circuit-broken'})`)
+    return { data: { success: true, host }, status: 200 }
   } catch (error) {
     console.error(`[Hosts] Failed to reactivate host '${id}':`, error)
     return operationFailed('reactivate host')

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.26",
-  "releaseDate": "2026-05-20",
+  "version": "0.35.28",
+  "releaseDate": "2026-05-28",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- **Circuit breaker**: Replace permanent host disabling (`enabled: false` in hosts.json) with in-memory half-open pattern. Exponential backoff 30s→5min cap, auto-recovery when cooldown expires on next UI poll. `hosts.json` is never mutated by the circuit breaker. Reactivate endpoint now handles both disabled and circuit-broken hosts.
- **Container hardening**: `docker run` now includes `--cap-drop=ALL` (selective `--cap-add` for 6 capabilities), `--security-opt no-new-privileges`, `--tmpfs /tmp:noexec,nosuid,size=100m`. Existing containers get these on next `/recreate`.
- **Docker stats endpoint**: `GET /api/docker/stats` returns real-time CPU %, memory usage/limit/%, network I/O, and PID count for all running `aim-*` containers, mapped to agent IDs.

## Test plan
- [x] `yarn test` — 792 tests pass
- [x] `yarn build` — clean production build
- [ ] Remote host goes down → after 3 failures shows offline with "retry in 30s"
- [ ] Host comes back → auto-recovers within 30s-5min on next UI poll
- [ ] `hosts.json` never gets `enabled: false` from circuit breaker
- [ ] New containers launch with hardened flags (verify with `docker inspect`)
- [ ] `GET /api/docker/stats` returns metrics for running containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)