### PR TITLE
revert: undo headless xterm.js (v0.35.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,10 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.35.53] - 2026-06-04
+## [0.35.54] - 2026-06-05
 
-### Added
-- **Terminal: headless xterm.js for lossless state reconstruction** — Server now maintains a headless xterm.js instance (`@xterm/headless` + `@xterm/addon-serialize`) per PTY session, receiving all PTY data in parallel. On client connect/reconnect, the full terminal state (scrollback, cursor position, colors, alternate screen buffer, TUI layout) is serialized and sent as a `terminal-state` message. Client deserializes into its own xterm.js for perfect reconstruction. This is the same approach VS Code uses for remote terminal reconnection. Falls back to `tmux capture-pane` for sessions without a headless terminal. Fixes the long-standing issue where Claude Code's green status bar and TUI layout were missing on initial load.
-
-### Changed
-- **Terminal: parallel addon loading** — All 6 xterm.js addon imports (`xterm`, `fit`, `web-links`, `clipboard`, `unicode11`, `serialize`) now load via `Promise.all()` instead of sequential `await`s. Combined with reducing the server-side state delay from 200ms to 100ms, this cuts first-render time significantly.
-- **Dependencies: node-pty 1.1.0, ws 8.21.0** — Updated `node-pty` from 1.0.0 to 1.1.0 and `ws` from 8.18.3 to 8.21.0 for latest bug fixes and performance improvements.
+### Reverted
+- **Terminal: revert headless xterm.js and parallel addon loading (v0.35.52–v0.35.53)** — The headless xterm.js approach (server-side serialized terminal state) caused terminal initialization failures, broken scrolling, and multi-minute load times on agent switch. Reverted `server.mjs`, `useTerminal.ts`, and `TerminalView.tsx` to the stable v0.35.50 behavior (tmux capture-pane for history, sequential addon loading, blocking WebGL init). Dependencies (node-pty 1.1.0, ws 8.21.0) remain updated.
 
 ## [0.35.50] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.53-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.54-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -92,7 +92,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
 
   const { registerTerminal, unregisterTerminal, reportActivity } = useTerminalRegistry()
 
-  const { terminal, initializeTerminal, fitTerminal, setSendData, deserializeState } = useTerminal({
+  const { terminal, initializeTerminal, fitTerminal, setSendData } = useTerminal({
     sessionId: session.id,
     disableWebGL: isTouch,  // MOBILE FIX: WebGL context loss on backgrounding causes blank terminals
     onRegister: (fitAddon) => {
@@ -226,16 +226,6 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       // Check if this is a control message (JSON)
       try {
         const parsed = JSON.parse(data)
-
-        // Handle lossless terminal state from server's headless xterm.js.
-        // This replaces the old capture-pane text dump with perfect state
-        // reconstruction including scrollback, cursor, colors, and TUI layout.
-        if (parsed.type === 'terminal-state') {
-          if (parsed.data && deserializeState) {
-            deserializeState(parsed.data)
-          }
-          return
-        }
 
         // Handle history-complete message
         if (parsed.type === 'history-complete') {

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -4,7 +4,6 @@ import { useRef, useCallback, useEffect } from 'react'
 import type { Terminal } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
 import type { WebglAddon } from '@xterm/addon-webgl'
-import type { SerializeAddon } from '@xterm/addon-serialize'
 
 export interface UseTerminalOptions {
   fontSize?: number
@@ -22,7 +21,6 @@ export function useTerminal(options: UseTerminalOptions = {}) {
   const terminalRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const webglAddonRef = useRef<WebglAddon | null>(null)
-  const serializeAddonRef = useRef<SerializeAddon | null>(null)
   const optionsRef = useRef(options)
   // Ref for sending data to PTY via WebSocket - set by TerminalView which has WebSocket access
   const sendDataRef = useRef<((data: string) => void) | null>(null)
@@ -45,26 +43,15 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       container.removeChild(container.firstChild)
     }
 
-    // Load all xterm.js modules in parallel (was sequential — each await blocked the next)
-    const [
-      { Terminal },
-      { FitAddon },
-      { WebLinksAddon },
-      clipboardMod,
-      unicodeMod,
-      serializeMod,
-    ] = await Promise.all([
-      import('@xterm/xterm'),
-      import('@xterm/addon-fit'),
-      import('@xterm/addon-web-links'),
-      import('@xterm/addon-clipboard').catch(() => null),
-      import('@xterm/addon-unicode11').catch(() => null),
-      import('@xterm/addon-serialize').catch(() => null),
-    ])
+    // Dynamic imports for browser-only code
+    const { Terminal } = await import('@xterm/xterm')
+    const { FitAddon } = await import('@xterm/addon-fit')
+    const { WebLinksAddon } = await import('@xterm/addon-web-links')
 
     const fontSize = optionsRef.current.fontSize || 16
     const fontFamily = optionsRef.current.fontFamily || '"SF Mono", "Monaco", "Cascadia Code", "Roboto Mono", "Courier New", monospace'
 
+    // Create terminal instance - let FitAddon handle sizing
     const terminal = new Terminal({
       cursorBlink: true,
       fontSize,
@@ -76,13 +63,13 @@ export function useTerminal(options: UseTerminalOptions = {}) {
         background: '#1e1e1e',
         foreground: '#d4d4d4',
         cursor: '#aeafad',
-        selectionBackground: '#3a3d41',
-        selectionForeground: '#ffffff',
-        selectionInactiveBackground: '#3a3d41',
+        selectionBackground: '#3a3d41',    // Visible selection background
+        selectionForeground: '#ffffff',     // White text when selected
+        selectionInactiveBackground: '#3a3d41', // Selection when terminal not focused
         black: '#000000',
         red: '#cd3131',
         green: '#0dbc79',
-        yellow: '#dcdcaa',
+        yellow: '#dcdcaa',  // Softer yellow (VS Code default)
         blue: '#2472c8',
         magenta: '#bc3fbc',
         cyan: '#11a8cd',
@@ -90,21 +77,27 @@ export function useTerminal(options: UseTerminalOptions = {}) {
         brightBlack: '#666666',
         brightRed: '#f14c4c',
         brightGreen: '#23d18b',
-        brightYellow: '#dcdcaa',
+        brightYellow: '#dcdcaa',  // Match normal yellow for consistency
         brightBlue: '#3b8eea',
         brightMagenta: '#d670d6',
         brightCyan: '#29b8db',
         brightWhite: '#ffffff',
       },
-      scrollback: 10000,
+      scrollback: 10000,  // Reasonable buffer for conversation context
+      // CRITICAL: Must be false for PTY connections
+      // PTY and tmux handle line endings correctly - setting this to true causes
+      // Claude Code status updates (using \r) to create new lines instead of overwriting
       convertEol: false,
       allowTransparency: false,
       scrollSensitivity: 1,
       fastScrollSensitivity: 5,
+      // Ensure scrollback works in all modes
       altClickMovesCursor: false,
+      // Support alternate screen buffer (used by Claude Code, vim, etc.)
       windowOptions: {
         setWinLines: true,
       },
+      // Disable screen reader mode - accessibility tree handled via CSS pointer-events
       screenReaderMode: false,
       disableStdin: false,
       customGlyphs: true,
@@ -112,27 +105,35 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       rightClickSelectsWord: true,
     })
 
+    // Initialize addons
     const fitAddon = new FitAddon()
     const webLinksAddon = new WebLinksAddon()
 
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(webLinksAddon)
 
-    if (clipboardMod) {
-      terminal.loadAddon(new clipboardMod.ClipboardAddon())
+    // Load clipboard addon for OSC 52 support (terminal programs accessing clipboard)
+    try {
+      const { ClipboardAddon } = await import('@xterm/addon-clipboard')
+      const clipboardAddon = new ClipboardAddon()
+      terminal.loadAddon(clipboardAddon)
+    } catch (e) {
+      console.warn(`[Terminal] ClipboardAddon not available for session ${optionsRef.current.sessionId}:`, e)
     }
 
-    if (unicodeMod) {
-      terminal.loadAddon(new unicodeMod.Unicode11Addon())
+    // Load Unicode 11 addon for proper wide character / emoji width calculation.
+    // Without this, TUI layouts (Claude Code /plan mode, box-drawing) are corrupted
+    // because xterm.js miscalculates character widths for CJK and emoji.
+    try {
+      const { Unicode11Addon } = await import('@xterm/addon-unicode11')
+      const unicode11Addon = new Unicode11Addon()
+      terminal.loadAddon(unicode11Addon)
       terminal.unicode.activeVersion = '11'
+    } catch (e) {
+      console.warn(`[Terminal] Unicode11Addon not available for session ${optionsRef.current.sessionId}:`, e)
     }
 
-    if (serializeMod) {
-      const serializeAddon = new serializeMod.SerializeAddon()
-      terminal.loadAddon(serializeAddon)
-      serializeAddonRef.current = serializeAddon
-    }
-
+    // Open terminal in container
     terminal.open(container)
 
     // NOTE: No MutationObserver or JS-based accessibility tree hiding.
@@ -368,22 +369,6 @@ export function useTerminal(options: UseTerminalOptions = {}) {
     }
   }, [])
 
-  // Deserialize full terminal state from server's headless xterm.js.
-  // Clears the terminal first, then writes the serialized state which
-  // restores scrollback, cursor position, colors, and alternate screen.
-  const deserializeState = useCallback((serializedData: string) => {
-    const term = terminalRef.current
-    if (!term) return false
-    try {
-      term.reset()
-      term.write(serializedData)
-      return true
-    } catch (e) {
-      console.warn('[Terminal] Failed to deserialize state:', e)
-      return false
-    }
-  }, [])
-
   // Allow TerminalView to set the WebSocket send function for paste support
   const setSendData = useCallback((fn: ((data: string) => void) | null) => {
     sendDataRef.current = fn
@@ -396,7 +381,6 @@ export function useTerminal(options: UseTerminalOptions = {}) {
     fitTerminal,
     clearTerminal,
     writeToTerminal,
-    deserializeState,
     setSendData,
   }
 }

--- a/server.mjs
+++ b/server.mjs
@@ -12,13 +12,6 @@ import { getHostById, isSelf } from './lib/hosts-config-server.mjs'
 import { hostHints } from './lib/host-hints-server.mjs'
 import { getOrCreateBuffer, removeBuffer } from './lib/cerebellum/session-bridge.mjs'
 import {
-  getOrCreateHeadlessTerminal,
-  writeToHeadlessTerminal,
-  serializeTerminalState,
-  resizeHeadlessTerminal,
-  disposeHeadlessTerminal,
-} from './lib/headless-terminal.mjs'
-import {
   sessionActivity,
   terminalSessions,
   statusSubscribers,
@@ -536,9 +529,6 @@ function cleanupSession(sessionName, sessionState, reason = 'unknown', ptyAlread
   if (sessionState.ptyProcess) {
     killPtyProcess(sessionState.ptyProcess, sessionName, ptyAlreadyExited)
   }
-
-  // Dispose headless terminal (lossless state tracker)
-  disposeHeadlessTerminal(sessionName)
 
   // Stop JSONL file watcher
   if (sessionState.jsonlWatcher) {
@@ -1857,7 +1847,6 @@ async function startServer(handleRequest) {
         sessionState.ptyProcess = ptyProcess
         sessionState.loggingEnabled = true
         sessionState.terminalBuffer = getOrCreateBuffer(sessionName)
-        getOrCreateHeadlessTerminal(sessionName, ptyProcess.cols || 80, ptyProcess.rows || 24)
         if (globalLoggingEnabled && !sessionState.logStream) {
           const logFilePath = path.join(logsDir, `${sessionName}.txt`)
           sessionState.logStream = fs.createWriteStream(logFilePath, { flags: 'a' })
@@ -1881,7 +1870,6 @@ async function startServer(handleRequest) {
               !(data.startsWith('\x1b') && !/[\x20-\x7E]/.test(data))
             if (hasSubstantialContent) trackSessionActivity(sessionName)
             if (sessionState.terminalBuffer && hasSubstantialContent) sessionState.terminalBuffer.write(data)
-            writeToHeadlessTerminal(sessionName, data)
             sessionState.clients.forEach((client) => {
               if (client.readyState === 1) {
                 try { client.send(data) } catch {}
@@ -1908,8 +1896,6 @@ async function startServer(handleRequest) {
         const logFilePath = path.join(logsDir, `${sessionName}.txt`)
         logStream = fs.createWriteStream(logFilePath, { flags: 'a' }) // 'a' for append mode
       }
-
-      getOrCreateHeadlessTerminal(sessionName, ptyProcess.cols || 80, ptyProcess.rows || 24)
 
       sessionState = {
         clients: new Set(),
@@ -1986,9 +1972,6 @@ async function startServer(handleRequest) {
             sessionState.terminalBuffer.write(data)
           }
 
-          // Feed ALL data to headless terminal (lossless state tracking)
-          writeToHeadlessTerminal(sessionName, data)
-
           // Send data to all connected clients synchronously
           sessionState.clients.forEach((client) => {
             if (client.readyState === 1) { // WebSocket.OPEN
@@ -2023,6 +2006,23 @@ async function startServer(handleRequest) {
       console.warn(`[PTY] Failed to set mouse off for ${sessionName}:`, e.message)
     }
 
+    // Capture FULL pane content (scrollback + visible area) with ANSI color codes.
+    // We send this as a single snapshot and intentionally DON'T add the client to the
+    // PTY broadcast set yet — the PTY's initial `tmux attach` redraw would duplicate
+    // the visible area. By delaying broadcast join, the redraw is discarded.
+    try {
+      const tmuxBase = socketPath ? `tmux -S "${socketPath}"` : 'tmux'
+      const paneContent = execSync(
+        `${tmuxBase} capture-pane -t "${sessionName}" -e -p -S -5000 2>/dev/null`,
+        { encoding: 'utf8', timeout: 3000 }
+      )
+      if (paneContent && paneContent.trim() && ws.readyState === 1) {
+        ws.send(paneContent.replace(/\n/g, '\r\n'))
+      }
+    } catch (e) {
+      // capture failed — client will get content once added to broadcast
+    }
+
     // Track connection as activity (so newly opened sessions show as active)
     trackSessionActivity(sessionName)
     console.log(`[ACTIVITY-TRACK] Set activity for ${sessionName}, map size: ${sessionActivity.size}`)
@@ -2034,39 +2034,15 @@ async function startServer(handleRequest) {
       sessionState.cleanupTimer = null
     }
 
-    // Delay before sending state and adding client to broadcast.
-    // 100ms lets the initial tmux redraw arrive and be processed by the headless
-    // terminal, so serialization captures the full screen state.
+    // Add client to broadcast AFTER the PTY's initial redraw has passed (discarded).
+    // 150ms is enough for the tmux attach redraw to fire and be ignored.
+    // After this, the client receives all live PTY output going forward.
     setTimeout(() => {
-      if (ws.readyState !== 1) return
-
-      // Send lossless terminal state from headless xterm.js instance.
-      // This replaces tmux capture-pane (which was lossy — flat text without cursor
-      // positioning, alternate screen, or TUI layout). The client deserializes this
-      // for perfect state reconstruction including scrollback, cursor, and TUI layout.
-      const serialized = serializeTerminalState(sessionName)
-      if (serialized) {
-        ws.send(JSON.stringify({ type: 'terminal-state', data: serialized }))
-        console.log(`[HeadlessTerm] Sent serialized state for ${sessionName} (${serialized.length} bytes)`)
-      } else {
-        // Fall back to capture-pane for sessions where headless terminal isn't ready
-        try {
-          const tmuxBase = socketPath ? `tmux -S "${socketPath}"` : 'tmux'
-          const paneContent = execSync(
-            `${tmuxBase} capture-pane -t "${sessionName}" -e -p -S -5000 2>/dev/null`,
-            { encoding: 'utf8', timeout: 3000 }
-          )
-          if (paneContent && paneContent.trim()) {
-            ws.send(paneContent.replace(/\n/g, '\r\n'))
-          }
-        } catch (e) {
-          // capture failed — client will get content once added to broadcast
-        }
-      }
-
       sessionState.clients.add(ws)
-      ws.send(JSON.stringify({ type: 'history-complete' }))
-    }, 100)
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: 'history-complete' }))
+      }
+    }, 150)
 
     // Handle client input
     ws.on('message', async (data) => {
@@ -2085,7 +2061,6 @@ async function startServer(handleRequest) {
 
           if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
             sessionState.ptyProcess.resize(parsed.cols, parsed.rows)
-            resizeHeadlessTerminal(sessionName, parsed.cols, parsed.rows)
             return
           }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.53",
+  "version": "0.35.54",
   "releaseDate": "2026-06-05",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary
- **Reverts v0.35.52–v0.35.53** — headless xterm.js server-side serialization, parallel addon loading, non-blocking WebGL, and isVisible WebSocket gating all caused terminal breakage: init failures (`allowProposedApi` dropped), broken scrolling, and multi-minute load times on agent switch
- **Restores v0.35.50 terminal behavior** — tmux capture-pane for history, sequential addon loading, blocking WebGL init
- **Keeps dependency updates** — node-pty 1.1.0, ws 8.21.0

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (792/792)
- [ ] Terminals load on agent switch without delay
- [ ] Scrolling works normally
- [ ] No "Initializing terminal..." spinner stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)