### PR TITLE
fix: chat view empty for agents with underscores in path (v0.35.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.31] - 2026-05-27
+
+### Fixed
+- **Chat view empty for agents with underscores in working directory** — Claude Code converts both `/` and `_` to `-` when naming project directories (e.g., `rag_ingestion` → `rag-ingestion`), but our JSONL path resolution only replaced `/`. Any agent with underscores in its path couldn't find its conversation files. Fixed in `server.mjs`, `agents-chat-service.ts`, and `voice-subsystem.ts`.
+
 ## [0.35.30] - 2026-05-27
 
 ### Fixed

--- a/lib/cerebellum/voice-subsystem.ts
+++ b/lib/cerebellum/voice-subsystem.ts
@@ -280,7 +280,7 @@ export class VoiceSubsystem implements Subsystem {
 
       // Derive the Claude projects directory path (same as chat route.ts)
       const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-      const projectDirName = workingDir.replace(/\//g, '-')
+      const projectDirName = workingDir.replace(/[/_]/g, '-')
       const conversationDir = path.join(claudeProjectsDir, projectDirName)
 
       if (!fs.existsSync(conversationDir)) return []

--- a/server.mjs
+++ b/server.mjs
@@ -177,7 +177,7 @@ function resolveJsonlPath(agent) {
   if (!workingDir) return null
 
   const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-  const projectDirName = workingDir.replace(/\//g, '-')
+  const projectDirName = workingDir.replace(/[/_]/g, '-')
   const conversationDir = path.join(claudeProjectsDir, projectDirName)
 
   if (!fs.existsSync(conversationDir)) return null

--- a/services/agents-chat-service.ts
+++ b/services/agents-chat-service.ts
@@ -51,7 +51,7 @@ export async function getConversationMessages(
 
   // Find the Claude conversation directory for this project
   const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-  const projectDirName = workingDir.replace(/\//g, '-')
+  const projectDirName = workingDir.replace(/[/_]/g, '-')
   const conversationDir = path.join(claudeProjectsDir, projectDirName)
 
   if (!fs.existsSync(conversationDir)) {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.30",
+  "version": "0.35.31",
   "releaseDate": "2026-05-28",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Chat view broken for agents with underscores in working directory** — Claude Code converts both `/` and `_` to `-` in project directory names (e.g., `rag_ingestion` → `rag-ingestion`), but our JSONL path resolution only replaced `/`. Fixed in all 3 locations: `server.mjs`, `agents-chat-service.ts`, `voice-subsystem.ts`.

## Test plan
- [ ] rag agent (`rag_ingestion` path) now shows chat history
- [ ] Agents without underscores still work (no regression)
- [ ] `yarn build` passes
- [ ] `yarn test` passes (792/792)

🤖 Generated with [Claude Code](https://claude.com/claude-code)