### PR TITLE
feat: agent scheduling + fix terminal resize storm (v0.35.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.30] - 2026-05-27
+
+### Fixed
+- **Terminal resize storm causing content to jump/rewrite** — Multiple independent systems (onOpen, history-complete, ResizeObserver, notes toggle) all triggered `fit()` → resize message → PTY resize → tmux full-screen redraw simultaneously. Now: no resize on connect (PTY spawns at correct size via URL params), no resize on history-complete, resize messages gated until history is loaded, deduplicated by tracking last sent cols/rows. Only real user actions (browser window resize, notes panel toggle) trigger a resize.
+- **Tab switching causing terminal re-render** — Switching between Terminal and Chat tabs disconnected/reconnected the WebSocket, causing a full history reload + resize storm on return. WebSocket now stays connected across tab switches.
+- **ResizeObserver debounce too short** — Increased from 150ms to 300ms so CSS transitions fully settle before refitting, preventing redundant fit→resize cascades.
+
+### Added
+- **Agent scheduling system** — Cron-based task scheduling for agents. Schedules stored in `~/.aimaestro/schedules.json`, checked every 60s by a timer in server.mjs. Supports creating tmux sessions for offline agents and sending prompts via send-keys. API: `GET/POST /api/agents/{id}/schedules`, `PATCH/DELETE /api/agents/{id}/schedules/{scheduleId}`, `GET /api/schedules` (global), `POST /api/schedules/{id}/trigger` (manual/webhook). Execution history tracked per schedule.
+
 ## [0.35.28] - 2026-05-27
 
 ### Fixed

--- a/app/api/agents/[id]/schedules/[scheduleId]/route.ts
+++ b/app/api/agents/[id]/schedules/[scheduleId]/route.ts
@@ -1,0 +1,36 @@
+import { getScheduleById, updateAgentSchedule, deleteAgentSchedule, getScheduleExecutions } from '@/services/agents-schedule-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; scheduleId: string }> }
+) {
+  const { scheduleId } = await params
+  const url = new URL(request.url)
+
+  if (url.searchParams.get('executions') === 'true') {
+    const limit = parseInt(url.searchParams.get('limit') || '20', 10)
+    return toResponse(getScheduleExecutions(scheduleId, limit))
+  }
+
+  return toResponse(getScheduleById(scheduleId))
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; scheduleId: string }> }
+) {
+  const { scheduleId } = await params
+  const body = await request.json()
+  return toResponse(updateAgentSchedule(scheduleId, body))
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; scheduleId: string }> }
+) {
+  const { scheduleId } = await params
+  return toResponse(deleteAgentSchedule(scheduleId))
+}

--- a/app/api/agents/[id]/schedules/route.ts
+++ b/app/api/agents/[id]/schedules/route.ts
@@ -1,0 +1,21 @@
+import { getAgentSchedules, createAgentSchedule } from '@/services/agents-schedule-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  return toResponse(getAgentSchedules(id))
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const body = await request.json()
+  return toResponse(createAgentSchedule(id, body))
+}

--- a/app/api/schedules/[scheduleId]/trigger/route.ts
+++ b/app/api/schedules/[scheduleId]/trigger/route.ts
@@ -1,0 +1,22 @@
+import { triggerSchedule } from '@/services/agents-schedule-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ scheduleId: string }> }
+) {
+  const { scheduleId } = await params
+  let triggeredBy: 'manual' | 'webhook' = 'manual'
+
+  try {
+    const body = await request.json()
+    if (body.triggeredBy === 'webhook') triggeredBy = 'webhook'
+  } catch {
+    // No body or invalid JSON — default to manual
+  }
+
+  const result = await triggerSchedule(scheduleId, triggeredBy)
+  return toResponse(result)
+}

--- a/app/api/schedules/route.ts
+++ b/app/api/schedules/route.ts
@@ -1,0 +1,15 @@
+import { getAllSchedules, getAllExecutions } from '@/services/agents-schedule-service'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+
+  if (url.searchParams.get('executions') === 'true') {
+    const limit = parseInt(url.searchParams.get('limit') || '50', 10)
+    return toResponse(getAllExecutions(limit))
+  }
+
+  return toResponse(getAllSchedules())
+}

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState, useCallback, useMemo, type KeyboardEvent, type ChangeEvent } from 'react'
 import { User, Bot, Wrench, Loader2, Send, RefreshCw, AlertCircle, ChevronDown, ChevronRight, Copy, Check, MessageSquare, ScanEye, Brain, X } from 'lucide-react'
 import { MarkdownContent } from '@/components/chat/MarkdownRenderer'
+import ToolBurstGroup from '@/components/chat/ToolBurstGroup'
+import { groupMessages, getToolPreview, type ToolBurst } from '@/lib/chat-utils'
 import type { Agent } from '@/types/agent'
 
 // Collapsible thinking block
@@ -487,49 +489,6 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     return content.filter(block => block.type === 'tool_use')
   }
 
-  // Shorten a file path to last 3 segments
-  const shortenPath = (p: string): string => {
-    const parts = p.split('/')
-    if (parts.length <= 3) return p
-    return '.../' + parts.slice(-3).join('/')
-  }
-
-  // Get a one-line contextual preview for a tool
-  const getToolPreview = (tool: ContentBlock): string => {
-    const input = tool.input
-    if (!input) return ''
-    const name = tool.name || ''
-
-    switch (name) {
-      case 'Bash':
-        return (input.command || '').slice(0, 80) + ((input.command?.length || 0) > 80 ? '...' : '')
-      case 'Read':
-      case 'Write':
-      case 'Edit':
-      case 'MultiEdit':
-        return input.file_path ? shortenPath(input.file_path) : ''
-      case 'Glob':
-        return input.pattern || ''
-      case 'Grep':
-        return `/${input.pattern || ''}/${input.path ? ' ' + shortenPath(input.path) : ''}`
-      case 'Task':
-        return (input.description || '').slice(0, 80)
-      case 'WebSearch':
-        return input.query || ''
-      case 'WebFetch':
-        return input.url || ''
-      default: {
-        // First key=value from input
-        const keys = Object.keys(input)
-        if (keys.length === 0) return ''
-        const k = keys[0]
-        const v = typeof input[k] === 'string' ? input[k] : JSON.stringify(input[k])
-        const preview = `${k}: ${v}`
-        return preview.slice(0, 80) + (preview.length > 80 ? '...' : '')
-      }
-    }
-  }
-
   // Render tool-specific expanded content
   const renderToolExpanded = (tool: ContentBlock) => {
     const input = tool.input
@@ -604,6 +563,9 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
   }
 
   const isOnline = agent.sessions?.some(s => s.status === 'online')
+
+  // Group consecutive tool-only messages into collapsible bursts
+  const groupedItems = useMemo(() => groupMessages(messages, chatMode), [messages, chatMode])
 
   // Activity state derived from hookState + messages + pending
   const activityState = useMemo(() => {
@@ -690,7 +652,22 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
           </div>
         )}
 
-        {messages.map((message, index) => {
+        {groupedItems.map((item, index) => {
+          // Tool burst — render collapsible group
+          if ('_isBurst' in item) {
+            const burst = item as ToolBurst
+            return (
+              <ToolBurstGroup
+                key={`burst-${burst.startTimestamp || index}`}
+                burst={burst}
+                expandedTools={expandedTools}
+                onToggleTool={toggleTool}
+                renderToolExpanded={renderToolExpanded}
+              />
+            )
+          }
+
+          const message = item as Message
           const isUser = message.type === 'user'
           const isQueued = message.type === 'queue-operation' && message.operation === 'enqueue'
           const isThinking = message.type === 'thinking'
@@ -730,8 +707,9 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
             return <ThinkingBlock key={message.uuid || index} text={content} timestamp={message.timestamp} />
           }
 
-          // Message grouping: check if previous message is same role within 60s
-          const prevMsg = index > 0 ? messages[index - 1] : null
+          // Message grouping: check if previous item is same role within 60s
+          const prevItem = index > 0 ? groupedItems[index - 1] : null
+          const prevMsg = prevItem && !('_isBurst' in prevItem) ? prevItem as Message : null
           const isSameRole = prevMsg && (
             (isUser && prevMsg.type === 'user') ||
             (isQueued && prevMsg.type === 'queue-operation' && prevMsg.operation === 'enqueue') ||

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { SendHorizontal, ChevronDown, ChevronRight, Loader2, Wrench, Copy, Check } from 'lucide-react'
+import MobileToolBurstGroup from '@/components/chat/MobileToolBurstGroup'
+import { groupMessages, getToolPreviewText, type ToolBurst } from '@/lib/chat-utils'
 
 interface MobileChatViewProps {
   agentId: string
@@ -188,42 +190,6 @@ function extractText(msg: ChatMessage): string {
     return msg.content
   }
   return ''
-}
-
-// Shorten a file path to last 3 segments
-function shortenPath(p: string): string {
-  const parts = p.split('/')
-  if (parts.length <= 3) return p
-  return '.../' + parts.slice(-3).join('/')
-}
-
-// Get a tool-specific preview string
-function getToolPreviewText(name: string, input: any): string {
-  if (!input) return ''
-  switch (name) {
-    case 'Bash':
-      return (input.command || '').slice(0, 60) + ((input.command?.length || 0) > 60 ? '...' : '')
-    case 'Read': case 'Write': case 'Edit': case 'MultiEdit':
-      return input.file_path ? shortenPath(input.file_path) : ''
-    case 'Glob':
-      return input.pattern || ''
-    case 'Grep':
-      return `/${input.pattern || ''}/${input.path ? ' ' + shortenPath(input.path) : ''}`
-    case 'Task':
-      return (input.description || '').slice(0, 60)
-    case 'WebSearch':
-      return input.query || ''
-    case 'WebFetch':
-      return input.url || ''
-    default: {
-      const keys = Object.keys(input)
-      if (keys.length === 0) return ''
-      const k = keys[0]
-      const v = typeof input[k] === 'string' ? input[k] : JSON.stringify(input[k])
-      const preview = `${k}: ${v}`
-      return preview.slice(0, 60) + (preview.length > 60 ? '...' : '')
-    }
-  }
 }
 
 // Extract tool use info from a message
@@ -539,6 +505,9 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
     }
   }
 
+  // Group consecutive tool-only messages into collapsible bursts
+  const groupedItems = useMemo(() => groupMessages(messages as any[], 'power'), [messages])
+
   // Determine status
   const isPermission = hookState?.status === 'permission_request'
   const isWaiting = hookState?.status === 'waiting_for_input'
@@ -562,7 +531,19 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
           </div>
         )}
 
-        {messages.map((msg, i) => {
+        {groupedItems.map((item, i) => {
+          // Tool burst — render collapsible group
+          if ('_isBurst' in item) {
+            const burst = item as ToolBurst
+            return (
+              <MobileToolBurstGroup
+                key={`burst-${burst.startTimestamp || i}`}
+                burst={burst}
+              />
+            )
+          }
+
+          const msg = item as ChatMessage
           const key = msg.uuid ? `${msg.uuid}-${i}` : `msg-${i}`
 
           // Thinking block
@@ -625,7 +606,7 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
             const text = extractText(msg)
             const tools = extractToolUses(msg)
 
-            // Tool-only message (no text content)
+            // Tool-only message (no text content) — not in a burst (1-2 consecutive)
             if (!text && tools.length > 0) {
               return (
                 <div key={key} className="mx-3 my-1">

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -32,12 +32,13 @@ interface TerminalViewProps {
   onConnectionStatusChange?: (isConnected: boolean) => void  // Callback for connection status changes
 }
 
-export default function TerminalView({ session, isVisible = true, hideFooter = false, hideHeader = false, onConnectionStatusChange }: TerminalViewProps) {
+export default function TerminalView({ session, isVisible: _isVisible = true, hideFooter = false, hideHeader = false, onConnectionStatusChange }: TerminalViewProps) {
   const { addToast } = useToast()
   const terminalRef = useRef<HTMLDivElement>(null)
   const [isReady, setIsReady] = useState(false)
-  const [historyLoaded, setHistoryLoaded] = useState(false) // Gate for input handler
   const messageBufferRef = useRef<string[]>([])
+  const historyCompleteRef = useRef(false)
+  const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null)
   const [notes, setNotes] = useState('')
   const [promptDraft, setPromptDraft] = useState('')
   const { isTouch } = useDeviceType()
@@ -198,23 +199,13 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
     socketPath: session.socketPath,  // Custom tmux socket (e.g., OpenClaw agents)
     initialCols: terminal?.cols,   // Pass actual terminal dimensions so PTY spawns at correct size
     initialRows: terminal?.rows,
-    autoConnect: isVisible && isReady,  // Wait for terminal init so PTY gets correct dimensions
+    autoConnect: isReady,  // Connect once terminal is ready — stay connected across tab switches
     onOpen: () => {
-      // Reset historyLoaded - server will send new history on each connect
-      setHistoryLoaded(false)
-      // Report activity when WebSocket connects
       reportActivity(session.id)
-      // Notify parent of connection status change
       onConnectionStatusChange?.(true)
-
-      // Send initial resize immediately so PTY/tmux starts at the correct size
-      // instead of defaulting to 80×24 (which corrupts TUI layouts like /plan mode)
-      const term = terminalInstanceRef.current
-      if (term) {
-        fitTerminal()
-        const resizeMsg = createResizeMessage(term.cols, term.rows)
-        sendMessage(resizeMsg)
-      }
+      // Reset history gate — server will send history then history-complete
+      historyCompleteRef.current = false
+      lastSentSizeRef.current = null
     },
     onClose: () => {
       // Notify parent of connection status change
@@ -227,36 +218,18 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
 
         // Handle history-complete message
         if (parsed.type === 'history-complete') {
-          setHistoryLoaded(true)
-          if (terminalInstanceRef.current) {
-            // Wait for xterm.js to finish processing history
-            setTimeout(() => {
-              const t = terminalInstanceRef.current
-              if (!t) return
-
-              // 1. CRITICAL: Refit terminal to ensure correct dimensions
-              fitTerminal()
-
-              // 2. Send resize to PTY to sync tmux with correct dimensions
-              // This also triggers a redraw which helps with color issues
-              const resizeMsg = createResizeMessage(t.cols, t.rows)
-              sendMessage(resizeMsg)
-
-              // 3. Scroll to bottom and focus
-              // try-catch guards against xterm.js renderer being undefined
-              // (WebGL context loss leaves RenderService.dimensions broken)
-              setTimeout(() => {
-                try {
-                  if (terminalInstanceRef.current) {
-                    terminalInstanceRef.current.scrollToBottom()
-                    terminalInstanceRef.current.focus()
-                  }
-                } catch {
-                  // Renderer not ready — safe to ignore, terminal will recover
-                }
-              }, 50)
-            }, 100)
+          try {
+            const term = terminalInstanceRef.current
+            if (term) {
+              term.scrollToBottom()
+              term.focus()
+            }
+          } catch {
+            // Renderer not ready
           }
+          // Unlock resize forwarding — from now on, only real user-initiated
+          // resizes (browser window drag, notes panel toggle) will be sent.
+          historyCompleteRef.current = true
           return
         }
 
@@ -392,19 +365,18 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
   // WebGL is now loaded inline during initializeTerminal() - no toggle needed.
   // Only one terminal is mounted at a time, so no GPU context exhaustion concern.
 
-  // Trigger fit when notes collapse/expand or footer tab changes (changes terminal height)
+  // Trigger fit when notes collapse/expand or footer tab changes (changes terminal height).
+  // Use a longer delay (300ms) so CSS transitions fully settle before refitting.
   useEffect(() => {
     if (isReady && terminal) {
-      // Notes state or footer tab changed, terminal height changed
       const timeout = setTimeout(() => {
         fitTerminal()
-      }, 150)
+      }, 300)
       return () => clearTimeout(timeout)
     }
-  }, [notesCollapsed, footerTab, isReady, terminal, fitTerminal, session.id])
+  }, [notesCollapsed, footerTab, isReady, terminal, fitTerminal])
 
   // Handle terminal input
-  // Note: Removed historyLoaded gate - it was preventing typing until ESC was pressed
   useEffect(() => {
     if (!terminal || !isConnected) {
       return
@@ -461,13 +433,17 @@ export default function TerminalView({ session, isVisible = true, hideFooter = f
     }
   }, [isConnected, sendMessage])
 
-  // Handle terminal resize
+  // Handle terminal resize — only forward to server after history is loaded
+  // and only if dimensions actually changed (prevents tmux redraw storms)
   useEffect(() => {
     if (!terminal || !isConnected) return
 
     const disposable = terminal.onResize(({ cols, rows }) => {
-      const message = createResizeMessage(cols, rows)
-      sendMessage(message)
+      if (!historyCompleteRef.current) return
+      const last = lastSentSizeRef.current
+      if (last && last.cols === cols && last.rows === rows) return
+      lastSentSizeRef.current = { cols, rows }
+      sendMessage(createResizeMessage(cols, rows))
     })
 
     return () => {

--- a/components/chat/MobileToolBurstGroup.tsx
+++ b/components/chat/MobileToolBurstGroup.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Wrench } from 'lucide-react'
+import type { ToolBurst } from '@/lib/chat-utils'
+import { getToolPreviewText } from '@/lib/chat-utils'
+
+interface MobileToolBurstGroupProps {
+  burst: ToolBurst
+}
+
+export default function MobileToolBurstGroup({ burst }: MobileToolBurstGroupProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const summaryParts = burst.tools.map(t =>
+    t.count > 1 ? `${t.count} ${t.name}` : t.name
+  )
+
+  // Collect all tool names + previews from burst messages
+  const allTools: { name: string; preview: string }[] = []
+  burst.messages.forEach(msg => {
+    const content = msg.message?.content
+    if (!Array.isArray(content)) return
+    content
+      .filter((b: any) => b.type === 'tool_use' && b.name)
+      .forEach((b: any) => {
+        allTools.push({
+          name: b.name,
+          preview: getToolPreviewText(b.name, b.input),
+        })
+      })
+  })
+
+  return (
+    <div className="mx-3 my-1">
+      <div
+        className="flex items-center gap-1.5 text-xs text-gray-500 italic py-0.5 cursor-pointer"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? (
+          <ChevronDown className="w-3 h-3 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="w-3 h-3 flex-shrink-0" />
+        )}
+        <Wrench className="w-3 h-3 flex-shrink-0" />
+        <span className="truncate">
+          <span className="text-gray-400">{burst.totalCount} tools</span>
+          <span className="text-gray-600"> {summaryParts.join(', ')}</span>
+        </span>
+      </div>
+
+      {expanded && (
+        <div className="ml-4 mt-0.5">
+          {allTools.map((tool, j) => (
+            <div key={j} className="flex items-center gap-1.5 text-xs text-gray-500 italic py-0.5">
+              <Wrench className="w-3 h-3 flex-shrink-0" />
+              <span className="truncate">
+                <span className="text-gray-400">{tool.name}</span>
+                {tool.preview && <span className="text-gray-600 font-mono"> {tool.preview}</span>}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/chat/ToolBurstGroup.tsx
+++ b/components/chat/ToolBurstGroup.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Wrench } from 'lucide-react'
+import type { ToolBurst } from '@/lib/chat-utils'
+import { getToolPreview } from '@/lib/chat-utils'
+
+interface ContentBlock {
+  type: string
+  text?: string
+  name?: string
+  input?: any
+  id?: string
+  [key: string]: any
+}
+
+interface ToolBurstGroupProps {
+  burst: ToolBurst
+  expandedTools: Set<string>
+  onToggleTool: (id: string) => void
+  renderToolExpanded: (tool: ContentBlock) => React.ReactNode
+}
+
+export default function ToolBurstGroup({ burst, expandedTools, onToggleTool, renderToolExpanded }: ToolBurstGroupProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const summaryParts = burst.tools.map(t =>
+    t.count > 1 ? `${t.count} ${t.name}` : t.name
+  )
+
+  const timestamp = burst.startTimestamp
+    ? new Date(burst.startTimestamp).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+    : ''
+
+  // Collect all tool ContentBlocks from burst messages for expanded view
+  const allTools: { tool: ContentBlock; msgIdx: number; toolIdx: number }[] = []
+  burst.messages.forEach((msg, mi) => {
+    const content = msg.message?.content
+    if (!Array.isArray(content)) return
+    content
+      .filter((b: ContentBlock) => b.type === 'tool_use')
+      .forEach((tool: ContentBlock, ti: number) => {
+        allTools.push({ tool, msgIdx: mi, toolIdx: ti })
+      })
+  })
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] w-full">
+        <div className="rounded-2xl bg-orange-900/20 border border-orange-800/40 overflow-hidden">
+          {/* Summary header — always visible */}
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-orange-900/20 transition-colors"
+          >
+            {expanded ? (
+              <ChevronDown className="w-3.5 h-3.5 text-orange-400 flex-shrink-0" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5 text-orange-400 flex-shrink-0" />
+            )}
+            <Wrench className="w-3.5 h-3.5 text-orange-400 flex-shrink-0" />
+            <span className="text-xs text-orange-300 font-medium">
+              {burst.totalCount} tool {burst.totalCount === 1 ? 'call' : 'calls'}
+            </span>
+            <span className="text-xs text-orange-400/60 truncate flex-1">
+              {summaryParts.join(', ')}
+            </span>
+            {timestamp && (
+              <span className="text-xs text-orange-400/40 flex-shrink-0 ml-2">
+                {timestamp}
+              </span>
+            )}
+          </button>
+
+          {/* Expanded: individual tools */}
+          {expanded && (
+            <div className="border-t border-orange-800/30 px-2 py-1.5 space-y-1">
+              {allTools.map(({ tool, msgIdx, toolIdx }) => {
+                const toolId = `burst-${burst.startTimestamp}-${msgIdx}-${toolIdx}`
+                const isToolExpanded = expandedTools.has(toolId)
+                const preview = getToolPreview(tool)
+
+                return (
+                  <div
+                    key={toolId}
+                    className="bg-orange-900/30 rounded-lg border border-orange-800/50"
+                  >
+                    <button
+                      onClick={() => onToggleTool(toolId)}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-orange-900/20 transition-colors rounded-lg"
+                    >
+                      <Wrench className="w-3 h-3 text-orange-400 flex-shrink-0" />
+                      <span className="text-xs text-orange-300 font-medium">
+                        {tool.name || 'Tool'}
+                      </span>
+                      {preview && !isToolExpanded && (
+                        <span className="text-xs text-orange-400/60 font-mono truncate flex-1 ml-1">
+                          {preview}
+                        </span>
+                      )}
+                      {!preview && <span className="flex-1" />}
+                      {isToolExpanded ? (
+                        <ChevronDown className="w-3 h-3 text-orange-400 flex-shrink-0" />
+                      ) : (
+                        <ChevronRight className="w-3 h-3 text-orange-400 flex-shrink-0" />
+                      )}
+                    </button>
+                    {isToolExpanded && tool.input && renderToolExpanded(tool)}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -202,8 +202,10 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       optionsRef.current.onRegister(fitAddon)
     }
 
-    // Debounced ResizeObserver - batch resize events to prevent layout thrashing
-    // 150ms debounce allows CSS transitions to complete before refitting
+    // Debounced ResizeObserver — batch resize events to prevent layout thrashing.
+    // 300ms debounce lets CSS transitions and layout shifts fully settle before
+    // refitting, which prevents the rapid fit→resize→tmux-redraw cascade that
+    // causes terminal content to visually jump/rewrite.
     const debouncedFit = debounce(() => {
       if (fitAddonRef.current && terminalRef.current) {
         try {
@@ -212,7 +214,7 @@ export function useTerminal(options: UseTerminalOptions = {}) {
           console.warn('[Terminal] Fit failed during resize:', e)
         }
       }
-    }, 150)
+    }, 300)
 
     const resizeObserver = new ResizeObserver(() => {
       debouncedFit()

--- a/lib/chat-utils.ts
+++ b/lib/chat-utils.ts
@@ -1,0 +1,224 @@
+/**
+ * Shared utilities for ChatView and MobileChatView
+ * - Tool burst grouping (collapsing consecutive tool-only messages)
+ * - Tool preview text generation
+ * - Path shortening
+ */
+
+// ── Types ─────────────────────────────────────────────────────────
+
+interface ContentBlock {
+  type: string
+  text?: string
+  name?: string
+  input?: any
+  id?: string
+  [key: string]: any
+}
+
+interface Message {
+  type: string
+  timestamp?: string
+  uuid?: string
+  message?: {
+    content?: string | ContentBlock[]
+    model?: string
+  }
+  thinking?: string
+  summary?: string
+  toolName?: string
+  toolInput?: any
+  operation?: 'enqueue' | 'dequeue'
+  content?: string
+}
+
+export interface ToolBurst {
+  _isBurst: true
+  messages: Message[]
+  tools: { name: string; count: number }[]
+  totalCount: number
+  startTimestamp?: string
+  endTimestamp?: string
+}
+
+export type GroupedItem = Message | ToolBurst
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+/** Shorten a file path to last 3 segments */
+export function shortenPath(p: string): string {
+  const parts = p.split('/')
+  if (parts.length <= 3) return p
+  return '.../' + parts.slice(-3).join('/')
+}
+
+/** Get tools from a message's content blocks */
+function getToolsFromContent(message: Message): ContentBlock[] {
+  const content = message.message?.content
+  if (!Array.isArray(content)) return []
+  return content.filter(block => block.type === 'tool_use')
+}
+
+/** Get text content from a message */
+function getTextContent(message: Message): string {
+  const content = message.message?.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter(block => block.type === 'text' && block.text)
+      .map(block => block.text)
+      .join('\n\n')
+  }
+  return ''
+}
+
+/** Returns true if the message is an assistant message with tools but no text content */
+export function isToolOnlyMessage(msg: Message): boolean {
+  if (msg.type !== 'assistant') return false
+  const tools = getToolsFromContent(msg)
+  if (tools.length === 0) return false
+  const text = getTextContent(msg)
+  return !text
+}
+
+// ── Tool Preview (Desktop — from ContentBlock) ────────────────────
+
+/** Get a one-line contextual preview for a tool (desktop ChatView) */
+export function getToolPreview(tool: ContentBlock): string {
+  const input = tool.input
+  if (!input) return ''
+  const name = tool.name || ''
+
+  switch (name) {
+    case 'Bash':
+      return (input.command || '').slice(0, 80) + ((input.command?.length || 0) > 80 ? '...' : '')
+    case 'Read':
+    case 'Write':
+    case 'Edit':
+    case 'MultiEdit':
+      return input.file_path ? shortenPath(input.file_path) : ''
+    case 'Glob':
+      return input.pattern || ''
+    case 'Grep':
+      return `/${input.pattern || ''}/${input.path ? ' ' + shortenPath(input.path) : ''}`
+    case 'Task':
+      return (input.description || '').slice(0, 80)
+    case 'WebSearch':
+      return input.query || ''
+    case 'WebFetch':
+      return input.url || ''
+    default: {
+      const keys = Object.keys(input)
+      if (keys.length === 0) return ''
+      const k = keys[0]
+      const v = typeof input[k] === 'string' ? input[k] : JSON.stringify(input[k])
+      const preview = `${k}: ${v}`
+      return preview.slice(0, 80) + (preview.length > 80 ? '...' : '')
+    }
+  }
+}
+
+// ── Tool Preview (Mobile — from name + input) ─────────────────────
+
+/** Get a tool-specific preview string (mobile MobileChatView) */
+export function getToolPreviewText(name: string, input: any): string {
+  if (!input) return ''
+  switch (name) {
+    case 'Bash':
+      return (input.command || '').slice(0, 60) + ((input.command?.length || 0) > 60 ? '...' : '')
+    case 'Read': case 'Write': case 'Edit': case 'MultiEdit':
+      return input.file_path ? shortenPath(input.file_path) : ''
+    case 'Glob':
+      return input.pattern || ''
+    case 'Grep':
+      return `/${input.pattern || ''}/${input.path ? ' ' + shortenPath(input.path) : ''}`
+    case 'Task':
+      return (input.description || '').slice(0, 60)
+    case 'WebSearch':
+      return input.query || ''
+    case 'WebFetch':
+      return input.url || ''
+    default: {
+      const keys = Object.keys(input)
+      if (keys.length === 0) return ''
+      const k = keys[0]
+      const v = typeof input[k] === 'string' ? input[k] : JSON.stringify(input[k])
+      const preview = `${k}: ${v}`
+      return preview.slice(0, 60) + (preview.length > 60 ? '...' : '')
+    }
+  }
+}
+
+// ── Message Grouping ──────────────────────────────────────────────
+
+/**
+ * Group consecutive tool-only assistant messages into ToolBurst objects.
+ *
+ * Rules:
+ * - Only tool-only assistant messages are candidates (has tools, no text)
+ * - Streaks of 3+ consecutive tool-only messages become a ToolBurst
+ * - Streaks of 1-2 pass through unchanged (not worth grouping)
+ * - In 'assisted' mode, tool-only messages are filtered out entirely
+ * - Non-assistant messages pass through unchanged
+ */
+export function groupMessages(messages: Message[], chatMode: 'power' | 'assisted'): GroupedItem[] {
+  if (chatMode === 'assisted') {
+    // Assisted mode: filter out tool-only messages entirely (existing behavior)
+    return messages.filter(msg => !isToolOnlyMessage(msg))
+  }
+
+  const result: GroupedItem[] = []
+  let streak: Message[] = []
+
+  const flushStreak = () => {
+    if (streak.length === 0) return
+
+    if (streak.length >= 3) {
+      // Build tool summary
+      const toolCounts = new Map<string, number>()
+      for (const msg of streak) {
+        const tools = getToolsFromContent(msg)
+        for (const tool of tools) {
+          const name = tool.name || 'Unknown'
+          toolCounts.set(name, (toolCounts.get(name) || 0) + 1)
+        }
+      }
+
+      const tools = Array.from(toolCounts.entries())
+        .sort((a, b) => b[1] - a[1]) // Most frequent first
+        .map(([name, count]) => ({ name, count }))
+
+      const totalCount = tools.reduce((sum, t) => sum + t.count, 0)
+
+      const burst: ToolBurst = {
+        _isBurst: true,
+        messages: [...streak],
+        tools,
+        totalCount,
+        startTimestamp: streak[0].timestamp,
+        endTimestamp: streak[streak.length - 1].timestamp,
+      }
+      result.push(burst)
+    } else {
+      // 1-2 tool-only messages: pass through individually
+      for (const msg of streak) {
+        result.push(msg)
+      }
+    }
+    streak = []
+  }
+
+  for (const msg of messages) {
+    if (isToolOnlyMessage(msg)) {
+      streak.push(msg)
+    } else {
+      flushStreak()
+      result.push(msg)
+    }
+  }
+
+  // Flush any remaining streak
+  flushStreak()
+
+  return result
+}

--- a/lib/schedule-executor.ts
+++ b/lib/schedule-executor.ts
@@ -1,0 +1,158 @@
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import {
+  getDueSchedules,
+  recordExecution,
+  completeExecution,
+  advanceNextRun,
+} from '@/lib/schedule-registry'
+import { getAgent } from '@/lib/agent-registry'
+import { getRuntime } from '@/lib/agent-runtime'
+import type { Schedule } from '@/types/schedule'
+
+const execAsync = promisify(exec)
+
+const CHECK_INTERVAL_MS = 60_000
+const EXISTING_SESSION_DELAY_MS = 2_000
+const NEW_SESSION_LAUNCH_DELAY_MS = 15_000
+const DEFAULT_TIMEOUT_MS = 300_000
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null
+const runningExecutions = new Set<string>()
+
+export function startScheduler(): void {
+  if (intervalHandle) return
+  console.log('[Scheduler] Starting schedule check loop (60s interval)')
+  intervalHandle = setInterval(checkAndExecute, CHECK_INTERVAL_MS)
+  // Also run immediately on startup
+  setTimeout(checkAndExecute, 5_000)
+}
+
+export function stopScheduler(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle)
+    intervalHandle = null
+    console.log('[Scheduler] Stopped')
+  }
+}
+
+export function isSchedulerRunning(): boolean {
+  return intervalHandle !== null
+}
+
+export function getRunningExecutions(): string[] {
+  return Array.from(runningExecutions)
+}
+
+async function checkAndExecute(): Promise<void> {
+  try {
+    const due = getDueSchedules()
+    if (due.length === 0) return
+
+    console.log(`[Scheduler] ${due.length} schedule(s) due`)
+    for (const schedule of due) {
+      if (runningExecutions.has(schedule.id)) {
+        console.log(`[Scheduler] Skipping ${schedule.name} — already executing`)
+        advanceNextRun(schedule.id)
+        continue
+      }
+      executeSchedule(schedule, 'cron')
+    }
+  } catch (error) {
+    console.error('[Scheduler] Check loop error:', error)
+  }
+}
+
+export async function executeSchedule(
+  schedule: Schedule,
+  triggeredBy: 'cron' | 'manual' | 'webhook' = 'cron'
+): Promise<{ executionId: string; status: string }> {
+  const runtime = getRuntime()
+  const agent = getAgent(schedule.agentId)
+  const sessionName = agent?.name || schedule.agentName
+
+  let sessionExisted = false
+  try {
+    sessionExisted = await runtime.sessionExists(sessionName)
+  } catch {
+    sessionExisted = false
+  }
+
+  const execution = recordExecution({
+    scheduleId: schedule.id,
+    agentId: schedule.agentId,
+    agentName: schedule.agentName,
+    prompt: schedule.prompt,
+    triggeredBy,
+    sessionExisted,
+  })
+
+  runningExecutions.add(schedule.id)
+  console.log(
+    `[Scheduler] Executing "${schedule.name}" for agent ${schedule.agentName} ` +
+    `(trigger=${triggeredBy}, session=${sessionExisted ? 'existing' : 'new'})`
+  )
+
+  // Fire and forget — don't block the check loop
+  runExecution(schedule, execution.id, sessionName, sessionExisted)
+    .catch(error => {
+      console.error(`[Scheduler] Execution failed for ${schedule.name}:`, error)
+      completeExecution(execution.id, 'failure', String(error))
+    })
+    .finally(() => {
+      runningExecutions.delete(schedule.id)
+    })
+
+  return { executionId: execution.id, status: 'started' }
+}
+
+async function runExecution(
+  schedule: Schedule,
+  executionId: string,
+  sessionName: string,
+  sessionExisted: boolean
+): Promise<void> {
+  const runtime = getRuntime()
+
+  if (!sessionExisted) {
+    // Need to wake the agent: create tmux session + launch claude
+    const agent = getAgent(schedule.agentId)
+    const cwd = agent?.workingDirectory || process.cwd()
+
+    console.log(`[Scheduler] Creating tmux session "${sessionName}" in ${cwd}`)
+    const env = { ...process.env, TMUX: undefined }
+    await execAsync(`tmux new-session -d -s "${sessionName}" -c "${cwd}"`, { env })
+
+    // Wait for shell to be ready
+    await sleep(1_000)
+
+    // Launch Claude Code
+    console.log(`[Scheduler] Launching claude in "${sessionName}"`)
+    await runtime.sendKeys(sessionName, '"claude"', { enter: true })
+
+    // Wait for Claude to initialize — this is the fragile part
+    console.log(`[Scheduler] Waiting ${NEW_SESSION_LAUNCH_DELAY_MS / 1000}s for claude to start...`)
+    await sleep(NEW_SESSION_LAUNCH_DELAY_MS)
+  } else {
+    // Session exists — small delay to ensure we're not mid-keystroke
+    await sleep(EXISTING_SESSION_DELAY_MS)
+  }
+
+  // Send the prompt
+  console.log(`[Scheduler] Sending prompt to "${sessionName}": ${schedule.prompt.substring(0, 80)}...`)
+  const escaped = schedule.prompt.replace(/'/g, "'\\''")
+  await runtime.sendKeys(sessionName, escaped, { literal: true, enter: true })
+
+  // For now, mark as success after sending. We can't easily detect when Claude
+  // finishes processing. Future: poll tmux pane for idle indicator.
+  const timeoutMs = schedule.timeoutMs || DEFAULT_TIMEOUT_MS
+  console.log(
+    `[Scheduler] Prompt sent for "${schedule.name}". ` +
+    `Marking success (timeout tracking: ${timeoutMs / 1000}s — not yet implemented)`
+  )
+  completeExecution(executionId, 'success')
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/lib/schedule-registry.ts
+++ b/lib/schedule-registry.ts
@@ -1,0 +1,277 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { v4 as uuidv4 } from 'uuid'
+import { CronExpressionParser } from 'cron-parser'
+import type {
+  Schedule,
+  ScheduleExecution,
+  ScheduleCreate,
+  ScheduleUpdate,
+  SchedulesFile,
+  ExecutionStatus,
+  ScheduleTrigger,
+} from '@/types/schedule'
+
+const AIMAESTRO_DIR = path.join(os.homedir(), '.aimaestro')
+const SCHEDULES_FILE = path.join(AIMAESTRO_DIR, 'schedules.json')
+const MAX_EXECUTIONS_PER_SCHEDULE = 50
+
+function ensureDir() {
+  if (!fs.existsSync(AIMAESTRO_DIR)) {
+    fs.mkdirSync(AIMAESTRO_DIR, { recursive: true })
+  }
+}
+
+function loadFile(): SchedulesFile {
+  try {
+    ensureDir()
+    if (!fs.existsSync(SCHEDULES_FILE)) {
+      return { version: 1, schedules: [], executions: [] }
+    }
+    const data = fs.readFileSync(SCHEDULES_FILE, 'utf-8')
+    return JSON.parse(data)
+  } catch {
+    return { version: 1, schedules: [], executions: [] }
+  }
+}
+
+function saveFile(file: SchedulesFile): void {
+  ensureDir()
+  fs.writeFileSync(SCHEDULES_FILE, JSON.stringify(file, null, 2), 'utf-8')
+}
+
+function calculateNextRun(cronExpression: string, timezone: string): string | null {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, { tz: timezone })
+    return interval.next().toISOString()
+  } catch {
+    return null
+  }
+}
+
+// --- Schedule CRUD ---
+
+export function listSchedules(): Schedule[] {
+  return loadFile().schedules
+}
+
+export function listSchedulesByAgent(agentId: string): Schedule[] {
+  return loadFile().schedules.filter(s => s.agentId === agentId)
+}
+
+export function getSchedule(scheduleId: string): Schedule | null {
+  return loadFile().schedules.find(s => s.id === scheduleId) ?? null
+}
+
+export function createSchedule(params: ScheduleCreate, agentName: string): Schedule {
+  const file = loadFile()
+  const now = new Date().toISOString()
+  const tz = params.timezone || 'UTC'
+
+  // Validate cron expression
+  try {
+    CronExpressionParser.parse(params.cronExpression, { tz })
+  } catch (e) {
+    throw new Error(`Invalid cron expression: ${params.cronExpression}`)
+  }
+
+  const schedule: Schedule = {
+    id: uuidv4(),
+    agentId: params.agentId,
+    agentName,
+    name: params.name,
+    description: params.description,
+    cronExpression: params.cronExpression,
+    timezone: tz,
+    prompt: params.prompt,
+    enabled: params.enabled !== false,
+    nextRunAt: params.enabled !== false ? calculateNextRun(params.cronExpression, tz) : null,
+    lastRunAt: null,
+    lastStatus: null,
+    consecutiveFailures: 0,
+    maxRetries: params.maxRetries ?? 0,
+    timeoutMs: params.timeoutMs ?? 300_000,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  file.schedules.push(schedule)
+  saveFile(file)
+  return schedule
+}
+
+export function updateSchedule(scheduleId: string, params: ScheduleUpdate): Schedule | null {
+  const file = loadFile()
+  const idx = file.schedules.findIndex(s => s.id === scheduleId)
+  if (idx === -1) return null
+
+  const schedule = file.schedules[idx]
+
+  if (params.cronExpression !== undefined) {
+    const tz = params.timezone || schedule.timezone
+    try {
+      CronExpressionParser.parse(params.cronExpression, { tz })
+    } catch {
+      throw new Error(`Invalid cron expression: ${params.cronExpression}`)
+    }
+  }
+
+  if (params.name !== undefined) schedule.name = params.name
+  if (params.description !== undefined) schedule.description = params.description
+  if (params.cronExpression !== undefined) schedule.cronExpression = params.cronExpression
+  if (params.timezone !== undefined) schedule.timezone = params.timezone
+  if (params.prompt !== undefined) schedule.prompt = params.prompt
+  if (params.maxRetries !== undefined) schedule.maxRetries = params.maxRetries
+  if (params.timeoutMs !== undefined) schedule.timeoutMs = params.timeoutMs
+
+  if (params.enabled !== undefined) {
+    schedule.enabled = params.enabled
+    if (params.enabled) {
+      schedule.nextRunAt = calculateNextRun(
+        params.cronExpression || schedule.cronExpression,
+        params.timezone || schedule.timezone
+      )
+    } else {
+      schedule.nextRunAt = null
+    }
+  } else if (params.cronExpression || params.timezone) {
+    schedule.nextRunAt = calculateNextRun(
+      params.cronExpression || schedule.cronExpression,
+      params.timezone || schedule.timezone
+    )
+  }
+
+  schedule.updatedAt = new Date().toISOString()
+  file.schedules[idx] = schedule
+  saveFile(file)
+  return schedule
+}
+
+export function deleteSchedule(scheduleId: string): boolean {
+  const file = loadFile()
+  const before = file.schedules.length
+  file.schedules = file.schedules.filter(s => s.id !== scheduleId)
+  file.executions = file.executions.filter(e => e.scheduleId !== scheduleId)
+  if (file.schedules.length === before) return false
+  saveFile(file)
+  return true
+}
+
+export function deleteSchedulesByAgent(agentId: string): number {
+  const file = loadFile()
+  const before = file.schedules.length
+  const removedIds = new Set(file.schedules.filter(s => s.agentId === agentId).map(s => s.id))
+  file.schedules = file.schedules.filter(s => s.agentId !== agentId)
+  file.executions = file.executions.filter(e => !removedIds.has(e.scheduleId))
+  saveFile(file)
+  return before - file.schedules.length
+}
+
+// --- Execution tracking ---
+
+export function recordExecution(params: {
+  scheduleId: string
+  agentId: string
+  agentName: string
+  prompt: string
+  triggeredBy: ScheduleTrigger
+  sessionExisted: boolean
+}): ScheduleExecution {
+  const file = loadFile()
+  const execution: ScheduleExecution = {
+    id: uuidv4(),
+    scheduleId: params.scheduleId,
+    agentId: params.agentId,
+    agentName: params.agentName,
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    prompt: params.prompt,
+    triggeredBy: params.triggeredBy,
+    sessionExisted: params.sessionExisted,
+  }
+
+  file.executions.push(execution)
+  pruneExecutions(file)
+  saveFile(file)
+  return execution
+}
+
+export function completeExecution(
+  executionId: string,
+  status: ExecutionStatus,
+  error?: string
+): void {
+  const file = loadFile()
+  const execution = file.executions.find(e => e.id === executionId)
+  if (!execution) return
+
+  execution.completedAt = new Date().toISOString()
+  execution.status = status
+  if (error) execution.error = error
+
+  // Update parent schedule
+  const schedule = file.schedules.find(s => s.id === execution.scheduleId)
+  if (schedule) {
+    schedule.lastRunAt = execution.startedAt
+    schedule.lastStatus = status
+    schedule.lastError = error
+    schedule.updatedAt = new Date().toISOString()
+
+    if (status === 'success') {
+      schedule.consecutiveFailures = 0
+    } else if (status === 'failure' || status === 'timeout') {
+      schedule.consecutiveFailures++
+    }
+
+    schedule.nextRunAt = calculateNextRun(schedule.cronExpression, schedule.timezone)
+  }
+
+  saveFile(file)
+}
+
+export function listExecutions(scheduleId: string, limit = 20): ScheduleExecution[] {
+  return loadFile()
+    .executions
+    .filter(e => e.scheduleId === scheduleId)
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+    .slice(0, limit)
+}
+
+export function listAllExecutions(limit = 50): ScheduleExecution[] {
+  return loadFile()
+    .executions
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+    .slice(0, limit)
+}
+
+// --- Helpers ---
+
+export function getDueSchedules(): Schedule[] {
+  const now = new Date().toISOString()
+  return loadFile().schedules.filter(s =>
+    s.enabled && s.nextRunAt && s.nextRunAt <= now
+  )
+}
+
+export function advanceNextRun(scheduleId: string): void {
+  const file = loadFile()
+  const schedule = file.schedules.find(s => s.id === scheduleId)
+  if (!schedule) return
+  schedule.nextRunAt = calculateNextRun(schedule.cronExpression, schedule.timezone)
+  schedule.updatedAt = new Date().toISOString()
+  saveFile(file)
+}
+
+function pruneExecutions(file: SchedulesFile): void {
+  const countBySchedule = new Map<string, number>()
+  // Sorted newest first for pruning
+  file.executions.sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+
+  file.executions = file.executions.filter(e => {
+    const count = countBySchedule.get(e.scheduleId) ?? 0
+    if (count >= MAX_EXECUTIONS_PER_SCHEDULE) return false
+    countBySchedule.set(e.scheduleId, count + 1)
+    return true
+  })
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@xterm/xterm": "^6.0.0",
     "archiver": "^7.0.1",
     "cozo-node": "^0.7.6",
+    "cron-parser": "^5.5.0",
     "cytoscape": "^3.33.1",
     "cytoscape-dagre": "^2.5.0",
     "form-data": "^4.0.5",

--- a/server.mjs
+++ b/server.mjs
@@ -1998,11 +1998,27 @@ async function startServer(handleRequest) {
 
     // Start periodic orphaned PTY cleanup to prevent leaks
     startOrphanedPtyCleanup()
+
+    // Start the agent schedule executor (checks due schedules every 60s)
+    setTimeout(async () => {
+      try {
+        const { startScheduler } = await import('./lib/schedule-executor.ts')
+        startScheduler()
+      } catch (error) {
+        console.error('[Scheduler] Failed to start schedule executor:', error.message)
+      }
+    }, 10000) // Wait 10 seconds for all services to be ready
   })
 
   // Graceful shutdown - kill PTYs FIRST before closing server
-  const gracefulShutdown = (signal) => {
+  const gracefulShutdown = async (signal) => {
     console.log(`[Server] Received ${signal}, shutting down gracefully...`)
+
+    // Stop the scheduler
+    try {
+      const { stopScheduler } = await import('./lib/schedule-executor.ts')
+      stopScheduler()
+    } catch { /* ignore */ }
 
     // Kill all PTY processes FIRST and synchronously
     const sessionCount = terminalSessions.size

--- a/services/agents-schedule-service.ts
+++ b/services/agents-schedule-service.ts
@@ -1,0 +1,120 @@
+import {
+  listSchedules,
+  listSchedulesByAgent,
+  getSchedule,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+  deleteSchedulesByAgent,
+  listExecutions,
+  listAllExecutions,
+} from '@/lib/schedule-registry'
+import { getAgent } from '@/lib/agent-registry'
+import { executeSchedule } from '@/lib/schedule-executor'
+import {
+  type ServiceResult,
+  ok,
+  notFound,
+  missingField,
+  invalidField,
+  operationFailed,
+} from '@/services/service-errors'
+import type { Schedule, ScheduleCreate, ScheduleUpdate, ScheduleExecution } from '@/types/schedule'
+
+export function getAgentSchedules(agentId: string): ServiceResult<{ schedules: Schedule[] }> {
+  const agent = getAgent(agentId)
+  if (!agent) return notFound('Agent', agentId)
+  return ok({ schedules: listSchedulesByAgent(agentId) })
+}
+
+export function getAllSchedules(): ServiceResult<{ schedules: Schedule[] }> {
+  return ok({ schedules: listSchedules() })
+}
+
+export function getScheduleById(scheduleId: string): ServiceResult<{ schedule: Schedule }> {
+  const schedule = getSchedule(scheduleId)
+  if (!schedule) return notFound('Schedule', scheduleId)
+  return ok({ schedule })
+}
+
+export function createAgentSchedule(
+  agentId: string,
+  body: Partial<ScheduleCreate>
+): ServiceResult<{ schedule: Schedule }> {
+  const agent = getAgent(agentId)
+  if (!agent) return notFound('Agent', agentId)
+
+  if (!body.name) return missingField('name')
+  if (!body.cronExpression) return missingField('cronExpression')
+  if (!body.prompt) return missingField('prompt')
+
+  try {
+    const schedule = createSchedule(
+      { ...body, agentId, name: body.name, cronExpression: body.cronExpression, prompt: body.prompt },
+      agent.name
+    )
+    console.log(`[Scheduler] Created schedule "${schedule.name}" for agent ${agent.name} (cron: ${schedule.cronExpression})`)
+    return ok({ schedule }, 201)
+  } catch (error) {
+    return invalidField('cronExpression', (error as Error).message)
+  }
+}
+
+export function updateAgentSchedule(
+  scheduleId: string,
+  body: ScheduleUpdate
+): ServiceResult<{ schedule: Schedule }> {
+  const existing = getSchedule(scheduleId)
+  if (!existing) return notFound('Schedule', scheduleId)
+
+  try {
+    const updated = updateSchedule(scheduleId, body)
+    if (!updated) return notFound('Schedule', scheduleId)
+    console.log(`[Scheduler] Updated schedule "${updated.name}" (enabled=${updated.enabled})`)
+    return ok({ schedule: updated })
+  } catch (error) {
+    return invalidField('cronExpression', (error as Error).message)
+  }
+}
+
+export function deleteAgentSchedule(scheduleId: string): ServiceResult<{ success: boolean }> {
+  const existing = getSchedule(scheduleId)
+  if (!existing) return notFound('Schedule', scheduleId)
+
+  deleteSchedule(scheduleId)
+  console.log(`[Scheduler] Deleted schedule "${existing.name}" for agent ${existing.agentName}`)
+  return ok({ success: true })
+}
+
+export function deleteAllAgentSchedules(agentId: string): ServiceResult<{ deleted: number }> {
+  const count = deleteSchedulesByAgent(agentId)
+  return ok({ deleted: count })
+}
+
+export async function triggerSchedule(
+  scheduleId: string,
+  triggeredBy: 'manual' | 'webhook' = 'manual'
+): Promise<ServiceResult<{ executionId: string; status: string }>> {
+  const schedule = getSchedule(scheduleId)
+  if (!schedule) return notFound('Schedule', scheduleId)
+
+  try {
+    const result = await executeSchedule(schedule, triggeredBy)
+    return ok(result)
+  } catch (error) {
+    return operationFailed('trigger schedule', (error as Error).message)
+  }
+}
+
+export function getScheduleExecutions(
+  scheduleId: string,
+  limit = 20
+): ServiceResult<{ executions: ScheduleExecution[] }> {
+  const schedule = getSchedule(scheduleId)
+  if (!schedule) return notFound('Schedule', scheduleId)
+  return ok({ executions: listExecutions(scheduleId, limit) })
+}
+
+export function getAllExecutions(limit = 50): ServiceResult<{ executions: ScheduleExecution[] }> {
+  return ok({ executions: listAllExecutions(limit) })
+}

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -148,6 +148,18 @@ import { createDockerAgent, recreateDockerAgent, getDockerStats } from '@/servic
 import { createCloudAgent, destroyCloudAgent, getCloudAgentStatus } from '@/services/agents-cloud-service'
 
 import {
+  getAllSchedules,
+  getAgentSchedules,
+  getScheduleById,
+  createAgentSchedule,
+  updateAgentSchedule,
+  deleteAgentSchedule,
+  triggerSchedule,
+  getScheduleExecutions,
+  getAllExecutions,
+} from '@/services/agents-schedule-service'
+
+import {
   listSessions,
   listLocalSessions,
   createSession,
@@ -834,6 +846,48 @@ const routes: Route[] = [
   }},
   { method: 'DELETE', pattern: /^\/api\/agents\/([^/]+)\/skills$/, paramNames: ['id'], handler: async (_req, res, params, query) => {
     sendServiceResult(res, removeSkill(params.id, query.skill || ''))
+  }},
+
+  // Schedules (per-agent)
+  { method: 'GET', pattern: /^\/api\/agents\/([^/]+)\/schedules\/([^/]+)$/, paramNames: ['id', 'scheduleId'], handler: async (_req, res, params, query) => {
+    if (query.executions === 'true') {
+      const limit = parseInt(query.limit || '20', 10)
+      sendServiceResult(res, getScheduleExecutions(params.scheduleId, limit))
+    } else {
+      sendServiceResult(res, getScheduleById(params.scheduleId))
+    }
+  }},
+  { method: 'PATCH', pattern: /^\/api\/agents\/([^/]+)\/schedules\/([^/]+)$/, paramNames: ['id', 'scheduleId'], handler: async (req, res, params) => {
+    const body = await readJsonBody(req)
+    sendServiceResult(res, updateAgentSchedule(params.scheduleId, body))
+  }},
+  { method: 'DELETE', pattern: /^\/api\/agents\/([^/]+)\/schedules\/([^/]+)$/, paramNames: ['id', 'scheduleId'], handler: async (_req, res, params) => {
+    sendServiceResult(res, deleteAgentSchedule(params.scheduleId))
+  }},
+  { method: 'GET', pattern: /^\/api\/agents\/([^/]+)\/schedules$/, paramNames: ['id'], handler: async (_req, res, params) => {
+    sendServiceResult(res, getAgentSchedules(params.id))
+  }},
+  { method: 'POST', pattern: /^\/api\/agents\/([^/]+)\/schedules$/, paramNames: ['id'], handler: async (req, res, params) => {
+    const body = await readJsonBody(req)
+    sendServiceResult(res, createAgentSchedule(params.id, body))
+  }},
+
+  // Schedules (global)
+  { method: 'GET', pattern: /^\/api\/schedules$/, paramNames: [], handler: async (_req, res, _params, query) => {
+    if (query.executions === 'true') {
+      const limit = parseInt(query.limit || '50', 10)
+      sendServiceResult(res, getAllExecutions(limit))
+    } else {
+      sendServiceResult(res, getAllSchedules())
+    }
+  }},
+  { method: 'POST', pattern: /^\/api\/schedules\/([^/]+)\/trigger$/, paramNames: ['scheduleId'], handler: async (req, res, params) => {
+    let triggeredBy: 'manual' | 'webhook' = 'manual'
+    try {
+      const body = await readJsonBody(req)
+      if (body.triggeredBy === 'webhook') triggeredBy = 'webhook'
+    } catch {}
+    sendServiceResult(res, await triggerSchedule(params.scheduleId, triggeredBy))
   }},
 
   // Subconscious

--- a/types/schedule.ts
+++ b/types/schedule.ts
@@ -1,0 +1,66 @@
+export type ScheduleTrigger = 'cron' | 'manual' | 'webhook'
+export type ExecutionStatus = 'pending' | 'running' | 'success' | 'failure' | 'timeout' | 'skipped'
+
+export interface Schedule {
+  id: string
+  agentId: string
+  agentName: string
+  name: string
+  description?: string
+  cronExpression: string
+  timezone: string
+  prompt: string
+  enabled: boolean
+  nextRunAt: string | null
+  lastRunAt: string | null
+  lastStatus: ExecutionStatus | null
+  lastError?: string
+  consecutiveFailures: number
+  maxRetries: number
+  timeoutMs: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ScheduleExecution {
+  id: string
+  scheduleId: string
+  agentId: string
+  agentName: string
+  startedAt: string
+  completedAt?: string
+  status: ExecutionStatus
+  prompt: string
+  error?: string
+  triggeredBy: ScheduleTrigger
+  sessionExisted: boolean
+}
+
+export interface ScheduleCreate {
+  agentId: string
+  name: string
+  description?: string
+  cronExpression: string
+  timezone?: string
+  prompt: string
+  enabled?: boolean
+  maxRetries?: number
+  timeoutMs?: number
+}
+
+export interface ScheduleUpdate {
+  name?: string
+  description?: string
+  cronExpression?: string
+  timezone?: string
+  prompt?: string
+  enabled?: boolean
+  maxRetries?: number
+  timeoutMs?: number
+}
+
+export interface SchedulesFile {
+  version: number
+  schedules: Schedule[]
+  executions: ScheduleExecution[]
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.28",
+  "version": "0.35.30",
   "releaseDate": "2026-05-28",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,6 +2045,13 @@ crc32-stream@^6.0.0:
     crc-32 "^1.2.0"
     readable-stream "^4.0.0"
 
+cron-parser@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-5.5.0.tgz#7706b441f5761b60a915c2661de2ee64194bd407"
+  integrity sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==
+  dependencies:
+    luxon "^3.7.1"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
@@ -3754,6 +3761,11 @@ lucide-react@^0.545.0:
   version "0.545.0"
   resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.545.0.tgz"
   integrity sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==
+
+luxon@^3.7.1:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
+  integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
 
 magic-string@^0.30.21:
   version "0.30.21"


### PR DESCRIPTION
## Summary
- **Agent scheduling system** — Cron-based task scheduling stored in `~/.aimaestro/schedules.json`. Timer in server.mjs checks every 60s for due schedules, wakes agents via tmux, sends prompts via send-keys. Full CRUD API + manual/webhook trigger + execution history.
- **Terminal resize storm fix** — Eliminated 4+ overlapping resize triggers (onOpen, history-complete, ResizeObserver, notes toggle) that caused terminal content to jump, rewrite, and leave users mid-page. PTY spawns at correct size via URL params; resize only sent on real user actions (window drag, notes panel toggle). WebSocket stays connected across tab switches.
- **ResizeObserver debounce increased** to 300ms (from 150ms) to let CSS transitions settle.

## New files
- `types/schedule.ts` — Schedule types
- `lib/schedule-registry.ts` — File-based CRUD for schedules
- `lib/schedule-executor.ts` — Timer loop + tmux execution
- `services/agents-schedule-service.ts` — Service layer
- `app/api/agents/[id]/schedules/` — Per-agent schedule CRUD
- `app/api/schedules/` — Global schedule list + trigger endpoint

## Test plan
- [ ] `yarn test` passes (792/792)
- [ ] `yarn build` passes
- [ ] Terminal loads without content jumping or re-rendering
- [ ] Switching Terminal ↔ Chat tabs doesn't cause content reload
- [ ] Resizing browser window still works (terminal reflows correctly)
- [ ] Notes panel expand/collapse reflows terminal correctly
- [ ] `POST /api/agents/{id}/schedules` creates a schedule
- [ ] `GET /api/schedules` returns all schedules
- [ ] `POST /api/schedules/{id}/trigger` executes a schedule manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)