### PR TITLE
docs: refine FAQ, fix version badge (v0.35.48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.29.16-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.48-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)
@@ -286,55 +286,20 @@ MIT — see [LICENSE](./LICENSE). Free for any purpose, including commercial.
 
 ## FAQ
 
-### What is AI Maestro?
+**Do I need to use Claude Code?**
+No. AI Maestro works with any terminal-based AI agent — Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes, Droid, or your own scripts. We're agent-agnostic.
 
-**AI Maestro** is the operating system for AI-first organizations — orchestrate any AI agent with **persistent memory**, **agent-to-agent messaging**, and **multi-machine support**. Built from real experience running 80+ agents across multiple computers.
+**Does it work on Linux / Windows?**
+Yes. macOS and Linux natively. Windows via WSL2 — see the [Windows guide](./docs/WINDOWS-INSTALLATION.md).
 
-### Key Features
+**Can agents on different machines talk to each other?**
+Yes. The [Agent Messaging Protocol (AMP)](https://agentmessaging.org) handles cross-machine messaging with cryptographic signatures and push notifications. No central server required.
 
-| Feature | Description |
-|---------|-------------|
-| **One Dashboard** | See and manage all AI agents in one place with smart naming and auto-coloring |
-| **Multi-Machine** | Peer mesh network — every machine is equal, no central server required |
-| **Agent Messaging (AMP)** | Agents communicate directly via email-like messaging protocol |
-| **Persistent Memory** | Three layers: Memory, Code Graph, Documentation — agents get smarter over time |
-| **Work Coordination** | Teams, Kanban boards, drag-and-drop task management |
-| **Any Agent** | Works with Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes, Droid, or any terminal-based agent |
-| **Multi-Deployment** | tmux (local), Docker, AWS EC2, AWS ECS Fargate |
-| **Gateways** | Slack, Discord, Email, WhatsApp integrations with smart routing |
+**How is this different from just using tmux?**
+tmux gives you terminals. AI Maestro gives you an organization — persistent memory, agent-to-agent messaging, team coordination, Kanban boards, multi-machine mesh, cloud deployment, and gateway integrations. tmux is the foundation; AI Maestro is the building.
 
-### How to Get Started
+**Is there a hosted / cloud version?**
+Not yet. AI Maestro runs on your machines. You own your data, your agents, and your infrastructure.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/23blocks-OS/ai-maestro/main/scripts/remote-install.sh | sh
-```
-
-Dashboard opens at `http://localhost:23000`
-
-**Time:** 5-10 minutes · **Requires:** Node.js 18+, tmux
-
-### Agent Deployment Modes
-
-| Mode | Best For |
-|------|----------|
-| **tmux** | Local development, zero setup |
-| **Docker** | Isolation, reproducibility, multi-project |
-| **AWS EC2** | Always-on agents, SSH access, persistent workloads |
-| **AWS ECS Fargate** | Burst scaling, zero maintenance, pay-per-use |
-
-### What is AMP (Agent Messaging Protocol)?
-
-AMP gives your agents email-like communication. Priority levels, message types, cryptographic signatures, and push notifications. Tell your agent *"send a message to backend about the deployment"* — it just works.
-
-### Help Resources
-
-| Resource | Link |
-|----------|------|
-| **Quick Start Guide** | ./docs/QUICKSTART.md |
-| **Windows Installation** | ./docs/WINDOWS-INSTALLATION.md |
-| **Contributing** | ./CONTRIBUTING.md |
-| **AMP Protocol** | https://agentmessaging.org |
-
-### License
-
-MIT License - Open source and free to use.
+**How do I add more agents?**
+Create them from the dashboard UI, the CLI (`aimaestro-agent.sh create`), or just start a new tmux session — AI Maestro auto-discovers it.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2843,6 +2843,37 @@ Modified files:
 
 ## Later (Future Considerations)
 
+### wterm Terminal Renderer (xterm.js Alternative)
+
+**Status:** On Hold — revisit when wterm reaches v1.0
+**Priority:** Low
+**Effort:** Medium (2-3 days)
+
+**Problem:**
+xterm.js uses Canvas/WebGL rendering which prevents native text selection, browser Cmd+F search, and accessibility. wterm (vercel-labs/wterm) uses DOM rendering, solving all three.
+
+**What we built:**
+- `components/WtermView.tsx` — full integration with WebSocket PTY bridge, scoped CSS, custom ResizeObserver
+- "Terminal v2" tab for side-by-side comparison with xterm.js
+- Packages installed: `@wterm/core@0.3.0`, `@wterm/dom@0.3.0`, `@wterm/react@0.3.0`
+
+**Why paused:**
+Our container/CSS/resize integration had bugs (half-width content, scroll position, content duplication on reconnect). These are solvable but need focused effort. wterm v0.3.0 also has open issues (#56 MAX_COLS=256, #57 no synchronized output, #49 tmux DEC alt charset, #43 scrollback corruption on resize) — none are blockers individually but add up.
+
+**What to do when revisiting:**
+1. Fix container sizing: wterm's `autoResize` ResizeObserver needs the container to have definite dimensions before init. Use the pattern from `examples/local/` — `flex h-screen flex-col` parent, `flex-1` on Terminal
+2. Handle reconnect: clear wterm buffer before replaying history to avoid duplication
+3. Clamp cols to 256 until #56 is fixed
+4. Scroll to bottom after writes (wterm's `_scrollToBottom` doesn't always fire)
+5. Scope CSS carefully — wterm's global CSS import (`@wterm/dom/css`) leaks to other tabs
+
+**Key advantages worth preserving:**
+- DOM rendering: native text selection, Cmd+F, accessibility
+- 12KB WASM core vs ~1MB xterm.js
+- Clean API: `new WTerm(el, opts)` → `await wt.init()` → `wt.write(data)`
+
+---
+
 ### Professional Distribution System
 
 **Status:** Planned

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.44",
-  "releaseDate": "2026-05-29",
+  "version": "0.35.48",
+  "releaseDate": "2026-06-01",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
- Refines @meichuanyi's FAQ contribution from PR #378
- Replaces duplicate feature/deployment tables with actual Q&A that adds value
- Fixes version badge (0.29.16 → 0.35.48)
- Adds wterm Terminal v2 experiment to BACKLOG.md for future revisit

## Changes
- **README.md**: FAQ rewritten — 6 real questions instead of copy-pasted tables
- **version.json**: bumped to 0.35.48
- **docs/BACKLOG.md**: added wterm backlog item with full context

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify version badge shows 0.35.48
- [ ] FAQ questions are distinct from Features section content

🤖 Generated with [Claude Code](https://claude.com/claude-code)