### PR TITLE
docs: add full ecosystem — AID, AAP, Canvas, LolaBot Factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,20 +165,30 @@ git clone https://github.com/23blocks-OS/lolabot.git
 cd lolabot && ./setup.sh
 ```
 
+**The LolaBot Ecosystem:**
+- **[LolaBot Framework](https://github.com/23blocks-OS/lolabot)** — Open-source agent framework. Build your own Lola.
+- **[lolabots.com](https://lolabots.com)** — The LolaBot Factory. Pre-built agent templates, one-click deploy.
+
 [Learn more about Lola →](https://github.com/23blocks-OS/lolabot)
 
 ---
 
 ## The Agent Ecosystem
 
-Every agent is built from four dimensions:
+Every agent is built from five dimensions:
 
 | | Dimension | What | Where |
 |-|-----------|------|-------|
 | **WHO** | Personality | Domain expertise, workflows, deliverables | [Agent Library](https://github.com/msitarzewski/agency-agents) (150+) |
-| **HOW** | Capabilities | Skills, scripts, CLI tools | [Plugin Builder](https://github.com/23blocks-OS/ai-maestro-plugins) |
+| **HOW** | Capabilities | Skills, scripts, CLI tools, Canvas | [Plugin Builder](https://github.com/23blocks-OS/ai-maestro-plugins) |
 | **TRUST** | Identity | Cryptographic keys, OAuth tokens | [AID](https://agentids.org) |
 | **TALK** | Communication | Agent-to-agent messaging | [AMP](https://agentmessaging.org) |
+| **ACT** | Actions | Tool execution, API calls, workflows | [AAP](https://agentactions.org) |
+
+**Open Protocols** — AI Maestro is built on three open standards:
+- **[AMP](https://agentmessaging.org)** — Agent Messaging Protocol. Email-like communication between agents with cryptographic signatures.
+- **[AID](https://agentids.org)** — Agent Identity. Portable cryptographic identity for agents across platforms.
+- **[AAP](https://agentactions.org)** — Agent Actions Protocol. Standardized tool execution and workflow triggers.
 
 AI Maestro is the stage. Pick personalities, give them skills, and run them from one dashboard.
 
@@ -235,8 +245,11 @@ AI Maestro is the stage. Pick personalities, give them skills, and run them from
 **Troubleshooting:**
 - [Common Issues](./docs/TROUBLESHOOTING.md) · [Security](./SECURITY.md) · [Windows Installation](./docs/WINDOWS-INSTALLATION.md)
 
+**Open Protocols:**
+- [AMP](https://agentmessaging.org) · [AID](https://agentids.org) · [AAP](https://agentactions.org)
+
 **Extending:**
-- [Plugin Development](./plugin/README.md) · [API Reference](./docs/AGENT-COMMUNICATION-ARCHITECTURE.md)
+- [Plugin Development](./plugin/README.md) · [API Reference](./docs/AGENT-COMMUNICATION-ARCHITECTURE.md) · [Ecosystem Guide](./docs/ECOSYSTEM.md)
 
 ---
 
@@ -295,8 +308,17 @@ Yes. macOS and Linux natively. Windows via WSL2 — see the [Windows guide](./do
 **Can agents on different machines talk to each other?**
 Yes. The [Agent Messaging Protocol (AMP)](https://agentmessaging.org) handles cross-machine messaging with cryptographic signatures and push notifications. No central server required.
 
+**What are AID and AAP?**
+[AID](https://agentids.org) (Agent Identity) gives each agent a portable cryptographic identity. [AAP](https://agentactions.org) (Agent Actions Protocol) standardizes how agents execute tools and trigger workflows. Together with [AMP](https://agentmessaging.org), they form the open protocol stack that AI Maestro is built on.
+
+**What is the Canvas skill?**
+Canvas lets agents generate visual artifacts — diagrams, charts, and interactive documents — directly from conversations. It's part of the plugin system and available to any agent.
+
 **How is this different from just using tmux?**
 tmux gives you terminals. AI Maestro gives you an organization — persistent memory, agent-to-agent messaging, team coordination, Kanban boards, multi-machine mesh, cloud deployment, and gateway integrations. tmux is the foundation; AI Maestro is the building.
+
+**What is LolaBot?**
+[LolaBot](https://github.com/23blocks-OS/lolabot) is an open-source agent framework — a batteries-included Chief of Staff that handles email, memory, tasks, and security. The [LolaBot Factory](https://lolabots.com) offers pre-built agent templates for one-click deployment.
 
 **Is there a hosted / cloud version?**
 Not yet. AI Maestro runs on your machines. You own your data, your agents, and your infrastructure.


### PR DESCRIPTION
## Summary
- Expands README to reflect the full 23blocks agent ecosystem
- Adds all three open protocols (AMP, AID, AAP) with descriptions
- Adds LolaBot Factory (lolabots.com) reference
- Adds Canvas skill and LolaBot FAQ entries

## Changes

**Ecosystem table** — expanded from 4 to 5 dimensions:
| Dimension | Protocol |
|-----------|----------|
| WHO | Agent Library |
| HOW | Plugin Builder + Canvas |
| TRUST | [AID](https://agentids.org) |
| TALK | [AMP](https://agentmessaging.org) |
| ACT | [AAP](https://agentactions.org) |

**LolaBot section** — added Framework + Factory links
**FAQ** — 3 new entries: AID/AAP, Canvas, LolaBot
**Documentation** — Open Protocols section with all 3 protocol links

## Test plan
- [ ] Verify all external links resolve (agentids.org, agentactions.org, agentmessaging.org, lolabots.com)
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)