### PR TITLE
fix: terminal content duplication on WebSocket reconnect (v0.35.50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.50] - 2026-06-04
+
+### Fixed
+- **Terminal: content duplication on WebSocket reconnect** — When a WebSocket connection dropped (heartbeat timeout, network blip), the client reconnected and the server sent 5000 lines of tmux history — but the terminal buffer was never cleared first. History was appended on top of existing content, causing visible duplication. For high-output agents (e.g., Claude Opus "thinking" animation producing dense ANSI), this created a devastating re-render every 30-40 seconds. Now clears the terminal buffer on reconnect before fresh history arrives.
+- **Chat: sending state distinguished from thinking** — Chat activity indicator now shows "Sending..." (blue pulse) while the message is being delivered to the agent, separate from "Thinking..." (amber pulse) when the agent is processing. Applies to both desktop ChatView and MobileChatView.
+- **Chat: paste-probe message delivery** — `sendChatMessage()` now uses tmux buffer paste (load-buffer + paste-buffer) instead of send-keys -l, with a poll-based verification loop that confirms the text appeared in the pane before sending Enter. Prevents lost messages when tmux input handling is slow. Also blocks sending when agent is at a permission prompt.
+- **Tab validation on load** — Active tab restored from localStorage is now validated against the list of valid tabs. Previously, a stale value (e.g., removed "terminal2") would silently fail to render any tab content.
+
 ## [0.35.44] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.48-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.50-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,7 +119,9 @@ export default function DashboardPage() {
   }
   const [activeTab, setActiveTab] = useState<'terminal' | 'chat' | 'messages' | 'worktree' | 'graph' | 'memory' | 'docs' | 'canvas' | 'search' | 'export' | 'playback'>(() => {
     if (typeof window === 'undefined') return 'chat'
-    return (localStorage.getItem('aimaestro-active-tab') as any) || 'chat'
+    const saved = localStorage.getItem('aimaestro-active-tab')
+    const validTabs = ['terminal', 'chat', 'messages', 'worktree', 'graph', 'memory', 'docs', 'canvas', 'search', 'export', 'playback']
+    return (saved && validTabs.includes(saved) ? saved : 'chat') as any
   })
   // Persist tab choice in localStorage
   useEffect(() => {
@@ -962,7 +964,6 @@ export default function DashboardPage() {
                         </ErrorBoundary>
                       )
                     ) : !isActive ? (
-                      // For inactive agents, don't mount heavy components - just show placeholder
                       <div className="flex-1 flex items-center justify-center text-gray-500">
                         <Loader2 className="w-6 h-6 animate-spin" />
                       </div>

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -620,7 +620,8 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
   const activityState = useMemo(() => {
     if (hookState?.status === 'permission_request') return 'permission' as const
     if (hookState?.status === 'waiting_for_input') return 'waiting' as const
-    if (pendingMessages.length > 0 || isSending) return 'thinking' as const
+    if (isSending) return 'sending' as const
+    if (pendingMessages.length > 0) return 'thinking' as const
     if (messages.length > 0) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const t = messages[i].type
@@ -638,6 +639,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
         <div className="flex items-center gap-3">
           <div className={`w-2 h-2 rounded-full flex-shrink-0 ${
             !isOnline ? 'bg-red-500'
+            : activityState === 'sending' ? 'bg-blue-400 animate-pulse'
             : activityState === 'thinking' ? 'bg-amber-400 animate-pulse'
             : activityState === 'permission' ? 'bg-red-400 animate-pulse'
             : activityState === 'waiting' ? 'bg-green-400'
@@ -646,6 +648,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
           <div>
             <h3 className="text-sm font-medium text-gray-200">
               {!isOnline ? 'Offline'
+              : activityState === 'sending' ? 'Sending...'
               : activityState === 'thinking'
                 ? (liveActivity
                   ? `${liveActivity.label}${liveActivity.detail ? ` · ${liveActivity.detail}` : ''}...`

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -543,8 +543,9 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
   // Determine status
   const isPermission = hookState?.status === 'permission_request'
   const isWaiting = hookState?.status === 'waiting_for_input'
-  const isWorking = pendingMessages.length > 0 || (messages.length > 0 && !isWaiting && !isPermission &&
-    (messages[messages.length - 1]?.type === 'user' || messages[messages.length - 1]?.type === 'human'))
+  const isSendingMsg = sending
+  const isWorking = !sending && (pendingMessages.length > 0 || (messages.length > 0 && !isWaiting && !isPermission &&
+    (messages[messages.length - 1]?.type === 'user' || messages[messages.length - 1]?.type === 'human')))
 
   return (
     <div className="flex flex-col h-full bg-gray-900">
@@ -883,16 +884,17 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
           <div className="px-3 py-1.5 flex items-center gap-2">
             <div
               className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                isWaiting ? 'bg-green-500' : isWorking ? 'bg-amber-500 animate-pulse' : 'bg-gray-500'
+                isWaiting ? 'bg-green-500' : isSendingMsg ? 'bg-blue-400 animate-pulse' : isWorking ? 'bg-amber-500 animate-pulse' : 'bg-gray-500'
               }`}
             />
             <span className="text-xs text-gray-400">
               {isWaiting ? 'Ready for input'
+               : isSendingMsg ? 'Sending...'
                : isWorking
                  ? (liveActivity ? `${liveActivity.label}${liveActivity.detail ? ` · ${liveActivity.detail}` : ''}` : 'Working...')
                  : 'Idle'}
             </span>
-            {isWorking && <Loader2 className="w-3 h-3 text-amber-500 animate-spin" />}
+            {(isSendingMsg || isWorking) && <Loader2 className={`w-3 h-3 animate-spin ${isSendingMsg ? 'text-blue-400' : 'text-amber-500'}`} />}
           </div>
         )}
       </div>

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -107,6 +107,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
 
   // Store terminal in a ref so the WebSocket callback can access the current value
   const terminalInstanceRef = useRef<typeof terminal>(null)
+  const hasConnectedOnceRef = useRef(false)
 
   useEffect(() => {
     terminalInstanceRef.current = terminal
@@ -206,6 +207,16 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       // Reset history gate — server will send history then history-complete
       historyCompleteRef.current = false
       lastSentSizeRef.current = null
+      // On reconnect, clear the terminal before fresh history arrives.
+      // Without this, the 5000-line history dump from the server is appended
+      // to existing content, causing visible duplication every reconnect cycle.
+      if (hasConnectedOnceRef.current) {
+        const term = terminalInstanceRef.current
+        if (term) {
+          term.clear()
+        }
+      }
+      hasConnectedOnceRef.current = true
     },
     onClose: () => {
       // Notify parent of connection status change

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
     "@huggingface/transformers": "^3.8.1",
+    "@wterm/core": "^0.3.0",
+    "@wterm/dom": "^0.3.0",
+    "@wterm/react": "^0.3.0",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/server.mjs
+++ b/server.mjs
@@ -670,6 +670,103 @@ function getAgentIdForSession(sessionName) {
 }
 
 /**
+ * Send a chat message to a tmux session with verification.
+ *
+ * 1. Check if the agent is at a permission prompt — refuse if so.
+ * 2. Capture pane baseline.
+ * 3. Write text to a temp file, load into tmux buffer, paste into pane.
+ * 4. Poll until the tail of the text appears in the pane (paste-probe).
+ * 5. Send Enter only after verification (or after timeout).
+ *
+ * Returns { ok, error? }
+ */
+const PASTE_PROBE_TIMEOUT_MS = 1200
+const PASTE_PROBE_INTERVAL_MS = 50
+const PASTE_PROBE_MIN_CHARS = 8
+
+function capturePaneCompact(sessionName, lines = 100) {
+  try {
+    const res = execSync(
+      `tmux capture-pane -p -J -t "${sessionName}" -S -${lines}`,
+      { timeout: 2000, encoding: 'utf-8' }
+    )
+    return res.replace(/\s+/g, ' ').trim()
+  } catch { return '' }
+}
+
+function pasteTailProbe(text) {
+  const compacted = text.replace(/\s+/g, ' ').trim()
+  if (compacted.length <= PASTE_PROBE_MIN_CHARS) return compacted
+  return compacted.slice(-Math.min(80, compacted.length))
+}
+
+function isAgentAtPermissionPrompt(sessionName) {
+  try {
+    const raw = execSync(
+      `tmux capture-pane -p -t "${sessionName}" -S -15`,
+      { timeout: 2000, encoding: 'utf-8' }
+    )
+    const lines = raw.split('\n').map(l => l.trim()).filter(Boolean)
+    const lastLines = lines.slice(-12).join('\n').toLowerCase()
+    return lastLines.includes('esc to cancel') &&
+      (lastLines.includes('do you want to proceed') ||
+       lastLines.includes('yes, and don\'t ask') ||
+       /❯\s*1\.\s*yes/i.test(lastLines))
+  } catch { return false }
+}
+
+async function sendChatMessage(sessionName, message) {
+  // 1. Check hookState first (fast path)
+  const sessionState = terminalSessions.get(sessionName)
+  if (sessionState?._lastPermission?.status === 'permission_request') {
+    return { ok: false, error: 'Agent is waiting for permission approval. Approve or deny the pending action first.' }
+  }
+  // 2. Check pane for permission prompt (catches cases hookState missed)
+  if (isAgentAtPermissionPrompt(sessionName)) {
+    return { ok: false, error: 'Agent is waiting for permission approval. Approve or deny the pending action first.' }
+  }
+
+  // 3. Capture baseline for paste-probe verification
+  const baseline = capturePaneCompact(sessionName)
+
+  // 4. Write text to temp file, load into tmux buffer, paste into pane
+  const tmpFile = path.join(os.tmpdir(), `aimaestro-send-${Date.now()}.txt`)
+  const bufferName = `aimaestro-${Date.now()}`
+  try {
+    fs.writeFileSync(tmpFile, message, 'utf-8')
+    execSync(`tmux load-buffer -b "${bufferName}" "${tmpFile}"`, { timeout: 3000 })
+    execSync(`tmux paste-buffer -d -r -b "${bufferName}" -t "${sessionName}"`, { timeout: 3000 })
+  } catch (err) {
+    try { fs.unlinkSync(tmpFile) } catch {}
+    try { execSync(`tmux delete-buffer -b "${bufferName}"`, { timeout: 1000 }) } catch {}
+    return { ok: false, error: 'Failed to paste text: ' + err.message }
+  }
+  try { fs.unlinkSync(tmpFile) } catch {}
+
+  // 5. Paste-probe: poll until text tail appears in pane
+  const probe = pasteTailProbe(message)
+  if (probe) {
+    const baselineCount = (baseline.match(new RegExp(probe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
+    const deadline = Date.now() + PASTE_PROBE_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      const captured = capturePaneCompact(sessionName)
+      const currentCount = (captured.match(new RegExp(probe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
+      if (currentCount > baselineCount) break
+      await new Promise(r => setTimeout(r, PASTE_PROBE_INTERVAL_MS))
+    }
+  }
+
+  // 6. Send Enter (C-m is more reliable than Enter through tmux)
+  try {
+    execSync(`tmux send-keys -t "${sessionName}" C-m`, { timeout: 3000 })
+  } catch (err) {
+    return { ok: false, error: 'Text pasted but Enter failed: ' + err.message }
+  }
+
+  return { ok: true }
+}
+
+/**
  * Extract structured activity signals from raw PTY output.
  * Returns { label, detail? } or null if no recognizable signal.
  */
@@ -1556,26 +1653,17 @@ async function startServer(handleRequest) {
             startJsonlWatcher(sessionName, sessionState, parsed.agentId)
           } else if (parsed.type === 'chat:send') {
             if (parsed.message) {
-              // Always use tmux send-keys -l with proper escaping and delay.
-              // Direct ptyProcess.write() bypasses tmux input handling and
-              // doesn't give Claude Code the 100ms gap it needs between text
-              // and Enter to process the input.
-              try {
-                const escaped = parsed.message.replace(/'/g, "'\\''")
-                execSync(`tmux send-keys -t "${sessionName}" -l '${escaped}'`, { timeout: 3000 })
-                // 100ms delay so Claude Code processes the literal text before Enter
-                await new Promise(r => setTimeout(r, 100))
-                execSync(`tmux send-keys -t "${sessionName}" Enter`, { timeout: 3000 })
+              const result = await sendChatMessage(sessionName, parsed.message)
+              if (result.ok) {
                 if (ws.readyState === 1) {
                   ws.send(JSON.stringify({ type: 'chat:sent' }))
                 }
-                // Burst-read JSONL to catch user message echo and early response
                 for (const delay of [500, 1500, 3000, 5000, 8000, 12000]) {
                   setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), delay)
                 }
-              } catch (err) {
+              } else {
                 if (ws.readyState === 1) {
-                  ws.send(JSON.stringify({ type: 'chat:error', error: 'Failed to send: ' + err.message }))
+                  ws.send(JSON.stringify({ type: 'chat:error', error: result.error }))
                 }
               }
             }
@@ -2007,20 +2095,17 @@ async function startServer(handleRequest) {
 
           if (parsed.type === 'chat:send') {
             if (parsed.message) {
-              try {
-                const escaped = parsed.message.replace(/'/g, "'\\''")
-                execSync(`tmux send-keys -t "${sessionName}" -l '${escaped}'`, { timeout: 3000 })
-                await new Promise(r => setTimeout(r, 100))
-                execSync(`tmux send-keys -t "${sessionName}" Enter`, { timeout: 3000 })
+              const result = await sendChatMessage(sessionName, parsed.message)
+              if (result.ok) {
                 if (ws.readyState === 1) {
                   ws.send(JSON.stringify({ type: 'chat:sent' }))
                 }
                 for (const delay of [500, 1500, 3000, 5000, 8000, 12000]) {
                   setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), delay)
                 }
-              } catch (err) {
+              } else {
                 if (ws.readyState === 1) {
-                  ws.send(JSON.stringify({ type: 'chat:error', error: 'Failed to send: ' + err.message }))
+                  ws.send(JSON.stringify({ type: 'chat:error', error: result.error }))
                 }
               }
             }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.48",
-  "releaseDate": "2026-06-01",
+  "version": "0.35.50",
+  "releaseDate": "2026-06-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,23 @@
     "@vitest/pretty-format" "4.0.18"
     tinyrainbow "^3.0.3"
 
+"@wterm/core@0.3.0", "@wterm/core@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wterm/core/-/core-0.3.0.tgz#3791a487154c992b3c5080bce0fe5739556faa0d"
+  integrity sha512-aQ73QBP+eyA3kcn31mA7DmAi7qmEsQijZdmvgwxtSjCi2248EAOZgtkGDpjlspfrxyVxQbUl/IF+gCVcXt4nZQ==
+
+"@wterm/dom@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wterm/dom/-/dom-0.3.0.tgz#776fcab8d587e9423e7234f5789cb07f86dfbad2"
+  integrity sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ==
+  dependencies:
+    "@wterm/core" "0.3.0"
+
+"@wterm/react@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wterm/react/-/react-0.3.0.tgz#3cf0a35d00edce4e86f63f05ded09310bb261ac4"
+  integrity sha512-1rua/roQGCIGkNxjs9TVq+EkXJ0n2IK6aCoaGIQJpvzuHv7iU9/lngG3i1SCpX6deOOO/wpfhtjDTI+z9XF0aA==
+
 "@xterm/addon-clipboard@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz#8f2027b141e78f70fc76ba56aacf467250c284a3"


### PR DESCRIPTION
## Summary
- **Terminal reconnect fix**: Clear terminal buffer on WebSocket reconnect before fresh history arrives. Prevents content duplication that made high-output agents (jarvis) unusable — history was appended on top of existing content every 30-40s.
- **Chat paste-probe delivery**: `sendChatMessage()` uses tmux buffer paste with poll-based verification instead of `send-keys -l`. Blocks sending at permission prompts.
- **Chat sending vs thinking state**: "Sending..." (blue) and "Thinking..." (amber) are now distinct activity states in both desktop and mobile chat views.
- **Tab validation**: localStorage active tab validated against known tabs on load, preventing blank content from stale values.

## Root Cause (Terminal)
When a WebSocket disconnects (heartbeat timeout, network blip), the server sends 5000 lines of `tmux capture-pane` history on reconnect. The client never cleared the terminal buffer first — history was appended to existing content. For jarvis (Claude Opus thinking animation producing dense ANSI output), this caused a full visual re-render every ~35 seconds.

## Test plan
- [ ] Open jarvis terminal — should no longer duplicate content on reconnect
- [ ] Disconnect network briefly, reconnect — terminal shows clean history without duplication
- [ ] Chat: send message while agent is at permission prompt — should show error
- [ ] Chat: send message — should show "Sending..." then "Thinking..."
- [ ] Remove `aimaestro-active-tab` from localStorage, set to invalid value, reload — should default to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)