### PR TITLE
Terminal + chat UX, streaming execution mode, permission reliability, security (v0.35.55→v0.36.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.6] – [0.36.10] - 2026-07-24 — Permission reliability, terminal scrollback, security
+
+### Security
+- **RCE via gray-matter JavaScript frontmatter (GHSA-g7qj-fhxp-6chc)** [0.36.7] — `gray-matter` evaluates `---js`/`---javascript`/`---coffee` frontmatter as executable code. Parsing untrusted `SKILL.md` (from the unauthenticated `POST /api/plugin-builder/scan-repo`, or installed marketplace plugins) with plain `matter()` was a remote-code-execution vector (CWE-94, high severity). Added `lib/safe-matter.ts` which overrides those engines to throw, and replaced both call sites (`plugin-builder-service.ts`, `marketplace-skills.ts`). Reported by tonghuaroot.
+
+### Fixed
+- **Chat: permission prompts now show reliably AND button responses land** [0.36.8–0.36.10] — Three stacked bugs that forced users to bounce between chat and terminal to see/answer tool-permission prompts:
+  - *Responses never landed:* permission button clicks went through `sendChatMessage`, whose guard **refuses to send while a prompt is pending** — so the answer to the prompt was blocked by the prompt. New `sendPermissionResponse()` bypasses the guard and sends the **raw keystroke** (`chat:permissionResponse` frame) that actually selects a Claude Code menu option, instead of pasting a line.
+  - *Session torn down under the chat:* cleanup counted only terminal (PTY) clients, so with the chat open and no terminal attached, the 30s grace cleanup destroyed the session — killing the permission watchers and orphaning the chat ("message sending forever"). Cleanup now fires only when **both** terminal and chat clients are gone; a 2.5s permission poll surfaces prompts regardless of hook/JSONL timing.
+  - *Prompts buried under output missed:* the pane detector scanned only the last 18 lines. Rewrote `detectPermissionFromPane()` to anchor on menu **structure** (footer/`❯` selector/"do you want to proceed" + ≥2 short numbered options) over a 45-line region — finds buried menus and AskUserQuestion pickers, rejects prose lists and "working" states. Fixes apply to desktop, mobile, and tablet chat (server-side detection + shared response path).
+- **Terminal: scrollback restored** [0.36.6] — Claude Code rolled out its fullscreen/alternate-screen renderer as default (2.1.11x→2.1.20x); on the alt screen nothing is written to the normal buffer, so tmux keeps zero history and scroll does nothing. Agents now launch with `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` (Anthropic's documented opt-out) so output returns to the normal buffer and scrollback works. Verified: plain claude → `alt=1 hist=0`; with the var → `alt=0`, history grows. Escape hatch: `AIMAESTRO_KEEP_ALT_SCREEN=true`. Takes effect on agents woken after the change.
+
+## [0.36.0] – [0.36.5] - 2026-07-23 — Streaming execution mode (Agent SDK)
+
+### Added
+- **Streaming agents — Claude via the Agent SDK, no tmux** — A per-agent `stream-json` runtime (`lib/streaming-runtime.mjs`, `@anthropic-ai/claude-agent-sdk`) as an alternative to the terminal: structured chat with token-level streaming, **permission cards** via the SDK `canUseTool` callback (risky tools prompt, safe ones auto-run), native session **resume** (continues the agent's latest conversation), persistent per-agent sessions with buffered replay across reconnects, and identity injection. Runs on the user's subscription (headless token from `~/.aimaestro/claude-oauth-token`).
+- **Wake-dialog execution mode** — Choose **Terminal** or **Streaming** when waking a Claude agent; streaming needs no tmux (spawns on connect and resumes the latest conversation). The Terminal tab is disabled with a jump-to-Streaming affordance while an agent runs in streaming mode; a mode badge shows the active mode. Additive — no changes to tmux online-detection; terminal agents untouched.
+
+## [0.35.55] – [0.35.64] - 2026-07-05 — Terminal + chat UX (phase 0)
+
+### Fixed
+- **Chat reliability** — Messages wrap inside the viewport (no clipped/overflowing bubbles); send never submits unverified text silently (fails visibly with retry, then reverted the over-strict gate so verified sends aren't dropped); pending bubbles clear only when their own echo lands and expire to a retryable failed state; dedup no longer drops thinking blocks; scroll-stick keeps you in place while reading with a "new messages" pill; reconnect after backgrounding actually reconnects; transcript path handles `.` in project dirs and re-resolves after `/clear`.
+- **Terminal reliability** — Fixed an idle-heartbeat false positive that force-reconnected healthy terminals every ~40s (the periodic refresh/flash); unified paste through `terminal.paste()` (no more literal `200~` leaks); copy-on-select is opt-in; async tmux calls on connect (no event-loop stalls); exponential reconnect backoff. Removed a mis-designed tmux copy-mode scroll experiment (`0/0`, swallowed Enter) in favor of plain xterm scrolling.
+- **Consolidated** the triplicated JSONL transcript logic into `lib/chat-transcript.mjs`; released the cerebellum ring-buffer on session cleanup.
+
 ## [0.35.54] - 2026-06-05
 
 ### Reverted

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.6-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.7-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.7-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.6-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.64-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.61-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.62-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.62-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.63-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.56-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.57-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.63-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.64-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.58-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.59-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.60-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.61-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.10-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.59-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.60-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.55-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.56-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.54-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.55-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.35.57-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.35.58-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/STREAMING-AGENTS-PLAN.md
+++ b/STREAMING-AGENTS-PLAN.md
@@ -1,0 +1,161 @@
+# Execution Modes for Agents (Terminal ⇄ Streaming) — Implementation Plan
+
+Status: DRAFT for review. Linchpin VERIFIED (see below). Author: 2026-07-08.
+
+## The model (corrected)
+
+An agent is **one persistent entity** whose state lives on disk (registry ID,
+name, working directory, AMP keys, CozoDB memory, and its `.jsonl` conversation
+history). **Terminal vs Streaming is not a kind of agent — it's an execution
+mode chosen at wake time.** The same agent can run in terminal (tmux TUI) mode
+one session and streaming (stream-json) mode the next, and keep its full
+conversation, because both modes resume the same session.
+
+> Desk: wake in **terminal** mode → tmux TUI, work for hours, hibernate.
+> Phone: wake in **streaming** mode → clean chat, **same conversation**, full
+> context. Switch back anytime. One agent, two ways to attach.
+
+This vindicates the original instinct: the mode choice belongs on the **wake
+dialog**, not agent creation.
+
+## Linchpin — VERIFIED (2026-07-08)
+
+`claude --resume <session_id>` carries full context across separate process
+invocations and across modes (same binary, same `.jsonl` store):
+- Streaming session stored "PURPLE-OTTER / 8899" → killed → fresh streaming
+  process `--resume` → recalled both. ✓
+- Resumed a real on-disk agent conversation in streaming mode → correctly
+  summarized prior turns. ✓
+
+## What this buys us for free (shared on-disk state)
+
+Because both modes share the agent's files, most "first-class" concerns need
+**no per-mode work**:
+- **Conversation continuity** — `--resume` the agent's current `session_id`. ✓
+- **Memory / subconscious** — the subconscious is file-based (reads `.jsonl`,
+  writes CozoDB). It indexes whatever the agent writes, in *either* mode, as
+  long as it's running for that agent. Mode-agnostic for free.
+- **AMP identity & keys** — on disk, shared. Same in both modes.
+- **Registry identity, working dir, skills, CLAUDE.md** — shared.
+
+So the plan is much smaller than a "parallel runtime." The real work is: track
+the agent's session_id, let wake pick the mode and `--resume`, teach
+online-detection about the streaming process, harden the streaming runtime, and
+(for AMP outbound) inject identity. Inbound AMP in streaming mode is the only
+genuinely new mechanism, and it's deferred.
+
+## Current state (PoC — shipped, v0.36.2)
+
+- `/stream-chat` WS; persistent per-agent claude process; buffered event stream
+  replayed on reconnect; continues the same live session; 15-min idle-kill.
+- Headless auth via `CLAUDE_CODE_OAUTH_TOKEN`. Permissions: `acceptEdits`.
+- NOT yet: `--resume` a tracked session_id, identity injection, wake-dialog mode
+  choice, online-detection integration.
+
+---
+
+## Phases
+
+### Phase 1 — Session-id tracking + resume (the core of the model)
+- **Track each agent's current `session_id`.** After any wake (either mode),
+  claude uses/creates a session_id — visible in `system:init` and as the
+  `.jsonl` filename in the encoded project dir. Record it on the agent
+  (registry field `currentSessionId`, updated on wake / on hibernate by reading
+  the most-recent `.jsonl` for the working dir).
+- **Wake resumes it.** Both the tmux launch and the streaming spawn pass
+  `--resume <currentSessionId>` (or start fresh if none). Verified this works.
+- Reuse the mtime-newest-`.jsonl` resolution already in `lib/chat-transcript.mjs`.
+
+### Phase 2 — Streaming runtime hardening (on the Agent SDK)
+- **Build on `@anthropic-ai/claude-agent-sdk`, not the raw CLI spawn.** The SDK
+  gives the `canUseTool` callback needed for permission cards (Phase 5, now v1),
+  same-subscription auth, and `--resume`. Restructure the PoC's per-agent
+  session manager around the SDK's `query()`; module extracted from `server.mjs`,
+  resume-aware, available in headless mode.
+- Identity injection: pass `AIMAESTRO_AGENT_ID` / `_NAME` (needed for outbound
+  AMP and agent-scoped skills).
+- Keep idle-stop + wake-on-connect; cap concurrent processes.
+- Formalize the headless-token flow (`setup-token`) with status + expiry handling.
+
+### Phase 3 — Wake dialog + lifecycle
+- **Wake dialog: mode choice** (Terminal / Streaming), the user's original ask.
+- `wake(agent, mode)`:
+  - terminal → tmux `claude --resume <sid>` (current behavior + resume)
+  - streaming → stream-json `claude --resume <sid>` (the runtime from Phase 2)
+- `hibernate` → kill the current process (either mode), persist `currentSessionId`.
+- **Switch mode** = hibernate + wake in the other mode. (Only one mode live at a
+  time — the two processes would fight over the session.)
+- **Online detection** becomes a union: an agent is online if a tmux session
+  exists OR its streaming process is alive. Track the current mode for the UI.
+
+### Phase 4 — UX
+- Status indicators show mode (terminal vs streaming) + online state.
+- For an agent currently in streaming mode, the **Terminal tab** shows a
+  disabled-state message ("Terminal is disabled while this agent runs in
+  streaming mode"). (Activity/log view is a later enhancement, not v1.)
+- Streaming chat tab (PoC) becomes the primary chat for streaming mode.
+
+### Phase 5 — Permissions (v1 — REQUIRED; chat is unusable without it)
+- Replace `acceptEdits` (auto-approve — unsafe/unusable for real work) with the
+  SDK `canUseTool` flow: before each tool runs, the agent pauses and the server
+  forwards the structured request to the browser; permission requests and
+  `AskUserQuestion` render as interactive **cards** (exact command/file + real
+  buttons); the click returns a structured decision. Cannot be accidentally
+  dismissed; buttons always match real choices. (Terminal mode keeps its
+  existing prompt-in-the-TUI behavior.)
+- Depends on Phase 2 being built on the SDK.
+
+### Phase 6 — AMP
+- **Outbound**: with identity injected (Phase 2), `amp-send --id <uuid>` works in
+  streaming mode. Verify.
+- **Inbound (deferred)**: introduce a **notify-agent seam** with two impls —
+  tmux-push (existing) and **stdin-inject** (inject the routed message into the
+  streaming process's stdin as a synthetic turn). This is the "how agents get
+  notified" problem, flagged for later.
+
+---
+
+## Cross-cutting
+- **Testing**: session-id capture/resume, wake in each mode, mode-switch,
+  online-detection union, e2e streaming reconnect.
+- **Headless-mode parity** (`services/headless-router.ts`).
+- **Billing**: streaming = metered credit pool if/when Anthropic un-pauses SDK
+  metering; terminal mode stays on the subscription pool. Surface per-turn cost
+  (`total_cost_usd`) so exposure is visible when in streaming mode.
+- **Auth**: streaming mode needs the headless token (esp. phone use — the
+  process runs on the Mac, serving the phone). Terminal mode auths via Keychain.
+
+## Decisions — ALL RESOLVED (v1 fully specified)
+1. **v1 scope**: Phases 1–5 (mode switch + continuity + UI + permission cards).
+   Inbound AMP (6-inbound) deferred.
+2. **Mode-switch UX**: EXPLICIT. To change modes the user **hibernates** the
+   agent and **wakes** it again, picking the mode in the wake dialog. No
+   one-click live switch.
+3. **Default mode**: terminal (today's default) unless the user picks streaming
+   in the wake dialog.
+4. **Terminal tab in streaming mode**: show a disabled-state message
+   ("Terminal is disabled while this agent runs in streaming mode" or similar) —
+   not an activity/log view for v1.
+5. **Session granularity**: always resume the **latest** conversation
+   (most-recent `.jsonl` for the working dir). No conversation picker in v1.
+
+## Recommended sequencing
+**Phases 1 → 2 → 3 → 4 → 5 = v1**: the same agent, waked in either mode, with
+full conversation continuity via `--resume`, correct UI, memory for free via the
+file-based subconscious, and **real permission cards** (without which the chat
+is unusable for real work). Phase 2 is built on the Agent SDK so Phase 5's
+`canUseTool` cards fall out. Then **6-outbound** (AMP send). Defer **6-inbound**
+behind the notify-seam design.
+
+## Why this is small
+Almost all "first-class citizen" concerns (memory, identity, history, skills)
+are satisfied by shared on-disk state + `--resume`, which is verified. The net
+new build is: session-id tracking, a mode switch on wake, online-detection
+union, streaming-runtime hardening, identity injection. That's a feature, not a
+runtime rewrite.
+
+## Non-goals / accepted limits
+- One mode live at a time (switch = hibernate + rewake).
+- Streaming auth needs a headless token (power-user step; not normal-user-smooth).
+- Inbound AMP in streaming mode deferred.
+- Not solving cloud multi-tenant / BYO-subscription-at-scale.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import AgentList from '@/components/AgentList'
 import TerminalView from '@/components/TerminalView'
 import ChatView from '@/components/ChatView'
 import StreamingChatView from '@/components/StreamingChatView'
+import { getRuntimeMode, setRuntimeMode } from '@/lib/runtime-mode'
 import MessageCenter from '@/components/MessageCenter'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import WorkTree from '@/components/WorkTree'
@@ -493,13 +494,25 @@ export default function DashboardPage() {
   }
 
   // Performs the actual wake with selected program
-  const handleWakeConfirm = async (program: string, options?: { permissionMode?: string }) => {
+  const handleWakeConfirm = async (program: string, options?: { permissionMode?: string; execMode?: 'terminal' | 'streaming' }) => {
     if (!wakeDialogAgent) return
 
     const agent = wakeDialogAgent
 
     // Close dialog immediately so UI isn't blocked
     setWakeDialogAgent(null)
+
+    // Streaming mode: no tmux wake. The SDK session spawns when the Streaming
+    // tab connects and resumes the agent's latest conversation. Just record the
+    // mode and open the tab.
+    if (options?.execMode === 'streaming') {
+      setRuntimeMode(agent.id, 'streaming')
+      setActiveAgentId(agent.id)
+      setActiveTab('streaming')
+      return
+    }
+    setRuntimeMode(agent.id, 'terminal')
+
     setWakingAgentId(agent.id)
 
     try {
@@ -750,6 +763,7 @@ export default function DashboardPage() {
               const isActive = true  // We only render the active agent
               const isHibernated = agent.session?.status !== 'online' && (agent.sessions && agent.sessions.length > 0)
               const session = agentToSession(agent)
+              const agentMode = getRuntimeMode(agent.id)  // 'terminal' | 'streaming'
 
               return (
                 <div
@@ -926,7 +940,24 @@ export default function DashboardPage() {
                   {/* Tab Content */}
                   <div className="flex-1 flex overflow-hidden min-h-0">
                     {activeTab === 'terminal' ? (
-                      isHibernated ? (
+                      agentMode === 'streaming' ? (
+                        <div className="flex-1 flex items-center justify-center text-gray-400">
+                          <div className="text-center max-w-md">
+                            <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-amber-900/30 flex items-center justify-center">
+                              <Zap className="w-10 h-10 text-amber-400" />
+                            </div>
+                            <p className="text-xl mb-2 text-gray-300">{agent.label || agent.name || agent.alias}</p>
+                            <p className="text-sm mb-2 text-gray-500">Terminal is disabled while this agent runs in streaming mode</p>
+                            <p className="text-xs text-gray-600 mb-4">Use the Streaming tab. To get the terminal back, hibernate and wake the agent in Terminal mode.</p>
+                            <button
+                              onClick={() => setActiveTab('streaming')}
+                              className="px-6 py-3 bg-amber-600 text-white rounded-lg hover:bg-amber-500 transition-all flex items-center gap-2 mx-auto"
+                            >
+                              <Zap className="w-4 h-4" /> Go to Streaming
+                            </button>
+                          </div>
+                        </div>
+                      ) : isHibernated ? (
                         <div className="flex-1 flex items-center justify-center text-gray-400">
                           <div className="text-center max-w-md">
                             <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-yellow-900/30 flex items-center justify-center">
@@ -1013,15 +1044,12 @@ export default function DashboardPage() {
                         </ErrorBoundary>
                       )
                     ) : activeTab === 'streaming' ? (
-                      isHibernated ? (
-                        <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">
-                          Wake this agent to use streaming chat.
-                        </div>
-                      ) : (
-                        <ErrorBoundary fallbackLabel="Streaming">
-                          <StreamingChatView agent={agent} isActive={true} />
-                        </ErrorBoundary>
-                      )
+                      // Streaming is self-sufficient: the SDK session spawns on
+                      // connect and resumes the agent's latest conversation —
+                      // no tmux/wake needed, works even when tmux-hibernated.
+                      <ErrorBoundary fallbackLabel="Streaming">
+                        <StreamingChatView agent={agent} isActive={true} />
+                      </ErrorBoundary>
                     ) : activeTab === 'messages' ? (
                       <ErrorBoundary fallbackLabel="Messages">
                         <MessageCenter

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -793,10 +793,17 @@ export default function DashboardPage() {
                     >
                       <Zap className="w-4 h-4" />
                       Streaming
+                      {agentMode === 'streaming' && (
+                        <span className="ml-0.5 text-[9px] uppercase tracking-wide bg-amber-500/20 text-amber-400 border border-amber-500/30 rounded px-1 py-0.5">
+                          active mode
+                        </span>
+                      )}
                     </button>
                     <button
                       onClick={() => setActiveTab('terminal')}
                       className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
+                        agentMode === 'streaming' ? 'opacity-50' : ''
+                      } ${
                         activeTab === 'terminal'
                           ? 'text-blue-400 border-b-2 border-blue-400 bg-gray-800/50'
                           : 'text-gray-400 hover:text-gray-300 hover:bg-gray-800/30'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic'
 import AgentList from '@/components/AgentList'
 import TerminalView from '@/components/TerminalView'
 import ChatView from '@/components/ChatView'
+import StreamingChatView from '@/components/StreamingChatView'
 import MessageCenter from '@/components/MessageCenter'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import WorkTree from '@/components/WorkTree'
@@ -21,7 +22,7 @@ import AgentPlayback from '@/components/AgentPlayback'
 import { useAgents } from '@/hooks/useAgents'
 import { TerminalProvider } from '@/contexts/TerminalContext'
 import { useToast } from '@/contexts/ToastContext'
-import { Terminal, Mail, User, GitBranch, MessageSquare, Share2, FileText, Moon, Power, Loader2, Brain, Plus, Search, Download, Play, ExternalLink, PanelTop } from 'lucide-react'
+import { Terminal, Mail, User, GitBranch, MessageSquare, Share2, FileText, Moon, Power, Loader2, Brain, Plus, Search, Download, Play, ExternalLink, PanelTop, Zap } from 'lucide-react'
 import { agentToSession, getAgentBaseUrl } from '@/lib/agent-utils'
 import type { Agent } from '@/types/agent'
 
@@ -117,7 +118,7 @@ export default function DashboardPage() {
     setLayoutOverride(next)
     localStorage.setItem('aimaestro-layout-mode', next)
   }
-  const [activeTab, setActiveTab] = useState<'terminal' | 'chat' | 'messages' | 'worktree' | 'graph' | 'memory' | 'docs' | 'canvas' | 'search' | 'export' | 'playback'>(() => {
+  const [activeTab, setActiveTab] = useState<'terminal' | 'chat' | 'streaming' | 'messages' | 'worktree' | 'graph' | 'memory' | 'docs' | 'canvas' | 'search' | 'export' | 'playback'>(() => {
     if (typeof window === 'undefined') return 'chat'
     const saved = localStorage.getItem('aimaestro-active-tab')
     const validTabs = ['terminal', 'chat', 'messages', 'worktree', 'graph', 'memory', 'docs', 'canvas', 'search', 'export', 'playback']
@@ -769,6 +770,17 @@ export default function DashboardPage() {
                       Chat
                     </button>
                     <button
+                      onClick={() => setActiveTab('streaming')}
+                      className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
+                        activeTab === 'streaming'
+                          ? 'text-amber-400 border-b-2 border-amber-400 bg-gray-800/50'
+                          : 'text-gray-400 hover:text-gray-300 hover:bg-gray-800/30'
+                      }`}
+                    >
+                      <Zap className="w-4 h-4" />
+                      Streaming
+                    </button>
+                    <button
                       onClick={() => setActiveTab('terminal')}
                       className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
                         activeTab === 'terminal'
@@ -998,6 +1010,16 @@ export default function DashboardPage() {
                       ) : (
                         <ErrorBoundary fallbackLabel="Chat">
                           <ChatView agent={agent} isActive={true} />
+                        </ErrorBoundary>
+                      )
+                    ) : activeTab === 'streaming' ? (
+                      isHibernated ? (
+                        <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">
+                          Wake this agent to use streaming chat.
+                        </div>
+                      ) : (
+                        <ErrorBoundary fallbackLabel="Streaming">
+                          <StreamingChatView agent={agent} isActive={true} />
                         </ErrorBoundary>
                       )
                     ) : activeTab === 'messages' ? (

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback, useMemo, type KeyboardEvent, type ChangeEvent } from 'react'
-import { User, Bot, Wrench, Loader2, Send, RefreshCw, AlertCircle, ChevronDown, ChevronRight, Copy, Check, MessageSquare, ScanEye, Brain, X } from 'lucide-react'
+import { User, Bot, Wrench, Loader2, Send, RefreshCw, AlertCircle, ChevronDown, ChevronRight, Copy, Check, MessageSquare, ScanEye } from 'lucide-react'
 import { MarkdownContent } from '@/components/chat/MarkdownRenderer'
 import ToolBurstGroup from '@/components/chat/ToolBurstGroup'
 import { groupMessages, getToolPreview, type ToolBurst } from '@/lib/chat-utils'
@@ -78,9 +78,36 @@ interface ContentBlock {
   [key: string]: any
 }
 
+interface PendingMessage {
+  id: string
+  text: string
+  timestamp: string
+  status: 'sending' | 'failed'
+}
+
+/** Extract the plain text of a message for pending-echo matching. */
+function messageText(m: Message): string {
+  if (m.type === 'queue-operation' && m.content) return m.content
+  const content = m.message?.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content.filter(b => b.type === 'text' && b.text).map(b => b.text).join('\n\n')
+  }
+  return ''
+}
+
+/** Dedup key: uuid when present, otherwise a content-derived fallback so
+ *  uuid-less messages (synthesized/summary) can't duplicate on overlapping reads. */
+function messageKey(m: Message): string {
+  if (m.uuid) return m.uuid
+  return `${m.type}|${m.timestamp || ''}|${messageText(m).slice(0, 120)}`
+}
+
+const PENDING_EXPIRY_MS = 30000
+
 export default function ChatView({ agent, isActive = false }: ChatViewProps) {
   const [messages, setMessages] = useState<Message[]>([])
-  const [pendingMessages, setPendingMessages] = useState<Array<{ text: string; timestamp: string }>>([])
+  const [pendingMessages, setPendingMessages] = useState<PendingMessage[]>([])
   const [input, setInput] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [isSending, setIsSending] = useState(false)
@@ -89,8 +116,6 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set())
   const [answeredQuestions, setAnsweredQuestions] = useState<Set<string>>(new Set())
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
-  const [memorizeTarget, setMemorizeTarget] = useState<{ index: number; content: string } | null>(null)
-  const [memorizeNote, setMemorizeNote] = useState('')
   const [hookState, setHookState] = useState<{
     status: string;
     message?: string;
@@ -118,10 +143,18 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
   })
   const [chatWsConnected, setChatWsConnected] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout>()
   const reconnectAttemptsRef = useRef(0)
+  // Latest connect() from the WS effect, callable from the visibility handler
+  // (which previously reset the attempt counter but never actually reconnected
+  // once the socket was gone — chat stayed dead until an agent switch)
+  const connectRef = useRef<(() => void) | null>(null)
+  // Scroll-stick: only autoscroll when the user is already near the bottom
+  const stickToBottomRef = useRef(true)
+  const [hasUnseenMessages, setHasUnseenMessages] = useState(false)
 
   // Track if we've done initial load
   const hasLoadedRef = useRef(false)
@@ -205,6 +238,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               setMessages(newMessages)
               setHookState(history.hookState || null)
               setLastModified(history.lastModified || null)
+              setError(null)
               // Only clear pending on initial load (server history includes sent msgs)
               if (!hasLoadedRef.current) {
                 setPendingMessages([])
@@ -218,21 +252,32 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               // Incremental new messages from JSONL watcher (only fires on real file changes)
               const newMsgs = data.data || []
               if (newMsgs.length > 0) {
+                setError(null)
                 setMessages(prev => {
-                  const existingUuids = new Set(prev.map(m => m.uuid).filter(Boolean))
-                  const uniqueNew = newMsgs.filter((m: Message) =>
-                    !m.uuid || !existingUuids.has(m.uuid)
-                  )
+                  const existingKeys = new Set(prev.map(messageKey))
+                  const uniqueNew = newMsgs.filter((m: Message) => !existingKeys.has(messageKey(m)))
                   if (uniqueNew.length === 0) return prev
                   return [...prev, ...uniqueNew].slice(-200)
                 })
-                // Only clear pending when we see the user's message echoed back or
-                // an assistant response — metadata (system, attachment) shouldn't clear it
-                const hasUserOrAssistant = newMsgs.some((m: Message) =>
-                  m.type === 'user' || m.type === 'assistant'
-                )
-                if (hasUserOrAssistant) {
-                  setPendingMessages([])
+                // Clear a pending bubble ONLY when ITS OWN echo appears in the
+                // transcript (user message or queued enqueue with matching text).
+                // Previously ANY user/assistant message cleared ALL pending
+                // bubbles — unrelated agent output made your message look
+                // delivered when it might not be.
+                const echoedTexts = newMsgs
+                  .filter((m: Message) => m.type === 'user' ||
+                    (m.type === 'queue-operation' && m.operation === 'enqueue'))
+                  .map((m: Message) => messageText(m).trim())
+                  .filter(Boolean)
+                if (echoedTexts.length > 0) {
+                  setPendingMessages(prev => {
+                    const remaining = [...prev]
+                    for (const text of echoedTexts) {
+                      const idx = remaining.findIndex(p => p.text.trim() === text)
+                      if (idx !== -1) remaining.splice(idx, 1)
+                    }
+                    return remaining.length === prev.length ? prev : remaining
+                  })
                 }
                 // Assistant response means the agent moved on — clear sticky permission + activity
                 if (newMsgs.some((m: Message) => m.type === 'assistant')) {
@@ -305,9 +350,11 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       wsRef.current = ws
     }
 
+    connectRef.current = connect
     connect()
 
     return () => {
+      connectRef.current = null
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current)
       }
@@ -327,9 +374,13 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       if (document.visibilityState === 'visible') {
         if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
           reconnectAttemptsRef.current = 0 // Reset for fresh retries
-          // Trigger reconnect by closing any zombie socket
           if (wsRef.current && wsRef.current.readyState !== WebSocket.CLOSED) {
+            // Zombie socket — closing it triggers onclose → reconnect
             wsRef.current.close()
+          } else {
+            // No socket at all (retries exhausted while backgrounded) —
+            // reconnect directly; closing nothing reconnects nothing
+            connectRef.current?.()
           }
         }
       } else {
@@ -363,6 +414,23 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     return () => clearInterval(interval)
   }, [isActive])
 
+  // Track whether the user is near the bottom of the message list.
+  // Autoscroll only sticks when they are — scrolling up to read history no
+  // longer gets yanked back down by every incoming message.
+  const handleMessagesScroll = useCallback(() => {
+    const el = messagesContainerRef.current
+    if (!el) return
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120
+    stickToBottomRef.current = nearBottom
+    if (nearBottom) setHasUnseenMessages(false)
+  }, [])
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    stickToBottomRef.current = true
+    setHasUnseenMessages(false)
+    messagesEndRef.current?.scrollIntoView({ behavior })
+  }, [])
+
   // Auto-scroll to bottom when new messages or pending messages arrive
   useEffect(() => {
     if (messages.length === 0 && pendingMessages.length === 0) return
@@ -373,20 +441,44 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     const hasNewMessages = lastId !== prevLastMsgIdRef.current
     prevLastMsgIdRef.current = lastId
 
-    // Scroll on initial load (instant) or new messages/pending messages (smooth)
     if (isInitialLoad) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'instant' })
+      scrollToBottom('instant' as ScrollBehavior)
     } else if (hasNewMessages || pendingMessages.length > 0) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+      if (stickToBottomRef.current) {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+      } else if (hasNewMessages) {
+        setHasUnseenMessages(true)
+      }
     }
-  }, [messages, pendingMessages])
+  }, [messages, pendingMessages, scrollToBottom])
 
-  // Auto-scroll when permission prompt appears
+  // Auto-scroll when permission prompt appears (needs action — always surface it)
   useEffect(() => {
     if (hookState?.status === 'permission_request') {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+      scrollToBottom()
     }
-  }, [hookState])
+  }, [hookState, scrollToBottom])
+
+  // Expire stuck pending bubbles into a visible "failed" state with retry.
+  // Without this, a lost message spins "Sending..." forever.
+  useEffect(() => {
+    if (pendingMessages.length === 0) return
+    const timer = setInterval(() => {
+      const now = Date.now()
+      setPendingMessages(prev => {
+        let changed = false
+        const next = prev.map(p => {
+          if (p.status === 'sending' && now - new Date(p.timestamp).getTime() > PENDING_EXPIRY_MS) {
+            changed = true
+            return { ...p, status: 'failed' as const }
+          }
+          return p
+        })
+        return changed ? next : prev
+      })
+    }, 5000)
+    return () => clearInterval(timer)
+  }, [pendingMessages.length])
 
   // Send quick response (assisted mode — for permission buttons)
   const sendQuickResponse = (text: string) => {
@@ -394,16 +486,38 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     setHookState(null)
 
     // Show pending bubble so user sees their click did something
-    const pendingMsg = { text, timestamp: new Date().toISOString() }
+    const pendingMsg: PendingMessage = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      text,
+      timestamp: new Date().toISOString(),
+      status: 'sending',
+    }
     setPendingMessages(prev => [...prev, pendingMsg])
 
     const sent = sendChatMessage('chat:send', { message: text })
     if (!sent) {
       setError('Not connected — try refreshing')
-      setPendingMessages(prev => prev.filter(p => p.timestamp !== pendingMsg.timestamp))
+      setPendingMessages(prev => prev.filter(p => p.id !== pendingMsg.id))
     }
 
     setIsSending(false)
+  }
+
+  // Retry a failed pending message (re-sends and resets its expiry clock)
+  const retryPendingMessage = (id: string) => {
+    const pending = pendingMessages.find(p => p.id === id)
+    if (!pending) return
+    const sent = sendChatMessage('chat:send', { message: pending.text })
+    setPendingMessages(prev => prev.map(p =>
+      p.id === id
+        ? { ...p, status: sent ? 'sending' as const : 'failed' as const, timestamp: new Date().toISOString() }
+        : p
+    ))
+    if (!sent) setError('Not connected — reconnecting...')
+  }
+
+  const dismissPendingMessage = (id: string) => {
+    setPendingMessages(prev => prev.filter(p => p.id !== id))
   }
 
   // Send message via WebSocket
@@ -431,13 +545,18 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     }
 
     // Add to pending messages immediately for instant feedback
-    const pendingMsg = { text: messageToSend, timestamp: new Date().toISOString() }
+    const pendingMsg: PendingMessage = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      text: messageToSend,
+      timestamp: new Date().toISOString(),
+      status: 'sending',
+    }
     setPendingMessages(prev => [...prev, pendingMsg])
 
     const sent = sendChatMessage('chat:send', { message: messageToSend })
     if (!sent) {
       setError('Failed to send — try again')
-      setPendingMessages(prev => prev.filter(p => p.timestamp !== pendingMsg.timestamp))
+      setPendingMessages(prev => prev.filter(p => p.id !== pendingMsg.id))
       setInput(messageToSend)
     }
 
@@ -688,7 +807,12 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       </div>
 
       {/* Messages Area */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4" style={{ minHeight: 0 }}>
+      <div
+        ref={messagesContainerRef}
+        onScroll={handleMessagesScroll}
+        className="flex-1 overflow-y-auto p-4 space-y-4 relative"
+        style={{ minHeight: 0 }}
+      >
         {isLoading && messages.length === 0 && (
           <div className="flex items-center justify-center h-full">
             <Loader2 className="w-6 h-6 text-gray-400 animate-spin" />
@@ -956,19 +1080,6 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                         <Copy className="w-3 h-3" />
                       )}
                     </button>
-                    {/* Memorize — only for assistant messages */}
-                    {message.type === 'assistant' && (
-                      <button
-                        onClick={() => {
-                          setMemorizeTarget({ index, content })
-                          setMemorizeNote('')
-                        }}
-                        className="p-1 rounded text-xs transition-colors text-gray-500 hover:text-purple-400"
-                        title="Save to memory"
-                      >
-                        <Brain className="w-3 h-3" />
-                      </button>
-                    )}
                   </div>
                 )}
               </div>
@@ -1058,19 +1169,45 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
           </div>
         )}
 
-        {/* Pending messages (sent via Chat but not yet in JSONL) */}
-        {pendingMessages.map((pending, idx) => (
-          <div key={`pending-${idx}`} className="flex justify-end">
+        {/* Pending messages (sent via Chat but not yet echoed in the transcript) */}
+        {pendingMessages.map((pending) => (
+          <div key={pending.id} className="flex justify-end">
             <div className="max-w-[85%]">
-              <div className="rounded-2xl px-4 py-3 bg-blue-600/70 text-white border border-blue-500/50">
+              <div className={`rounded-2xl px-4 py-3 text-white border ${
+                pending.status === 'failed'
+                  ? 'bg-red-900/60 border-red-600/60'
+                  : 'bg-blue-600/70 border-blue-500/50'
+              }`}>
                 <div className="flex items-center gap-2 mb-1">
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  <span className="text-xs opacity-70">Sending...</span>
+                  {pending.status === 'failed' ? (
+                    <AlertCircle className="w-3.5 h-3.5 text-red-300" />
+                  ) : (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  )}
+                  <span className="text-xs opacity-70">
+                    {pending.status === 'failed' ? 'Not confirmed — may not have reached the agent' : 'Sending...'}
+                  </span>
                   <span className="text-xs opacity-50 ml-auto">
                     {formatTimestamp(pending.timestamp)}
                   </span>
                 </div>
                 <div className="text-sm">{pending.text}</div>
+                {pending.status === 'failed' && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <button
+                      onClick={() => retryPendingMessage(pending.id)}
+                      className="px-2 py-1 text-xs rounded bg-red-700/60 hover:bg-red-600/60 border border-red-500/50 transition-colors"
+                    >
+                      Retry
+                    </button>
+                    <button
+                      onClick={() => dismissPendingMessage(pending.id)}
+                      className="px-2 py-1 text-xs rounded bg-gray-800/60 hover:bg-gray-700/60 border border-gray-600/50 transition-colors"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -1079,68 +1216,16 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Memorize popup */}
-      {memorizeTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setMemorizeTarget(null)}>
-          <div
-            className="bg-gray-800 border border-gray-600 rounded-xl shadow-2xl w-full max-w-lg mx-4"
-            onClick={e => e.stopPropagation()}
+      {/* New-messages pill — shown when messages arrive while scrolled up */}
+      {hasUnseenMessages && (
+        <div className="relative flex-shrink-0">
+          <button
+            onClick={() => scrollToBottom()}
+            className="absolute -top-12 left-1/2 -translate-x-1/2 z-10 px-3 py-1.5 rounded-full bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium shadow-lg flex items-center gap-1.5 transition-colors"
           >
-            {/* Header */}
-            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
-              <div className="flex items-center gap-2">
-                <Brain className="w-4 h-4 text-purple-400" />
-                <h3 className="text-sm font-medium text-gray-200">Save to Memory</h3>
-              </div>
-              <button
-                onClick={() => setMemorizeTarget(null)}
-                className="p-1 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-
-            {/* Content preview */}
-            <div className="px-4 pt-3">
-              <label className="text-xs text-gray-400 mb-1 block">Agent response</label>
-              <div className="text-xs text-gray-300 bg-gray-900/50 rounded-lg p-3 max-h-32 overflow-y-auto whitespace-pre-wrap border border-gray-700/50">
-                {memorizeTarget.content.slice(0, 500)}{memorizeTarget.content.length > 500 ? '...' : ''}
-              </div>
-            </div>
-
-            {/* Instructions textarea */}
-            <div className="px-4 pt-3">
-              <label className="text-xs text-gray-400 mb-1 block">Additional instructions (optional)</label>
-              <textarea
-                value={memorizeNote}
-                onChange={e => setMemorizeNote(e.target.value)}
-                placeholder="Add context, corrections, or notes for the agent to remember..."
-                className="w-full bg-gray-900 text-gray-200 text-sm rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 border border-gray-700 placeholder-gray-500"
-                rows={3}
-                autoFocus
-              />
-            </div>
-
-            {/* Actions */}
-            <div className="flex items-center justify-end gap-2 px-4 py-3">
-              <button
-                onClick={() => setMemorizeTarget(null)}
-                className="px-3 py-1.5 text-xs text-gray-400 hover:text-white rounded-lg hover:bg-gray-700 transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => {
-                  // TODO: save to agent memory files + database
-                  console.log('[ChatView] Memorize:', { content: memorizeTarget.content, note: memorizeNote, agentId: agent.id })
-                  setMemorizeTarget(null)
-                }}
-                className="px-4 py-1.5 text-xs font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
-              >
-                Save to Memory
-              </button>
-            </div>
-          </div>
+            <ChevronDown className="w-3.5 h-3.5" />
+            New messages
+          </button>
         </div>
       )}
 

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -33,7 +33,7 @@ function ThinkingBlock({ text, timestamp }: { text: string; timestamp?: string }
             )}
           </div>
           {expanded ? (
-            <div className="text-sm text-purple-200/80 whitespace-pre-wrap break-words italic max-h-64 overflow-y-auto select-text" style={{ overflowWrap: 'anywhere' }}>
+            <div className="text-sm text-purple-200/80 whitespace-pre-wrap break-words italic max-h-64 overflow-y-auto select-text">
               {text}
             </div>
           ) : (
@@ -956,7 +956,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                   {/* Content — use markdown for assistant, plain for user */}
                   {content && (
                     (isUser || isQueued) ? (
-                      <div className="text-sm whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>
+                      <div className="text-sm whitespace-pre-wrap break-words">
                         {content}
                       </div>
                     ) : (
@@ -1206,7 +1206,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                     {formatTimestamp(pending.timestamp)}
                   </span>
                 </div>
-                <div className="text-sm whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>{pending.text}</div>
+                <div className="text-sm whitespace-pre-wrap break-words">{pending.text}</div>
                 {pending.status === 'failed' && (
                   <div className="flex items-center gap-2 mt-2">
                     <button

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -318,6 +318,21 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
               break
             }
 
+            case 'chat:sendFailed': {
+              // Server refused/failed the send (permission prompt up, paste
+              // unverified, etc.) — mark the matching pending bubble failed
+              // NOW instead of letting it spin until the 30s expiry
+              const failedText = (data.message || '').trim()
+              setPendingMessages(prev => {
+                const idx = prev.findIndex(p => p.status === 'sending' && p.text.trim() === failedText)
+                if (idx === -1) return prev
+                const next = [...prev]
+                next[idx] = { ...next[idx], status: 'failed' }
+                return next
+              })
+              break
+            }
+
             case 'chat:error': {
               setError(data.error || 'Unknown error')
               setIsLoading(false)

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -495,27 +495,14 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
     return () => clearInterval(timer)
   }, [pendingMessages.length])
 
-  // Send quick response (assisted mode — for permission buttons)
+  // Answer a permission / choice menu (a single key like "1"/"2"/"3").
+  // Uses the dedicated permission path: the server sends it as a RAW KEYSTROKE
+  // that actually selects the menu option, and bypasses the send guard that was
+  // silently swallowing these clicks (the "response never lands" bug).
   const sendQuickResponse = (text: string) => {
-    setIsSending(true)
-    setHookState(null)
-
-    // Show pending bubble so user sees their click did something
-    const pendingMsg: PendingMessage = {
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      text,
-      timestamp: new Date().toISOString(),
-      status: 'sending',
-    }
-    setPendingMessages(prev => [...prev, pendingMsg])
-
-    const sent = sendChatMessage('chat:send', { message: text })
-    if (!sent) {
-      setError('Not connected — try refreshing')
-      setPendingMessages(prev => prev.filter(p => p.id !== pendingMsg.id))
-    }
-
-    setIsSending(false)
+    setHookState(null)  // clear the sticky card optimistically
+    const sent = sendChatMessage('chat:permissionResponse', { key: text })
+    if (!sent) setError('Not connected — reopen the agent and try again')
   }
 
   // Retry a failed pending message (re-sends and resets its expiry clock)

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -14,7 +14,7 @@ function ThinkingBlock({ text, timestamp }: { text: string; timestamp?: string }
 
   return (
     <div className="flex justify-start">
-      <div className="max-w-[85%]">
+      <div className="max-w-[85%] min-w-0 overflow-hidden">
         <div
           className="rounded-2xl px-4 py-3 bg-purple-900/20 border border-purple-700/30 cursor-pointer transition-colors hover:bg-purple-900/30"
           onClick={() => setExpanded(!expanded)}
@@ -33,7 +33,7 @@ function ThinkingBlock({ text, timestamp }: { text: string; timestamp?: string }
             )}
           </div>
           {expanded ? (
-            <div className="text-sm text-purple-200/80 whitespace-pre-wrap italic max-h-64 overflow-y-auto select-text">
+            <div className="text-sm text-purple-200/80 whitespace-pre-wrap break-words italic max-h-64 overflow-y-auto select-text" style={{ overflowWrap: 'anywhere' }}>
               {text}
             </div>
           ) : (
@@ -810,7 +810,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
       <div
         ref={messagesContainerRef}
         onScroll={handleMessagesScroll}
-        className="flex-1 overflow-y-auto p-4 space-y-4 relative"
+        className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-4 relative"
         style={{ minHeight: 0 }}
       >
         {isLoading && messages.length === 0 && (
@@ -941,7 +941,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                   {/* Content — use markdown for assistant, plain for user */}
                   {content && (
                     (isUser || isQueued) ? (
-                      <div className="text-sm whitespace-pre-wrap break-words">
+                      <div className="text-sm whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>
                         {content}
                       </div>
                     ) : (
@@ -1109,7 +1109,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
         {/* PERMISSION REQUEST — always from hookState */}
         {hookState?.status === 'permission_request' && (
           <div className="flex justify-start">
-            <div className="max-w-[85%]">
+            <div className="max-w-[85%] min-w-0 overflow-hidden">
               <div className="rounded-2xl px-4 py-3 bg-amber-900/40 border border-amber-600/50 text-amber-200">
                 {/* Header: what tool is asking */}
                 <div className="flex items-center gap-2 mb-2">
@@ -1172,7 +1172,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
         {/* Pending messages (sent via Chat but not yet echoed in the transcript) */}
         {pendingMessages.map((pending) => (
           <div key={pending.id} className="flex justify-end">
-            <div className="max-w-[85%]">
+            <div className="max-w-[85%] min-w-0 overflow-hidden">
               <div className={`rounded-2xl px-4 py-3 text-white border ${
                 pending.status === 'failed'
                   ? 'bg-red-900/60 border-red-600/60'
@@ -1191,7 +1191,7 @@ export default function ChatView({ agent, isActive = false }: ChatViewProps) {
                     {formatTimestamp(pending.timestamp)}
                   </span>
                 </div>
-                <div className="text-sm">{pending.text}</div>
+                <div className="text-sm whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>{pending.text}</div>
                 {pending.status === 'failed' && (
                   <div className="flex items-center gap-2 mt-2">
                     <button

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -508,17 +508,12 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
   }
 
   // Send quick response (for permission prompts)
+  // Answer a permission / choice menu via the dedicated raw-keystroke path
+  // (bypasses the send guard that swallowed clicks; selects the menu option).
   const sendQuickResponse = (text: string) => {
-    setSending(true)
-    const pendingMsg = { text, timestamp: new Date().toISOString() }
-    setPendingMessages(prev => [...prev, pendingMsg])
-
-    const sent = sendChatWs('chat:send', { message: text })
-    if (!sent) {
-      setError('Not connected')
-      setPendingMessages(prev => prev.filter(p => p.timestamp !== pendingMsg.timestamp))
-    }
-    setSending(false)
+    setHookState(null)  // clear the card optimistically
+    const sent = sendChatWs('chat:permissionResponse', { key: text })
+    if (!sent) setError('Not connected — reopen the agent and try again')
   }
 
   // Check if an AskUserQuestion has been answered

--- a/components/MobileChatView.tsx
+++ b/components/MobileChatView.tsx
@@ -369,6 +369,19 @@ export default function MobileChatView({ agentId, agentName, sessionName: sessio
               break
             }
 
+            case 'chat:sendFailed': {
+              // Server refused/failed the send — remove the matching pending
+              // bubble so it doesn't sit on "sending" forever; the chat:error
+              // banner (sent alongside) explains what happened
+              const failedText = (data.message || '').trim()
+              setPendingMessages(prev => {
+                const idx = prev.findIndex(p => p.text.trim() === failedText)
+                if (idx === -1) return prev
+                return prev.filter((_, i) => i !== idx)
+              })
+              break
+            }
+
             case 'chat:error': {
               setError(data.error || 'Unknown error')
               break

--- a/components/StreamingChatView.tsx
+++ b/components/StreamingChatView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback, type KeyboardEvent } from 'react'
-import { User, Bot, Wrench, Loader2, Send, Zap, AlertCircle } from 'lucide-react'
+import { User, Bot, Wrench, Loader2, Send, Zap, AlertCircle, ShieldAlert } from 'lucide-react'
 import { MarkdownContent } from '@/components/chat/MarkdownRenderer'
 import type { Agent } from '@/types/agent'
 
@@ -31,6 +31,12 @@ interface Meta {
   turns?: number
 }
 
+interface PermReq {
+  requestId: string
+  toolName: string
+  input: any
+}
+
 let idCounter = 0
 const nextId = () => `t${++idCounter}`
 
@@ -42,6 +48,7 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
   const [error, setError] = useState<string | null>(null)
   const [noToken, setNoToken] = useState(false)
   const [meta, setMeta] = useState<Meta>({})
+  const [permissions, setPermissions] = useState<PermReq[]>([])
 
   const wsRef = useRef<WebSocket | null>(null)
   const curAssistantId = useRef<string | null>(null)
@@ -97,8 +104,20 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
           setThinking(false)
           setError(null)
           setMeta({})
+          setPermissions([])
           break
         case 'stream:replay-done':
+          break
+        case 'stream:permission':
+          // Claude wants to use a tool that needs approval → show a card
+          setPermissions(prev =>
+            prev.some(p => p.requestId === msg.requestId)
+              ? prev
+              : [...prev, { requestId: msg.requestId, toolName: msg.toolName, input: msg.input }]
+          )
+          break
+        case 'stream:permission-resolved':
+          setPermissions(prev => prev.filter(p => p.requestId !== msg.requestId))
           break
         case 'stream:user': {
           // A user turn (this client's or another's) — rebuild it. Server
@@ -167,7 +186,7 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
     return () => { ws.close(); wsRef.current = null }
   }, [agent.id, agent.name, agent.alias, isActive, appendText, addTool])
 
-  useEffect(() => { scrollToBottom() }, [turns])
+  useEffect(() => { scrollToBottom() }, [turns, permissions])
 
   const send = () => {
     const text = input.trim()
@@ -184,6 +203,17 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+  }
+
+  const respondPermission = (requestId: string, decision: 'allow' | 'deny') => {
+    wsRef.current?.send(JSON.stringify({ type: 'permissionDecision', requestId, decision }))
+    setPermissions(prev => prev.filter(p => p.requestId !== requestId))  // optimistic
+  }
+
+  // One-line preview of what a tool wants to do
+  const permPreview = (p: PermReq): string => {
+    const i = p.input || {}
+    return i.command || i.file_path || i.path || i.pattern || i.url || (Object.keys(i).length ? JSON.stringify(i).slice(0, 120) : '')
   }
 
   return (
@@ -267,6 +297,42 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
             </div>
           )
         })}
+
+        {/* Permission cards — Claude wants to do something that needs approval */}
+        {permissions.map((p) => (
+          <div key={p.requestId} className="flex justify-start">
+            <div className="max-w-[85%] min-w-0 overflow-hidden">
+              <div className="rounded-2xl px-4 py-3 bg-amber-900/40 border border-amber-600/50 text-amber-100">
+                <div className="flex items-center gap-2 mb-2">
+                  <ShieldAlert className="w-4 h-4 text-amber-400 flex-shrink-0" />
+                  <span className="text-xs font-medium text-amber-300">
+                    Allow <span className="font-mono">{p.toolName}</span>?
+                  </span>
+                </div>
+                {permPreview(p) && (
+                  <pre className="text-xs bg-gray-950/50 p-2 rounded font-mono whitespace-pre-wrap break-words max-h-40 overflow-y-auto mb-3">
+                    {permPreview(p)}
+                  </pre>
+                )}
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => respondPermission(p.requestId, 'allow')}
+                    className="px-3 py-1.5 text-xs font-medium rounded-lg bg-amber-700/60 hover:bg-amber-600/60 border border-amber-500/50 transition-colors"
+                  >
+                    Allow
+                  </button>
+                  <button
+                    onClick={() => respondPermission(p.requestId, 'deny')}
+                    className="px-3 py-1.5 text-xs font-medium rounded-lg bg-gray-800/60 hover:bg-gray-700/60 border border-gray-600/50 transition-colors"
+                  >
+                    Deny
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+
         <div ref={endRef} />
       </div>
 

--- a/components/StreamingChatView.tsx
+++ b/components/StreamingChatView.tsx
@@ -40,6 +40,7 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
   const [connected, setConnected] = useState(false)
   const [thinking, setThinking] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [noToken, setNoToken] = useState(false)
   const [meta, setMeta] = useState<Meta>({})
 
   const wsRef = useRef<WebSocket | null>(null)
@@ -88,6 +89,7 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
       switch (msg.type) {
         case 'stream:ready':
           setConnected(true)
+          setNoToken(msg.hasToken === false)
           break
         case 'stream:error':
           setError(msg.error || 'Stream error')
@@ -111,10 +113,16 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
               appendText(inner.delta.text || '')
             }
           } else if (ev.type === 'assistant') {
-            // full assistant message — use it ONLY for tool_use blocks
-            // (text already streamed via deltas above)
+            // full assistant message — authoritative. Set text from its text
+            // blocks (covers responses that arrive with NO deltas, e.g. the
+            // "Not logged in" error), and add tool_use cards.
             const content = ev.message?.content
             if (Array.isArray(content)) {
+              const text = content.filter((b: any) => b.type === 'text' && b.text).map((b: any) => b.text).join('')
+              if (text) {
+                const id = ensureAssistant()
+                setTurns(prev => prev.map(t => t.id === id ? { ...t, text } : t))
+              }
               for (const block of content) {
                 if (block.type === 'tool_use') addTool(block.name || 'tool', block.input)
               }
@@ -185,6 +193,12 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-4" style={{ minHeight: 0 }}>
+        {noToken && (
+          <div className="px-4 py-3 bg-amber-900/20 border border-amber-800 rounded-lg text-xs text-amber-300">
+            <p className="font-medium mb-1">⚠️ No headless auth token found</p>
+            <p className="text-amber-300/80">This server can’t use your Keychain login. Run <code className="bg-gray-950/50 px-1 rounded font-mono">claude setup-token</code> in a terminal, then save the token to <code className="bg-gray-950/50 px-1 rounded font-mono">~/.aimaestro/claude-oauth-token</code> and restart. Until then the agent will reply “Not logged in”.</p>
+          </div>
+        )}
         {error && (
           <div className="flex items-center gap-2 px-4 py-3 bg-red-900/20 border border-red-800 rounded-lg text-sm text-red-400">
             <AlertCircle className="w-4 h-4 flex-shrink-0" />{error}

--- a/components/StreamingChatView.tsx
+++ b/components/StreamingChatView.tsx
@@ -88,9 +88,26 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
 
       switch (msg.type) {
         case 'stream:ready':
+          // Fresh connect OR reconnect to a live session: reset and rebuild
+          // purely from the server's replayed buffer (single source of truth).
           setConnected(true)
           setNoToken(msg.hasToken === false)
+          setTurns([])
+          curAssistantId.current = null
+          setThinking(false)
+          setError(null)
+          setMeta({})
           break
+        case 'stream:replay-done':
+          break
+        case 'stream:user': {
+          // A user turn (this client's or another's) — rebuild it. Server
+          // echoes every send here so live + replay share one code path.
+          curAssistantId.current = null
+          setTurns(prev => [...prev, { id: nextId(), role: 'user', text: msg.text || '', tools: [], done: true }])
+          setThinking(true)
+          break
+        }
         case 'stream:error':
           setError(msg.error || 'Stream error')
           setThinking(false)
@@ -156,7 +173,8 @@ export default function StreamingChatView({ agent, isActive = false }: Streaming
     const text = input.trim()
     if (!text || !connected || thinking) return
     if (wsRef.current?.readyState !== WebSocket.OPEN) { setError('Not connected'); return }
-    setTurns(prev => [...prev, { id: nextId(), role: 'user', text, tools: [], done: true }])
+    // No optimistic add — the server echoes a stream:user event that renders
+    // the turn, so live and replay-on-reconnect share one path (no duplicates).
     wsRef.current.send(JSON.stringify({ type: 'send', text }))
     setInput('')
     setThinking(true)

--- a/components/StreamingChatView.tsx
+++ b/components/StreamingChatView.tsx
@@ -1,0 +1,273 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback, type KeyboardEvent } from 'react'
+import { User, Bot, Wrench, Loader2, Send, Zap, AlertCircle } from 'lucide-react'
+import { MarkdownContent } from '@/components/chat/MarkdownRenderer'
+import type { Agent } from '@/types/agent'
+
+/**
+ * EXPERIMENTAL streaming-chat PoC. Drives Claude Code in stream-json mode
+ * (NOT tmux) via the /stream-chat WebSocket. One persistent claude process
+ * per connection. No terminal — this is the "chat that actually works" spike.
+ */
+
+interface StreamingChatViewProps {
+  agent: Agent
+  isActive?: boolean
+}
+
+interface Turn {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+  tools: Array<{ name: string; input: any }>
+  done?: boolean
+}
+
+interface Meta {
+  model?: string
+  sessionId?: string
+  cost?: number
+  turns?: number
+}
+
+let idCounter = 0
+const nextId = () => `t${++idCounter}`
+
+export default function StreamingChatView({ agent, isActive = false }: StreamingChatViewProps) {
+  const [turns, setTurns] = useState<Turn[]>([])
+  const [input, setInput] = useState('')
+  const [connected, setConnected] = useState(false)
+  const [thinking, setThinking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [meta, setMeta] = useState<Meta>({})
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const curAssistantId = useRef<string | null>(null)
+  const endRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  const scrollToBottom = () => endRef.current?.scrollIntoView({ behavior: 'smooth' })
+
+  // Ensure a current assistant turn exists to append streaming text/tools into
+  const ensureAssistant = useCallback(() => {
+    if (curAssistantId.current) return curAssistantId.current
+    const id = nextId()
+    curAssistantId.current = id
+    setTurns(prev => [...prev, { id, role: 'assistant', text: '', tools: [] }])
+    return id
+  }, [])
+
+  const appendText = useCallback((delta: string) => {
+    const id = ensureAssistant()
+    setTurns(prev => prev.map(t => t.id === id ? { ...t, text: t.text + delta } : t))
+  }, [ensureAssistant])
+
+  const addTool = useCallback((name: string, toolInput: any) => {
+    const id = ensureAssistant()
+    setTurns(prev => prev.map(t =>
+      t.id === id ? { ...t, tools: [...t.tools, { name, input: toolInput }] } : t
+    ))
+  }, [ensureAssistant])
+
+  useEffect(() => {
+    if (!isActive || !agent?.id) return
+
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const sessionName = agent.name || agent.alias || agent.id
+    const url = `${protocol}//${window.location.host}/stream-chat?agentId=${encodeURIComponent(agent.id)}&name=${encodeURIComponent(sessionName)}`
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onopen = () => setError(null)
+
+    ws.onmessage = (e) => {
+      let msg: any
+      try { msg = JSON.parse(e.data) } catch { return }
+
+      switch (msg.type) {
+        case 'stream:ready':
+          setConnected(true)
+          break
+        case 'stream:error':
+          setError(msg.error || 'Stream error')
+          setThinking(false)
+          break
+        case 'stream:exit':
+          setConnected(false)
+          setThinking(false)
+          setError(`Claude process exited (code ${msg.code ?? '?'})`)
+          break
+        case 'stream:event': {
+          const ev = msg.event
+          if (!ev || !ev.type) break
+
+          if (ev.type === 'system' && ev.subtype === 'init') {
+            setMeta(m => ({ ...m, model: ev.model, sessionId: ev.session_id }))
+          } else if (ev.type === 'stream_event') {
+            // token-by-token text deltas (--include-partial-messages)
+            const inner = ev.event
+            if (inner?.type === 'content_block_delta' && inner.delta?.type === 'text_delta') {
+              appendText(inner.delta.text || '')
+            }
+          } else if (ev.type === 'assistant') {
+            // full assistant message — use it ONLY for tool_use blocks
+            // (text already streamed via deltas above)
+            const content = ev.message?.content
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (block.type === 'tool_use') addTool(block.name || 'tool', block.input)
+              }
+            }
+          } else if (ev.type === 'result') {
+            // turn complete
+            const id = curAssistantId.current
+            if (id) setTurns(prev => prev.map(t => t.id === id ? { ...t, done: true } : t))
+            curAssistantId.current = null
+            setThinking(false)
+            setMeta(m => ({
+              ...m,
+              cost: (m.cost || 0) + (ev.total_cost_usd || 0),
+              turns: (m.turns || 0) + 1,
+            }))
+          }
+          break
+        }
+      }
+    }
+
+    ws.onclose = () => { setConnected(false); setThinking(false) }
+    ws.onerror = () => setError('WebSocket error')
+
+    return () => { ws.close(); wsRef.current = null }
+  }, [agent.id, agent.name, agent.alias, isActive, appendText, addTool])
+
+  useEffect(() => { scrollToBottom() }, [turns])
+
+  const send = () => {
+    const text = input.trim()
+    if (!text || !connected || thinking) return
+    if (wsRef.current?.readyState !== WebSocket.OPEN) { setError('Not connected'); return }
+    setTurns(prev => [...prev, { id: nextId(), role: 'user', text, tools: [], done: true }])
+    wsRef.current.send(JSON.stringify({ type: 'send', text }))
+    setInput('')
+    setThinking(true)
+    setError(null)
+    if (inputRef.current) inputRef.current.style.height = 'auto'
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 bg-gray-900">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-gray-700 bg-gray-800 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-3">
+          <div className={`w-2 h-2 rounded-full flex-shrink-0 ${
+            !connected ? 'bg-red-500' : thinking ? 'bg-amber-400 animate-pulse' : 'bg-green-500'
+          }`} />
+          <div>
+            <h3 className="text-sm font-medium text-gray-200 flex items-center gap-1.5">
+              <Zap className="w-3.5 h-3.5 text-amber-400" />
+              {!connected ? 'Connecting…' : thinking ? 'Streaming…' : (agent.label || agent.name || 'Streaming chat')}
+            </h3>
+            <p className="text-xs text-gray-400 mt-0.5">
+              stream-json (no tmux){meta.model ? ` · ${meta.model}` : ''}
+              {meta.turns ? ` · ${meta.turns} turns` : ''}
+              {meta.cost ? ` · $${meta.cost.toFixed(4)}` : ''}
+            </p>
+          </div>
+        </div>
+        <span className="text-[10px] uppercase tracking-wide text-amber-400/70 border border-amber-400/30 rounded px-1.5 py-0.5">PoC</span>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-4" style={{ minHeight: 0 }}>
+        {error && (
+          <div className="flex items-center gap-2 px-4 py-3 bg-red-900/20 border border-red-800 rounded-lg text-sm text-red-400">
+            <AlertCircle className="w-4 h-4 flex-shrink-0" />{error}
+          </div>
+        )}
+
+        {turns.length === 0 && !error && (
+          <div className="flex flex-col items-center justify-center h-full text-gray-500">
+            <Zap className="w-14 h-14 mb-3 opacity-30 text-amber-400" />
+            <p className="text-base text-gray-400">Streaming chat (experimental)</p>
+            <p className="text-xs mt-1">Runs Claude directly — no terminal, no tmux. Type to start.</p>
+          </div>
+        )}
+
+        {turns.map(turn => {
+          const isUser = turn.role === 'user'
+          return (
+            <div key={turn.id} className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+              <div className="max-w-[85%] min-w-0 overflow-hidden">
+                <div className={`rounded-2xl px-4 py-3 ${isUser ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-200'}`}>
+                  <div className="flex items-center gap-2 mb-1">
+                    {isUser ? <User className="w-3.5 h-3.5" /> : <Bot className="w-3.5 h-3.5" />}
+                    <span className="text-xs opacity-70">{isUser ? 'You' : (agent.label || agent.name || 'Agent')}</span>
+                    {!isUser && !turn.done && <Loader2 className="w-3 h-3 animate-spin opacity-60" />}
+                  </div>
+
+                  {turn.text && (
+                    isUser
+                      ? <div className="text-sm whitespace-pre-wrap break-words">{turn.text}</div>
+                      : <MarkdownContent text={turn.text} />
+                  )}
+
+                  {turn.tools.length > 0 && (
+                    <div className="mt-2 space-y-1.5">
+                      {turn.tools.map((tool, i) => (
+                        <div key={i} className="flex items-center gap-2 bg-orange-900/30 border border-orange-800/50 rounded-lg px-3 py-1.5">
+                          <Wrench className="w-3.5 h-3.5 text-orange-400 flex-shrink-0" />
+                          <span className="text-xs text-orange-300 font-medium">{tool.name}</span>
+                          <span className="text-xs text-orange-400/60 font-mono truncate">
+                            {tool.input?.command || tool.input?.file_path || tool.input?.pattern || tool.input?.path || ''}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+        <div ref={endRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-gray-700 bg-gray-800 p-4 flex-shrink-0">
+        <div className="flex items-end gap-3">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value)
+              e.target.style.height = 'auto'
+              e.target.style.height = Math.min(e.target.scrollHeight, 160) + 'px'
+            }}
+            onKeyDown={onKeyDown}
+            placeholder={connected ? 'Message the agent (stream-json)… Enter to send' : 'Connecting…'}
+            className="flex-1 bg-gray-900 text-gray-200 text-sm rounded-lg px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-amber-500 border border-gray-700 disabled:opacity-50"
+            rows={1}
+            style={{ maxHeight: '160px' }}
+            disabled={!connected || thinking}
+          />
+          <button
+            onClick={send}
+            disabled={!connected || thinking || !input.trim()}
+            className="px-4 py-3 bg-amber-600 hover:bg-amber-500 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {thinking ? <Loader2 className="w-5 h-5 animate-spin" /> : <Send className="w-5 h-5" />}
+          </button>
+        </div>
+        <div className="mt-2 text-xs text-gray-500">
+          Experimental · runs on your subscription · acceptEdits mode (auto-approves edits)
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -473,6 +473,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
     if (!isMobile || !terminal || !terminalRef.current) return
 
     let touchStartY = 0
+    let touchTmuxDepth = 0 // approx. lines scrolled into tmux copy-mode
     let isTouchingTerminal = false
     const terminalElement = terminalRef.current
 
@@ -500,10 +501,20 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       const linesToScroll = Math.round(deltaY / 30) // 30px per line (slower scroll)
 
       if (Math.abs(linesToScroll) > 0) {
-        if (terminal.buffer.active.type === 'alternate') {
-          // Alt-screen (Claude Code): real scrollback lives in tmux — drive
-          // copy-mode server-side (same protocol as the desktop wheel handler)
+        // Two-tier scrollback (mirrors the desktop wheel handler): local xterm
+        // buffer first; when exhausted (or alt screen), forward to tmux
+        // copy-mode server-side. Depth tracks how far we've scrolled into tmux.
+        const buf = terminal.buffer.active
+        if (linesToScroll < 0) {
+          if (buf.type === 'alternate' || buf.viewportY <= 0) {
+            sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
+            touchTmuxDepth = Math.min(touchTmuxDepth - linesToScroll, 100000)
+          } else {
+            terminal.scrollLines(linesToScroll)
+          }
+        } else if (touchTmuxDepth > 0) {
           sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
+          touchTmuxDepth = Math.max(0, touchTmuxDepth - linesToScroll)
         } else {
           terminal.scrollLines(linesToScroll)
         }

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -36,9 +36,6 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
   const messageBufferRef = useRef<string[]>([])
   const historyCompleteRef = useRef(false)
   const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null)
-  // True only after the END server (local/remote/container) advertises
-  // tmux-scroll support — old servers type unknown frames into the prompt
-  const tmuxScrollCapsRef = useRef(false)
   const [notes, setNotes] = useState('')
   const [promptDraft, setPromptDraft] = useState('')
   const { isTouch } = useDeviceType()
@@ -108,7 +105,6 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
   const { terminal, initializeTerminal, fitTerminal, setSendData } = useTerminal({
     sessionId: session.id,
     disableWebGL: isTouch,  // MOBILE FIX: WebGL context loss on backgrounding causes blank terminals
-    getTmuxScrollSupported: () => tmuxScrollCapsRef.current,
     onRegister: (fitAddon) => {
       // Register terminal when it's fully initialized
       registerTerminal(session.id, fitAddon)
@@ -221,8 +217,6 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       // Reset history gate — server will send history then history-complete
       historyCompleteRef.current = false
       lastSentSizeRef.current = null
-      // Re-learn server capabilities on every (re)connect
-      tmuxScrollCapsRef.current = false
       // On reconnect, clear the terminal before fresh history arrives.
       // Without this, the 5000-line history dump from the server is appended
       // to existing content, causing visible duplication every reconnect cycle.
@@ -266,10 +260,10 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
           return
         }
 
-        // Server capability advertisement (passes through proxies, so this
-        // reflects the END server — old remote hosts never send it)
+        // Server capability advertisement — consumed (currently unused; the
+        // tmux copy-mode scroll feature was removed). Drop so it isn't written
+        // to the terminal.
         if (parsed.type === 'server-caps') {
-          tmuxScrollCapsRef.current = parsed.tmuxScroll === true
           return
         }
 
@@ -486,7 +480,6 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
     if (!isMobile || !terminal || !terminalRef.current) return
 
     let touchStartY = 0
-    let touchTmuxDepth = 0 // approx. lines scrolled into tmux copy-mode
     let isTouchingTerminal = false
     const terminalElement = terminalRef.current
 
@@ -514,26 +507,9 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       const linesToScroll = Math.round(deltaY / 30) // 30px per line (slower scroll)
 
       if (Math.abs(linesToScroll) > 0) {
-        // Two-tier scrollback (mirrors the desktop wheel handler): local xterm
-        // buffer first; when exhausted (or alt screen), forward to tmux
-        // copy-mode server-side. Depth tracks how far we've scrolled into tmux.
-        // Only forward when the END server advertised support (server-caps) —
-        // old hosts type unknown frames into the prompt as literal text.
-        const buf = terminal.buffer.active
-        const canForward = tmuxScrollCapsRef.current
-        if (linesToScroll < 0) {
-          if (canForward && (buf.type === 'alternate' || buf.viewportY <= 0)) {
-            sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
-            touchTmuxDepth = Math.min(touchTmuxDepth - linesToScroll, 100000)
-          } else {
-            terminal.scrollLines(linesToScroll)
-          }
-        } else if (canForward && touchTmuxDepth > 0) {
-          sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
-          touchTmuxDepth = Math.max(0, touchTmuxDepth - linesToScroll)
-        } else {
-          terminal.scrollLines(linesToScroll)
-        }
+        // Plain xterm scroll (see the desktop wheel handler note): tmux
+        // copy-mode forwarding was removed — alt-screen panes have no history.
+        terminal.scrollLines(linesToScroll)
         touchStartY = touchY
       }
 

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -10,9 +10,6 @@ import MobileKeyToolbar from './MobileKeyToolbar'
 import type { Session } from '@/types/session'
 import { useToast } from '@/contexts/ToastContext'
 
-const BRACKETED_PASTE_START = '\u001b[200~'
-const BRACKETED_PASTE_END = '\u001b[201~'
-
 // PERFORMANCE: Hoist static JSX to avoid recreation on every render
 const LoadingSpinner = (
   <div className="absolute inset-0 flex items-center justify-center bg-terminal-bg">
@@ -79,6 +76,19 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
   })
 
   const [globalLoggingEnabled, setGlobalLoggingEnabled] = useState(false)
+
+  // Copy-on-select: opt-in (global setting). useTerminal reads the same
+  // localStorage key on each selection, so no re-init is needed on toggle.
+  const [copyOnSelect, setCopyOnSelect] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem('terminal-copy-on-select') === 'true'
+  })
+  const toggleCopyOnSelect = () => {
+    setCopyOnSelect(prev => {
+      localStorage.setItem('terminal-copy-on-select', String(!prev))
+      return !prev
+    })
+  }
 
   // Copy/paste handlers defined after useTerminal below
 
@@ -416,22 +426,18 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
     }
   }, [terminal])
 
-  // Paste from clipboard (with user gesture - required for mobile)
+  // Paste from clipboard (with user gesture - required for mobile).
+  // Routed through terminal.paste() — the single paste path — which normalizes
+  // line endings and applies bracketed paste only when the app enabled it.
   const pasteFromClipboard = useCallback(async () => {
     if (!isConnected) return
 
     try {
       const text = await navigator.clipboard.readText()
-      if (text) {
-        // Send as bracketed paste to handle multi-line content properly
-        const carriageAdjusted = text.replace(/\r\n?/g, '\n').replace(/\n/g, '\r')
-        const bracketedPayload = `${BRACKETED_PASTE_START}${carriageAdjusted}${BRACKETED_PASTE_END}`
-        sendMessage(bracketedPayload)
-        console.log('[Terminal] Pasted from clipboard')
-        // Focus terminal after paste
-        if (terminalInstanceRef.current) {
-          terminalInstanceRef.current.focus()
-        }
+      const term = terminalInstanceRef.current
+      if (text && term) {
+        term.paste(text)
+        term.focus()
       }
     } catch (err) {
       console.error('[Terminal] Failed to paste:', err)
@@ -442,7 +448,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
         message: 'Unable to access clipboard. Try using the Prompt Builder tab to paste text.',
       })
     }
-  }, [isConnected, sendMessage])
+  }, [isConnected, addToast])
 
   // Handle terminal resize — only forward to server after history is loaded
   // and only if dimensions actually changed (prevents tmux redraw storms)
@@ -494,7 +500,13 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       const linesToScroll = Math.round(deltaY / 30) // 30px per line (slower scroll)
 
       if (Math.abs(linesToScroll) > 0) {
-        terminal.scrollLines(linesToScroll)
+        if (terminal.buffer.active.type === 'alternate') {
+          // Alt-screen (Claude Code): real scrollback lives in tmux — drive
+          // copy-mode server-side (same protocol as the desktop wheel handler)
+          sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
+        } else {
+          terminal.scrollLines(linesToScroll)
+        }
         touchStartY = touchY
       }
 
@@ -521,7 +533,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       document.removeEventListener('touchend', handleTouchEnd, true)
       document.removeEventListener('touchcancel', handleTouchEnd, true)
     }
-  }, [isMobile, terminal])
+  }, [isMobile, terminal, sendMessage])
 
   // Load notes from localStorage ONCE on mount
   // Tab-based architecture: notes stay in memory, no need to reload on session switch
@@ -611,14 +623,15 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
 
       const normalized = promptDraft.replace(/\r\n?/g, '\n')
       const withoutEscape = normalized.replace(/\u001b/g, '')
-      const carriageAdjusted = withoutEscape.replace(/\n/g, '\r')
-      const bracketedPayload = `${BRACKETED_PASTE_START}${carriageAdjusted}${BRACKETED_PASTE_END}`
-
-      const staged = sendMessage(bracketedPayload)
-      if (!staged) {
-        console.warn('[PromptBuilder] Failed to send staged text via WebSocket')
+      // Stage via terminal.paste() — the single paste path. It normalizes line
+      // endings and applies bracketed paste only if the app enabled it (manual
+      // ESC[200~ wrapping leaked literal "200~" into non-bracketed programs).
+      const term = terminalInstanceRef.current
+      if (!term || !isConnected) {
+        console.warn('[PromptBuilder] Terminal not connected, cannot stage text')
         return
       }
+      term.paste(withoutEscape)
 
       if (mode === 'send') {
         const executed = sendMessage('\r')
@@ -630,7 +643,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
         focusTerminal()
       }
     },
-    [focusTerminal, promptDraft, sendMessage]
+    [focusTerminal, promptDraft, sendMessage, isConnected]
   )
 
   const handlePromptKeyDown = useCallback(
@@ -694,7 +707,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
                 {terminal.cols}x{terminal.rows}
               </span>
               <span className="text-gray-500 hidden md:inline">|</span>
-              <span className="hidden md:inline" title={`Buffer: ${terminal.buffer.active.length} lines (max: 50000)`}>
+              <span className="hidden md:inline" title={`Buffer: ${terminal.buffer.active.length} lines (scrollback: 10000)`}>
                 📜 {terminal.buffer.active.length} lines
               </span>
               <span className="text-gray-500 hidden md:inline">|</span>
@@ -729,6 +742,19 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
                 title="Copy selected text to clipboard"
               >
                 📋 <span className="hidden md:inline">Copy</span>
+              </button>
+              <button
+                onClick={toggleCopyOnSelect}
+                className={`px-2 py-1 rounded transition-colors text-xs hidden md:inline-block ${
+                  copyOnSelect
+                    ? 'bg-green-700 hover:bg-green-600 text-white'
+                    : 'bg-gray-700 hover:bg-gray-600 text-gray-200'
+                }`}
+                title={copyOnSelect
+                  ? 'Copy-on-select ON: selecting text copies it automatically — click to disable'
+                  : 'Copy-on-select OFF: selection leaves your clipboard alone — click to enable'}
+              >
+                ✂️ <span className="hidden md:inline">{copyOnSelect ? 'Auto-copy' : 'Auto-copy off'}</span>
               </button>
               <button
                 onClick={pasteFromClipboard}

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -36,6 +36,9 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
   const messageBufferRef = useRef<string[]>([])
   const historyCompleteRef = useRef(false)
   const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null)
+  // True only after the END server (local/remote/container) advertises
+  // tmux-scroll support — old servers type unknown frames into the prompt
+  const tmuxScrollCapsRef = useRef(false)
   const [notes, setNotes] = useState('')
   const [promptDraft, setPromptDraft] = useState('')
   const { isTouch } = useDeviceType()
@@ -105,6 +108,7 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
   const { terminal, initializeTerminal, fitTerminal, setSendData } = useTerminal({
     sessionId: session.id,
     disableWebGL: isTouch,  // MOBILE FIX: WebGL context loss on backgrounding causes blank terminals
+    getTmuxScrollSupported: () => tmuxScrollCapsRef.current,
     onRegister: (fitAddon) => {
       // Register terminal when it's fully initialized
       registerTerminal(session.id, fitAddon)
@@ -217,6 +221,8 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       // Reset history gate — server will send history then history-complete
       historyCompleteRef.current = false
       lastSentSizeRef.current = null
+      // Re-learn server capabilities on every (re)connect
+      tmuxScrollCapsRef.current = false
       // On reconnect, clear the terminal before fresh history arrives.
       // Without this, the 5000-line history dump from the server is appended
       // to existing content, causing visible duplication every reconnect cycle.
@@ -257,6 +263,13 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
         // Handle container connection message
         if (parsed.type === 'connected') {
           console.log(`[CONTAINER] Connected to agent: ${parsed.agentId}`)
+          return
+        }
+
+        // Server capability advertisement (passes through proxies, so this
+        // reflects the END server — old remote hosts never send it)
+        if (parsed.type === 'server-caps') {
+          tmuxScrollCapsRef.current = parsed.tmuxScroll === true
           return
         }
 
@@ -504,15 +517,18 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
         // Two-tier scrollback (mirrors the desktop wheel handler): local xterm
         // buffer first; when exhausted (or alt screen), forward to tmux
         // copy-mode server-side. Depth tracks how far we've scrolled into tmux.
+        // Only forward when the END server advertised support (server-caps) —
+        // old hosts type unknown frames into the prompt as literal text.
         const buf = terminal.buffer.active
+        const canForward = tmuxScrollCapsRef.current
         if (linesToScroll < 0) {
-          if (buf.type === 'alternate' || buf.viewportY <= 0) {
+          if (canForward && (buf.type === 'alternate' || buf.viewportY <= 0)) {
             sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
             touchTmuxDepth = Math.min(touchTmuxDepth - linesToScroll, 100000)
           } else {
             terminal.scrollLines(linesToScroll)
           }
-        } else if (touchTmuxDepth > 0) {
+        } else if (canForward && touchTmuxDepth > 0) {
           sendMessage(JSON.stringify({ type: 'tmux-scroll', lines: linesToScroll }))
           touchTmuxDepth = Math.max(0, touchTmuxDepth - linesToScroll)
         } else {

--- a/components/WakeAgentDialog.tsx
+++ b/components/WakeAgentDialog.tsx
@@ -10,7 +10,7 @@ import type { AgentPermissionMode } from '@/types/agent'
 interface WakeAgentDialogProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (program: string, options?: { permissionMode?: AgentPermissionMode }) => void
+  onConfirm: (program: string, options?: { permissionMode?: AgentPermissionMode; execMode?: 'terminal' | 'streaming' }) => void
   agentName: string
   agentAlias?: string
   defaultPermissionMode?: AgentPermissionMode
@@ -64,6 +64,7 @@ export default function WakeAgentDialog({
 }: WakeAgentDialogProps) {
   const [selectedProgram, setSelectedProgram] = useState<string>('claude')
   const [permissionMode, setPermissionMode] = useState<AgentPermissionMode>(defaultPermissionMode || 'supervised')
+  const [execMode, setExecMode] = useState<'terminal' | 'streaming'>('terminal')
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [isWaking, setIsWaking] = useState(false)
   const [mounted, setMounted] = useState(false)
@@ -81,6 +82,7 @@ export default function WakeAgentDialog({
       setIsWaking(false)
       setSelectedProgram('claude')
       setPermissionMode(defaultPermissionMode || 'supervised')
+      setExecMode('terminal')
       setShowAdvanced(false)
     }
   }, [isOpen, defaultPermissionMode])
@@ -96,7 +98,7 @@ export default function WakeAgentDialog({
 
   const handleConfirm = () => {
     setIsWaking(true)
-    onConfirm(selectedProgram, selectedProgram === 'claude' ? { permissionMode } : undefined)
+    onConfirm(selectedProgram, selectedProgram === 'claude' ? { permissionMode, execMode } : undefined)
     // Dialog will be closed by parent after wake completes
   }
 
@@ -214,6 +216,42 @@ export default function WakeAgentDialog({
                   })}
                 </div>
               </div>
+
+              {/* Execution mode — only for Claude Code */}
+              {selectedProgram === 'claude' && (
+                <div className="px-6 pb-1">
+                  <p className="text-xs text-zinc-500 mb-2">Execution mode</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setExecMode('terminal')}
+                      disabled={isWaking}
+                      className={`p-2.5 rounded-lg border text-left transition-all ${
+                        execMode === 'terminal' ? 'border-emerald-500 bg-emerald-500/10' : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600'
+                      }`}
+                    >
+                      <div className={`text-sm font-medium ${execMode === 'terminal' ? 'text-emerald-400' : 'text-zinc-200'}`}>Terminal</div>
+                      <div className="text-[11px] text-zinc-500">tmux TUI · full terminal</div>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setExecMode('streaming')}
+                      disabled={isWaking}
+                      className={`p-2.5 rounded-lg border text-left transition-all ${
+                        execMode === 'streaming' ? 'border-amber-500 bg-amber-500/10' : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600'
+                      }`}
+                    >
+                      <div className={`text-sm font-medium ${execMode === 'streaming' ? 'text-amber-400' : 'text-zinc-200'}`}>Streaming</div>
+                      <div className="text-[11px] text-zinc-500">clean chat · no terminal</div>
+                    </button>
+                  </div>
+                  {execMode === 'streaming' && (
+                    <p className="text-[11px] text-amber-400/70 mt-2">
+                      Continues the agent’s latest conversation. No terminal view. Needs a headless token.
+                    </p>
+                  )}
+                </div>
+              )}
 
               {/* Advanced Options — only for Claude Code */}
               {selectedProgram === 'claude' && (

--- a/components/chat/MarkdownRenderer.tsx
+++ b/components/chat/MarkdownRenderer.tsx
@@ -163,7 +163,7 @@ function renderMarkdown(text: string): JSX.Element {
     // Regular line
     if (line.trim()) {
       elements.push(
-        <p key={i} className="whitespace-pre-wrap break-words" style={{ overflowWrap: 'anywhere' }}>
+        <p key={i} className="whitespace-pre-wrap break-words">
           {renderInline(line)}
         </p>
       )
@@ -182,12 +182,13 @@ function renderMarkdown(text: string): JSX.Element {
 }
 
 export function MarkdownContent({ text }: { text: string }) {
-  // overflowWrap:anywhere inherits to ALL inline descendants (headers, list
-  // items, inline code) so no single unbroken token can exceed the bubble.
-  // Code blocks are exempt by design: <pre> is white-space:pre with its own
-  // overflow-x-auto scrollbar.
+  // `break-words` (overflow-wrap: break-word) wraps long unbroken tokens
+  // (paths, URLs) so they can't overflow the bubble — WITHOUT the min-content
+  // collapse that `overflow-wrap: anywhere` caused (bubbles shrank to ~1char
+  // wide, wrapping every character). Code blocks keep their own horizontal
+  // scrollbar (<pre> is white-space: pre).
   return (
-    <div className="text-sm break-words overflow-hidden min-w-0" style={{ overflowWrap: 'anywhere' }}>
+    <div className="text-sm break-words overflow-hidden min-w-0">
       {renderMarkdown(text)}
     </div>
   )

--- a/components/chat/MarkdownRenderer.tsx
+++ b/components/chat/MarkdownRenderer.tsx
@@ -136,12 +136,13 @@ function renderMarkdown(text: string): JSX.Element {
       continue
     }
 
-    // Bullet list items
+    // Bullet list items — min-w-0 lets the flex item shrink so long unbroken
+    // content (paths, inline code, URLs) wraps instead of overflowing the bubble
     if (line.match(/^[-*]\s/)) {
       elements.push(
         <div key={i} className="flex gap-1.5 ml-2">
           <span className="text-gray-500 flex-shrink-0">&#x2022;</span>
-          <span>{renderInline(line.replace(/^[-*]\s/, ''))}</span>
+          <span className="min-w-0 break-words">{renderInline(line.replace(/^[-*]\s/, ''))}</span>
         </div>
       )
       continue
@@ -153,7 +154,7 @@ function renderMarkdown(text: string): JSX.Element {
       elements.push(
         <div key={i} className="flex gap-1.5 ml-2">
           <span className="text-gray-500 flex-shrink-0">{numberedMatch[1]}.</span>
-          <span>{renderInline(numberedMatch[2])}</span>
+          <span className="min-w-0 break-words">{renderInline(numberedMatch[2])}</span>
         </div>
       )
       continue
@@ -181,5 +182,13 @@ function renderMarkdown(text: string): JSX.Element {
 }
 
 export function MarkdownContent({ text }: { text: string }) {
-  return <div className="text-sm break-words overflow-hidden min-w-0">{renderMarkdown(text)}</div>
+  // overflowWrap:anywhere inherits to ALL inline descendants (headers, list
+  // items, inline code) so no single unbroken token can exceed the bubble.
+  // Code blocks are exempt by design: <pre> is white-space:pre with its own
+  // overflow-x-auto scrollbar.
+  return (
+    <div className="text-sm break-words overflow-hidden min-w-0" style={{ overflowWrap: 'anywhere' }}>
+      {renderMarkdown(text)}
+    </div>
+  )
 }

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -13,6 +13,10 @@ export interface UseTerminalOptions {
   disableWebGL?: boolean  // Skip WebGL on touch devices (context loss causes blank terminals)
   onRegister?: (fitAddon: FitAddon) => void
   onUnregister?: () => void
+  /** Whether the END server (local/remote/container) advertised tmux-scroll
+   *  support via a server-caps frame. Old servers type unknown protocol
+   *  frames into the PTY as literal text — never send without this. */
+  getTmuxScrollSupported?: () => boolean
 }
 
 import { debounce } from '@/lib/utils'
@@ -345,7 +349,8 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       e.stopPropagation()
       const lines = Math.round(e.deltaY / 25) || (e.deltaY > 0 ? 1 : -1)
       const buf = terminal.buffer.active
-      const canForward = !!sendDataRef.current
+      const canForward = !!sendDataRef.current &&
+        optionsRef.current.getTmuxScrollSupported?.() === true
       if (lines < 0) {
         // Scrolling up: local first, tmux when local can't go further
         const localExhausted = buf.viewportY <= 0

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -274,20 +274,19 @@ export function useTerminal(options: UseTerminalOptions = {}) {
         }
       }
 
-      // Cmd+V (macOS) or Ctrl+Shift+V (Linux) - Paste from clipboard into PTY via WebSocket
+      // Cmd+V (macOS) or Ctrl+Shift+V (Linux) - Paste from clipboard
       if ((event.metaKey && event.key === 'v') || (event.ctrlKey && event.shiftKey && event.key === 'V')) {
         if (event.type === 'keydown') {
           // preventDefault stops the browser from ALSO firing a 'paste' event on the
           // hidden textarea, which xterm would process via onData — causing double paste.
           event.preventDefault()
           navigator.clipboard.readText().then((text) => {
-            if (text && sendDataRef.current) {
-              // Use bracketed paste mode so multi-line content is handled correctly by the shell
-              const PASTE_START = '\x1b[200~'
-              const PASTE_END = '\x1b[201~'
-              // Normalize line endings: convert \r\n and \n to \r (what PTY expects)
-              const normalized = text.replace(/\r\n?/g, '\n').replace(/\n/g, '\r')
-              sendDataRef.current(PASTE_START + normalized + PASTE_END)
+            if (text) {
+              // terminal.paste() normalizes line endings and applies bracketed
+              // paste ONLY if the running app enabled it (DECSET 2004). Manual
+              // \x1b[200~ wrapping printed literal "200~" into programs that
+              // never enabled bracketed paste (bare REPLs, cat, password prompts).
+              terminal.paste(text)
             }
           }).catch((err) => {
             console.warn('Clipboard read denied:', err)
@@ -299,9 +298,12 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       return true
     })
 
-    // Auto-copy selection to clipboard when user selects 3+ characters
-    // Threshold of 3 chars prevents accidental clipboard overwrites from stray clicks
+    // Auto-copy selection to clipboard — OPT-IN via the header toggle.
+    // Was always-on: any 3-char selection silently overwrote the clipboard,
+    // destroying whatever the user was about to paste.
     terminal.onSelectionChange(() => {
+      if (typeof window === 'undefined') return
+      if (window.localStorage.getItem('terminal-copy-on-select') !== 'true') return
       const sel = terminal.getSelection()
       if (sel && sel.length >= 3) {
         navigator.clipboard.writeText(sel).catch(() => {
@@ -310,22 +312,44 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       }
     })
 
-    // Wheel handler: intercept mouse wheel at the DOM level (capture phase) to
-    // scroll xterm.js buffer directly. Without this, xterm.js may convert wheel
-    // events to cursor key sequences (sent to shell/app as arrow up/down) instead
-    // of scrolling the terminal buffer. We always intercept because tmux mouse is
-    // disabled per-session, so there's no app that needs the raw wheel events.
+    // Wheel handler: intercept mouse wheel at the DOM level (capture phase).
+    // - Normal buffer: scroll xterm.js scrollback directly (as before).
+    // - Alternate screen (Claude Code, vim, less): xterm has NO alt-screen
+    //   scrollback — the history lives in tmux. Send an accumulated
+    //   'tmux-scroll' control message; the server drives tmux copy-mode
+    //   (auto-exiting when scrolled back to the bottom). tmux mouse stays off,
+    //   so native browser selection keeps working.
+    let pendingTmuxScroll = 0
+    let tmuxScrollTimer: ReturnType<typeof setTimeout> | null = null
+    const flushTmuxScroll = () => {
+      tmuxScrollTimer = null
+      if (pendingTmuxScroll !== 0 && sendDataRef.current) {
+        sendDataRef.current(JSON.stringify({ type: 'tmux-scroll', lines: pendingTmuxScroll }))
+      }
+      pendingTmuxScroll = 0
+    }
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault()
       e.stopPropagation()
       const lines = Math.round(e.deltaY / 25) || (e.deltaY > 0 ? 1 : -1)
-      terminal.scrollLines(lines)
+      if (terminal.buffer.active.type === 'alternate' && sendDataRef.current) {
+        // Accumulate deltas for 80ms so fast scrolling doesn't flood the
+        // server with one tmux command per wheel tick
+        pendingTmuxScroll += lines
+        if (!tmuxScrollTimer) tmuxScrollTimer = setTimeout(flushTmuxScroll, 80)
+      } else {
+        terminal.scrollLines(lines)
+      }
     }
     container.addEventListener('wheel', handleWheel, { passive: false, capture: true })
 
     // Cleanup function
     return () => {
       container.removeEventListener('wheel', handleWheel, { capture: true } as EventListenerOptions)
+      if (tmuxScrollTimer) {
+        clearTimeout(tmuxScrollTimer)
+        tmuxScrollTimer = null
+      }
       resizeObserver.disconnect()
       // Dispose WebGL addon before terminal to free GPU context cleanly
       if (webglAddonRef.current) {

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -13,10 +13,6 @@ export interface UseTerminalOptions {
   disableWebGL?: boolean  // Skip WebGL on touch devices (context loss causes blank terminals)
   onRegister?: (fitAddon: FitAddon) => void
   onUnregister?: () => void
-  /** Whether the END server (local/remote/container) advertised tmux-scroll
-   *  support via a server-caps frame. Old servers type unknown protocol
-   *  frames into the PTY as literal text — never send without this. */
-  getTmuxScrollSupported?: () => boolean
 }
 
 import { debounce } from '@/lib/utils'
@@ -316,71 +312,25 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       }
     })
 
-    // Wheel handler: intercept mouse wheel at the DOM level (capture phase).
-    // Seamless two-tier scrollback:
-    // - Scrolling UP uses xterm's local scrollback first; when it's exhausted
-    //   (or the app is on the alternate screen, which has none), the deltas are
-    //   forwarded as 'tmux-scroll' messages and the server drives tmux
-    //   copy-mode — the real server-side history. NOTE: the client buffer type
-    //   can't be trusted as the only signal — after a reconnect the capture
-    //   replay never includes the alt-screen-enter sequence, so the client
-    //   sits in the normal buffer even when the tmux pane is alternate.
-    // - Scrolling DOWN unwinds tmux copy-mode first (server auto-exits it at
-    //   the bottom via `copy-mode -e`), then scrolls the local viewport.
-    // tmux mouse stays off, so native browser selection keeps working.
-    let pendingTmuxScroll = 0
-    let tmuxCopyDepth = 0 // approx. lines we've scrolled into tmux copy-mode
-    let tmuxScrollTimer: ReturnType<typeof setTimeout> | null = null
-    const flushTmuxScroll = () => {
-      tmuxScrollTimer = null
-      if (pendingTmuxScroll !== 0 && sendDataRef.current) {
-        sendDataRef.current(JSON.stringify({ type: 'tmux-scroll', lines: pendingTmuxScroll }))
-      }
-      pendingTmuxScroll = 0
-    }
-    const queueTmuxScroll = (lines: number) => {
-      // Accumulate deltas for 80ms so fast scrolling doesn't flood the
-      // server with one tmux command per wheel tick
-      pendingTmuxScroll += lines
-      if (!tmuxScrollTimer) tmuxScrollTimer = setTimeout(flushTmuxScroll, 80)
-    }
+    // Wheel handler: intercept mouse wheel at the DOM level (capture phase) and
+    // scroll xterm's local buffer. We do NOT drive tmux copy-mode: Claude Code
+    // runs on tmux's alternate screen, which keeps zero history, so copy-mode
+    // just showed an empty "0/0" and stranded the pane (breaking Enter/typing).
+    // Real scrollback comes instead from `alternate-screen off` (set per session
+    // on the server) — Claude's output then accumulates in xterm's normal-buffer
+    // scrollback and this plain scroll handles it. Takes effect after the agent's
+    // claude process restarts. tmux mouse stays off, so native selection works.
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault()
       e.stopPropagation()
       const lines = Math.round(e.deltaY / 25) || (e.deltaY > 0 ? 1 : -1)
-      const buf = terminal.buffer.active
-      const canForward = !!sendDataRef.current &&
-        optionsRef.current.getTmuxScrollSupported?.() === true
-      if (lines < 0) {
-        // Scrolling up: local first, tmux when local can't go further
-        const localExhausted = buf.viewportY <= 0
-        if (canForward && (buf.type === 'alternate' || localExhausted)) {
-          queueTmuxScroll(lines)
-          tmuxCopyDepth = Math.min(tmuxCopyDepth - lines, 100000)
-        } else {
-          terminal.scrollLines(lines)
-        }
-      } else {
-        // Scrolling down: unwind tmux copy-mode first, then local viewport.
-        // Depth is approximate (copy-mode may have hit the top of history);
-        // over-forwarded scroll-downs fail harmlessly server-side.
-        if (canForward && tmuxCopyDepth > 0) {
-          queueTmuxScroll(lines)
-          tmuxCopyDepth = Math.max(0, tmuxCopyDepth - lines)
-        } else {
-          terminal.scrollLines(lines)
-        }
-      }
+      terminal.scrollLines(lines)
     }
     container.addEventListener('wheel', handleWheel, { passive: false, capture: true })
 
     // Cleanup function
     return () => {
       container.removeEventListener('wheel', handleWheel, { capture: true } as EventListenerOptions)
-      if (tmuxScrollTimer) {
-        clearTimeout(tmuxScrollTimer)
-        tmuxScrollTimer = null
-      }
       resizeObserver.disconnect()
       // Dispose WebGL addon before terminal to free GPU context cleanly
       if (webglAddonRef.current) {

--- a/hooks/useTerminal.ts
+++ b/hooks/useTerminal.ts
@@ -313,13 +313,19 @@ export function useTerminal(options: UseTerminalOptions = {}) {
     })
 
     // Wheel handler: intercept mouse wheel at the DOM level (capture phase).
-    // - Normal buffer: scroll xterm.js scrollback directly (as before).
-    // - Alternate screen (Claude Code, vim, less): xterm has NO alt-screen
-    //   scrollback — the history lives in tmux. Send an accumulated
-    //   'tmux-scroll' control message; the server drives tmux copy-mode
-    //   (auto-exiting when scrolled back to the bottom). tmux mouse stays off,
-    //   so native browser selection keeps working.
+    // Seamless two-tier scrollback:
+    // - Scrolling UP uses xterm's local scrollback first; when it's exhausted
+    //   (or the app is on the alternate screen, which has none), the deltas are
+    //   forwarded as 'tmux-scroll' messages and the server drives tmux
+    //   copy-mode — the real server-side history. NOTE: the client buffer type
+    //   can't be trusted as the only signal — after a reconnect the capture
+    //   replay never includes the alt-screen-enter sequence, so the client
+    //   sits in the normal buffer even when the tmux pane is alternate.
+    // - Scrolling DOWN unwinds tmux copy-mode first (server auto-exits it at
+    //   the bottom via `copy-mode -e`), then scrolls the local viewport.
+    // tmux mouse stays off, so native browser selection keeps working.
     let pendingTmuxScroll = 0
+    let tmuxCopyDepth = 0 // approx. lines we've scrolled into tmux copy-mode
     let tmuxScrollTimer: ReturnType<typeof setTimeout> | null = null
     const flushTmuxScroll = () => {
       tmuxScrollTimer = null
@@ -328,17 +334,37 @@ export function useTerminal(options: UseTerminalOptions = {}) {
       }
       pendingTmuxScroll = 0
     }
+    const queueTmuxScroll = (lines: number) => {
+      // Accumulate deltas for 80ms so fast scrolling doesn't flood the
+      // server with one tmux command per wheel tick
+      pendingTmuxScroll += lines
+      if (!tmuxScrollTimer) tmuxScrollTimer = setTimeout(flushTmuxScroll, 80)
+    }
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault()
       e.stopPropagation()
       const lines = Math.round(e.deltaY / 25) || (e.deltaY > 0 ? 1 : -1)
-      if (terminal.buffer.active.type === 'alternate' && sendDataRef.current) {
-        // Accumulate deltas for 80ms so fast scrolling doesn't flood the
-        // server with one tmux command per wheel tick
-        pendingTmuxScroll += lines
-        if (!tmuxScrollTimer) tmuxScrollTimer = setTimeout(flushTmuxScroll, 80)
+      const buf = terminal.buffer.active
+      const canForward = !!sendDataRef.current
+      if (lines < 0) {
+        // Scrolling up: local first, tmux when local can't go further
+        const localExhausted = buf.viewportY <= 0
+        if (canForward && (buf.type === 'alternate' || localExhausted)) {
+          queueTmuxScroll(lines)
+          tmuxCopyDepth = Math.min(tmuxCopyDepth - lines, 100000)
+        } else {
+          terminal.scrollLines(lines)
+        }
       } else {
-        terminal.scrollLines(lines)
+        // Scrolling down: unwind tmux copy-mode first, then local viewport.
+        // Depth is approximate (copy-mode may have hit the top of history);
+        // over-forwarded scroll-downs fail harmlessly server-side.
+        if (canForward && tmuxCopyDepth > 0) {
+          queueTmuxScroll(lines)
+          tmuxCopyDepth = Math.max(0, tmuxCopyDepth - lines)
+        } else {
+          terminal.scrollLines(lines)
+        }
       }
     }
     container.addEventListener('wheel', handleWheel, { passive: false, capture: true })

--- a/hooks/useWebSocket.ts
+++ b/hooks/useWebSocket.ts
@@ -3,8 +3,11 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { WebSocketMessage, WebSocketStatus } from '@/types/websocket'
 
-const WS_RECONNECT_DELAY = 3000
-const WS_MAX_RECONNECT_ATTEMPTS = 5
+// Exponential backoff: quick first retry (transient blips), spaced-out later
+// attempts (server restarts take a few seconds). Was a fixed 3s × 5 attempts,
+// which burned all retries in 15s and left the terminal permanently dead.
+const WS_RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 15000]
+const WS_MAX_RECONNECT_ATTEMPTS = WS_RECONNECT_DELAYS.length
 const WS_HEARTBEAT_INTERVAL = 30000  // Send ping every 30s
 const WS_HEARTBEAT_TIMEOUT = 10000   // Expect pong within 10s
 
@@ -249,13 +252,14 @@ export function useWebSocket({
           return
         }
 
-        // Attempt reconnection for transient failures
+        // Attempt reconnection for transient failures (exponential backoff)
         if (reconnectAttemptsRef.current < WS_MAX_RECONNECT_ATTEMPTS) {
+          const delay = WS_RECONNECT_DELAYS[Math.min(reconnectAttemptsRef.current, WS_RECONNECT_DELAYS.length - 1)]
           reconnectAttemptsRef.current++
 
           reconnectTimeoutRef.current = setTimeout(() => {
             connect()
-          }, WS_RECONNECT_DELAY)
+          }, delay)
         } else {
           setConnectionError(
             new Error('Failed to connect after maximum reconnection attempts')

--- a/hooks/useWebSocket.ts
+++ b/hooks/useWebSocket.ts
@@ -219,6 +219,19 @@ export function useWebSocket({
             return
           }
 
+          // Terminal protocol frames the VIEW layer must see — forward to
+          // onMessage, whose own JSON handling consumes them:
+          //   history-complete → scroll-to-bottom + unlocks resize forwarding
+          //   server-caps      → gates the tmux-scroll feature
+          //   connected        → container attach logging
+          // This blanket typed-JSON drop below used to swallow these too,
+          // leaving TerminalView's handlers dead (resize gate never opened,
+          // caps never learned).
+          if (parsed.type === 'history-complete' || parsed.type === 'server-caps' || parsed.type === 'connected') {
+            onMessageRef.current?.(event.data)
+            return
+          }
+
           // Any other JSON with a 'type' field is a protocol message we don't
           // recognize — drop it silently instead of leaking raw JSON into the
           // terminal (this prevents {"type":"ping"} / pong / etc. from appearing

--- a/hooks/useWebSocket.ts
+++ b/hooks/useWebSocket.ts
@@ -133,6 +133,7 @@ export function useWebSocket({
       }
 
       // Send a ping
+      const pingSentAt = Date.now()
       try {
         ws.send(JSON.stringify({ type: 'ping' }))
       } catch {
@@ -142,9 +143,14 @@ export function useWebSocket({
         return
       }
 
-      // Set a per-ping timeout: if no data arrives within WS_HEARTBEAT_TIMEOUT, connection is dead
+      // Dead-connection check: close only if NO data arrived since this ping.
+      // The old check (`now - lastData > TIMEOUT`) compared against the same
+      // 10s the timer itself waits — on an idle terminal the pong lands ~5ms
+      // after the ping while the timer fires ≥10s after it, so every healthy
+      // idle connection "timed out" and force-reconnected every ~40s (the
+      // periodic terminal clear/refresh users saw).
       pongTimeoutRef.current = setTimeout(() => {
-        if (Date.now() - lastDataRef.current > WS_HEARTBEAT_TIMEOUT) {
+        if (lastDataRef.current < pingSentAt) {
           console.warn('[WS] Heartbeat timeout — no pong received, forcing reconnect')
           stopHeartbeat()
           ws.close()

--- a/lib/cerebellum/voice-subsystem.ts
+++ b/lib/cerebellum/voice-subsystem.ts
@@ -278,9 +278,11 @@ export class VoiceSubsystem implements Subsystem {
         || registryAgent?.sessions?.[0]?.workingDirectory
       if (!workingDir) return []
 
-      // Derive the Claude projects directory path (same as chat route.ts)
+      // Derive the Claude projects directory path. Claude Code replaces
+      // `/`, `_` AND `.` with `-` — keep in sync with lib/chat-transcript.mjs
+      // (encodeProjectDirName); this CJS-style method can't import that ESM module.
       const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-      const projectDirName = workingDir.replace(/[/_]/g, '-')
+      const projectDirName = workingDir.replace(/[/_.]/g, '-')
       const conversationDir = path.join(claudeProjectsDir, projectDirName)
 
       if (!fs.existsSync(conversationDir)) return []

--- a/lib/chat-transcript.mjs
+++ b/lib/chat-transcript.mjs
@@ -1,0 +1,160 @@
+/**
+ * Chat transcript helpers — single source of truth for locating and parsing
+ * Claude Code conversation JSONL files and the chat-state (hook) file.
+ *
+ * Used by BOTH server.mjs (plain Node ESM) and the TypeScript services
+ * (services/agents-chat-service.ts). Keep this file dependency-free plain JS.
+ *
+ * History: this logic used to be duplicated in three places, and the
+ * underscore path-encoding bug (v0.35.31, commit 67fca8d) had to be fixed in
+ * all of them. Do not fork this logic again.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+
+/**
+ * Encode a working directory the way Claude Code names project dirs under
+ * ~/.claude/projects. Claude Code replaces `/`, `_` AND `.` with `-`.
+ * (The `.` case is the same bug class as the v0.35.31 underscore fix.)
+ */
+export function encodeProjectDirName(workingDir) {
+  return workingDir.replace(/[/_.]/g, '-')
+}
+
+/** Extract the effective working directory from a registry agent. */
+export function getAgentWorkingDir(agent) {
+  return (
+    agent?.workingDirectory ||
+    agent?.sessions?.[0]?.workingDirectory ||
+    agent?.preferences?.defaultWorkingDirectory ||
+    null
+  )
+}
+
+/**
+ * Resolve the current conversation JSONL file for a working directory.
+ * Returns { name, path, mtime } of the most recently modified .jsonl, or null.
+ */
+export function resolveJsonlPathForDir(workingDir) {
+  if (!workingDir) return null
+
+  const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
+  const conversationDir = path.join(claudeProjectsDir, encodeProjectDirName(workingDir))
+
+  if (!fs.existsSync(conversationDir)) return null
+
+  let files
+  try {
+    files = fs.readdirSync(conversationDir)
+      .filter(f => f.endsWith('.jsonl'))
+      .map(f => {
+        const p = path.join(conversationDir, f)
+        try {
+          return { name: f, path: p, mtime: fs.statSync(p).mtime }
+        } catch {
+          return null
+        }
+      })
+      .filter(Boolean)
+      .sort((a, b) => b.mtime.getTime() - a.mtime.getTime())
+  } catch {
+    return null
+  }
+
+  return files.length > 0 ? files[0] : null
+}
+
+/** Convenience wrapper taking a registry agent. */
+export function resolveJsonlPath(agent) {
+  return resolveJsonlPathForDir(getAgentWorkingDir(agent))
+}
+
+/**
+ * Parse JSONL lines into chat message objects.
+ *
+ * - Skips tool-result user messages (invisible in chat)
+ * - Converts compact_boundary system messages to `summary` messages
+ * - Extracts assistant thinking blocks into separate `thinking` messages
+ *
+ * Synthesized messages get DERIVED uuids (`<parent>#thinking-0`, `<parent>#summary`)
+ * so client-side uuid dedup never drops a thinking block against its parent
+ * assistant message (they used to share the parent's uuid verbatim).
+ */
+export function parseJsonlLines(lines, limit = 100) {
+  const messages = []
+  for (const line of lines) {
+    if (!line.trim()) continue
+    try {
+      const message = JSON.parse(line)
+
+      if (message.type === 'user' && message.toolUseResult) continue
+
+      if (message.type === 'system' &&
+          (message.subtype === 'compact_boundary' || message.subtype === 'microcompact_boundary')) {
+        messages.push({
+          type: 'summary',
+          summary: message.content || 'Conversation compacted',
+          timestamp: message.timestamp,
+          uuid: message.uuid ? `${message.uuid}#summary` : undefined,
+        })
+        continue
+      }
+
+      if (message.type === 'assistant' && message.message?.content) {
+        const content = message.message.content
+        if (Array.isArray(content)) {
+          let thinkingIdx = 0
+          for (const block of content) {
+            if (block.type === 'thinking' && block.thinking) {
+              messages.push({
+                type: 'thinking',
+                thinking: block.thinking,
+                timestamp: message.timestamp,
+                uuid: message.uuid ? `${message.uuid}#thinking-${thinkingIdx}` : undefined,
+              })
+              thinkingIdx++
+            }
+          }
+        }
+      }
+      messages.push(message)
+    } catch { /* skip malformed */ }
+  }
+  return messages.slice(-limit)
+}
+
+/** Hash a working directory the way the chat-state hook does. */
+export function hashCwd(workingDir) {
+  return crypto.createHash('md5').update(workingDir || '').digest('hex').substring(0, 16)
+}
+
+/** Path of the hook chat-state file for a working directory. */
+export function hookStateFilePath(workingDir) {
+  return path.join(os.homedir(), '.aimaestro', 'chat-state', `${hashCwd(workingDir)}.json`)
+}
+
+/**
+ * Read the hook chat-state file for a working directory.
+ * Non-waiting states expire after 60s; a missing/unparseable updatedAt counts
+ * as expired (previously `Date.now() - NaN > 60000` was false, so stale states
+ * were served forever).
+ */
+export function readHookState(workingDir) {
+  if (!workingDir) return null
+  const stateFile = hookStateFilePath(workingDir)
+  try {
+    if (fs.existsSync(stateFile)) {
+      const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'))
+      const isWaitingState = state.status === 'waiting_for_input' || state.status === 'permission_request'
+      if (!isWaitingState) {
+        const updatedAtMs = new Date(state.updatedAt).getTime()
+        if (!Number.isFinite(updatedAtMs) || Date.now() - updatedAtMs > 60000) return null
+      }
+      return state
+    }
+  } catch { /* ignore */ }
+  return null
+}

--- a/lib/marketplace-skills.ts
+++ b/lib/marketplace-skills.ts
@@ -21,7 +21,7 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import os from 'os'
-import matter from 'gray-matter'
+import { safeMatter } from '@/lib/safe-matter'
 import type {
   Marketplace,
   MarketplacePlugin,
@@ -160,7 +160,7 @@ async function findSkillFiles(dir: string): Promise<string[]> {
  */
 function parseSkillFrontmatter(content: string): SkillFrontmatter {
   try {
-    const parsed = matter(content)
+    const parsed = safeMatter(content)
     return parsed.data as SkillFrontmatter
   } catch {
     return {}

--- a/lib/runtime-mode.ts
+++ b/lib/runtime-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Agent execution mode (terminal ⇄ streaming).
+ *
+ * An agent is ONE entity; "terminal" (tmux TUI) vs "streaming" (Agent SDK,
+ * stream-json) is how it's currently being run, chosen at wake. Continuity
+ * across modes comes from `--resume` on the agent's session_id (server-side).
+ *
+ * The MODE PREFERENCE is stored per-agent in localStorage (which tab is the
+ * agent's home). The streaming SESSION itself is server-side and shared across
+ * devices, so a phone opening the streaming tab attaches to the same session —
+ * only the "default tab" preference is device-local (cross-device sync of the
+ * preference is a later enhancement).
+ */
+
+export type RuntimeMode = 'terminal' | 'streaming'
+
+const key = (agentId: string) => `agent-runtime-mode-${agentId}`
+
+export function getRuntimeMode(agentId: string): RuntimeMode {
+  if (typeof window === 'undefined') return 'terminal'
+  return window.localStorage.getItem(key(agentId)) === 'streaming' ? 'streaming' : 'terminal'
+}
+
+export function setRuntimeMode(agentId: string, mode: RuntimeMode): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(key(agentId), mode)
+}

--- a/lib/safe-matter.ts
+++ b/lib/safe-matter.ts
@@ -1,0 +1,31 @@
+/**
+ * Safe front-matter parser.
+ *
+ * SECURITY (GHSA-g7qj-fhxp-6chc): gray-matter evaluates `---js` / `---javascript`
+ * / `---coffee` / `---coffeescript` frontmatter blocks as EXECUTABLE code by
+ * default. Parsing untrusted SKILL.md content (e.g. from a scanned/cloned git
+ * repo, or an installed marketplace plugin) with plain `matter()` is therefore
+ * a remote code execution vector.
+ *
+ * This wrapper overrides those engines so executable frontmatter is rejected
+ * instead of run. Use `safeMatter()` for ANY frontmatter that could originate
+ * from outside this codebase.
+ */
+import matter from 'gray-matter'
+
+const reject = (kind: string) => () => {
+  throw new Error(`${kind} frontmatter is not supported`)
+}
+
+const SAFE_ENGINES = {
+  js: { parse: reject('JavaScript'), stringify: reject('JavaScript') },
+  javascript: { parse: reject('JavaScript'), stringify: reject('JavaScript') },
+  coffee: { parse: reject('CoffeeScript'), stringify: reject('CoffeeScript') },
+  coffeescript: { parse: reject('CoffeeScript'), stringify: reject('CoffeeScript') },
+} as const
+
+export function safeMatter(content: string) {
+  return matter(content, { engines: SAFE_ENGINES as any })
+}
+
+export default safeMatter

--- a/lib/streaming-runtime.mjs
+++ b/lib/streaming-runtime.mjs
@@ -1,0 +1,221 @@
+/**
+ * Streaming Runtime — per-agent Claude Agent SDK sessions (stream-json mode).
+ *
+ * One persistent SDK-driven `claude` session per agent, kept alive across
+ * client (re)connects. Drives the Agent SDK's streaming-input `query()` so we
+ * get, on the user's subscription:
+ *   - persistent context across turns (one long-lived session)
+ *   - `--resume` of the agent's latest conversation (continuity with terminal mode)
+ *   - `canUseTool` permission callbacks (rendered as cards in the browser)
+ *
+ * The WebSocket layer (server.mjs /stream-chat) attaches clients to a session,
+ * pushes user turns, relays permission decisions, and receives the buffered +
+ * live event stream. This module owns the SDK lifecycle; server.mjs owns transport.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+
+const IDLE_MS = 15 * 60 * 1000   // kill a session 15 min after the last client leaves
+const BUFFER_MAX = 5000          // cap buffered events (older drop)
+const PERMISSION_TIMEOUT_MS = 5 * 60 * 1000  // auto-deny a permission after 5 min unanswered
+
+// agentKey -> Session
+const sessions = new Map()
+
+/** Build a clean env for the SDK subprocess: subscription token, never an API
+ *  key. Reads the headless token (macOS daemons can't reach the Keychain). */
+function buildEnv(agentId, agentName) {
+  const env = { ...process.env }
+  delete env.ANTHROPIC_API_KEY
+  if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+    try {
+      const f = path.join(os.homedir(), '.aimaestro', 'claude-oauth-token')
+      if (fs.existsSync(f)) {
+        const t = fs.readFileSync(f, 'utf-8').trim()
+        if (t) env.CLAUDE_CODE_OAUTH_TOKEN = t
+      }
+    } catch { /* ignore */ }
+  }
+  if (agentId) env.AIMAESTRO_AGENT_ID = agentId
+  if (agentName) env.AIMAESTRO_AGENT_NAME = agentName
+  return env
+}
+
+class Session {
+  constructor(agentKey, opts) {
+    this.agentKey = agentKey
+    this.cwd = opts.cwd
+    this.agentId = opts.agentId || null
+    this.agentName = opts.agentName || null
+    this.hasToken = false
+    this.clients = new Set()
+    this.events = []          // buffered envelope strings for replay
+    this.pending = new Map()  // requestId -> { resolve, timer } for permissions
+    this.idleTimer = null
+    this.closed = false
+    this.exited = false
+
+    // streaming-input queue + waker (push user turns into the live session)
+    this._queue = []
+    this._waker = null
+
+    const env = buildEnv(this.agentId, this.agentName)
+    this.hasToken = !!env.CLAUDE_CODE_OAUTH_TOKEN
+
+    const options = {
+      cwd: this.cwd,
+      env,
+      includePartialMessages: true,     // token-by-token deltas
+      settingSources: ['project', 'user', 'local'],  // load CLAUDE.md, skills, allow-rules
+      permissionMode: 'default',        // safe tools auto-approve; risky ones → canUseTool
+      canUseTool: (toolName, input, ctx) => this._onCanUseTool(toolName, input, ctx),
+    }
+    if (opts.resumeSessionId) options.resume = opts.resumeSessionId
+
+    this._query = query({ prompt: this._input(), options })
+    this._consume()
+  }
+
+  async *_input() {
+    while (!this.closed) {
+      while (this._queue.length > 0) yield this._queue.shift()
+      if (this.closed) return
+      await new Promise((r) => { this._waker = r })
+    }
+  }
+
+  /** Push a user turn into the live SDK session. */
+  push(text) {
+    if (this.closed) return
+    this._queue.push({ type: 'user', message: { role: 'user', content: text }, parent_tool_use_id: null, session_id: '' })
+    this._waker?.()
+    // mirror the user turn to clients + buffer (SDK stdout doesn't echo input)
+    this._emit({ type: 'stream:user', text })
+  }
+
+  /** Permission callback — forward to clients, await the user's decision. */
+  _onCanUseTool(toolName, input, ctx) {
+    return new Promise((resolve) => {
+      const requestId = `perm_${Date.now()}_${this.pending.size}_${Math.floor(performance.now())}`
+      const timer = setTimeout(() => {
+        if (this.pending.has(requestId)) {
+          this.pending.delete(requestId)
+          this._emit({ type: 'stream:permission-resolved', requestId, decision: 'timeout' })
+          resolve({ behavior: 'deny', message: 'Permission request timed out with no response.' })
+        }
+      }, PERMISSION_TIMEOUT_MS)
+      this.pending.set(requestId, { resolve, input, timer })
+      // Surface the request as a card. Include the suggestion options the SDK
+      // offers (ctx.suggestions) when present.
+      this._emit({
+        type: 'stream:permission',
+        requestId,
+        toolName,
+        input,
+        suggestions: (ctx && ctx.suggestions) || null,
+      })
+    })
+  }
+
+  /** Client answered a permission card. decision: 'allow' | 'allow-always' | 'deny'. */
+  resolvePermission(requestId, decision, message) {
+    const p = this.pending.get(requestId)
+    if (!p) return
+    clearTimeout(p.timer)
+    this.pending.delete(requestId)
+    this._emit({ type: 'stream:permission-resolved', requestId, decision })
+    if (decision === 'allow' || decision === 'allow-always') {
+      const result = { behavior: 'allow', updatedInput: p.input }
+      // 'allow-always' could add a permission suggestion here later
+      p.resolve(result)
+    } else {
+      p.resolve({ behavior: 'deny', message: message || 'Denied by the user.' })
+    }
+  }
+
+  async _consume() {
+    try {
+      for await (const msg of this._query) {
+        // Forward every SDK message to the client as a stream:event (the
+        // renderer already understands system/stream_event/assistant/result).
+        this._emit({ type: 'stream:event', event: msg })
+      }
+    } catch (err) {
+      this._emit({ type: 'stream:error', error: String(err && err.message || err) })
+    } finally {
+      this.exited = true
+      this._emit({ type: 'stream:exit' })
+    }
+  }
+
+  /** Buffer + broadcast an envelope object to all attached clients. */
+  _emit(obj) {
+    const s = JSON.stringify(obj)
+    this.events.push(s)
+    if (this.events.length > BUFFER_MAX) this.events.shift()
+    this.clients.forEach((ws) => { if (ws.readyState === 1) { try { ws.send(s) } catch { /* gone */ } } })
+  }
+
+  attach(ws) {
+    if (this.idleTimer) { clearTimeout(this.idleTimer); this.idleTimer = null }
+    this.clients.add(ws)
+    // ready + full replay so a returning client rebuilds the conversation
+    if (ws.readyState === 1) {
+      try {
+        ws.send(JSON.stringify({ type: 'stream:ready', cwd: this.cwd, hasToken: this.hasToken, resumed: this.events.length > 0 }))
+        for (const e of this.events) ws.send(e)
+        ws.send(JSON.stringify({ type: 'stream:replay-done' }))
+      } catch { /* gone */ }
+    }
+  }
+
+  detach(ws) {
+    this.clients.delete(ws)
+    if (this.clients.size === 0 && !this.idleTimer && !this.exited) {
+      this.idleTimer = setTimeout(() => destroy(this.agentKey), IDLE_MS)
+    }
+  }
+
+  close() {
+    this.closed = true
+    this._waker?.()
+    // deny any dangling permission requests
+    for (const [, p] of this.pending) { clearTimeout(p.timer); try { p.resolve({ behavior: 'deny', message: 'Session closed.' }) } catch { /* ignore */ } }
+    this.pending.clear()
+    try { this._query.interrupt?.() } catch { /* ignore */ }
+    try { this._query.return?.() } catch { /* ignore */ }
+  }
+}
+
+/** Get or create the streaming session for an agent. */
+export function getOrCreateStreamSession(agentKey, opts) {
+  let s = sessions.get(agentKey)
+  if (s && s.exited) { destroy(agentKey); s = null }
+  if (!s) {
+    s = new Session(agentKey, opts)
+    sessions.set(agentKey, s)
+    console.log(`[StreamRuntime] Started SDK session for ${agentKey} in ${opts.cwd} (resume: ${opts.resumeSessionId ? opts.resumeSessionId.slice(0, 8) : 'none'}, token: ${s.hasToken})`)
+  }
+  return s
+}
+
+export function getStreamSession(agentKey) {
+  return sessions.get(agentKey) || null
+}
+
+/** Destroy a session (kill the SDK subprocess + drop from the map). */
+export function destroy(agentKey) {
+  const s = sessions.get(agentKey)
+  if (!s) return
+  console.log(`[StreamRuntime] Destroying SDK session for ${agentKey}`)
+  s.close()
+  sessions.delete(agentKey)
+}
+
+/** For shutdown: close everything. */
+export function destroyAllStreamSessions() {
+  for (const k of Array.from(sessions.keys())) destroy(k)
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "container:ci": "podman run --rm ai-maestro-dev sh -c 'yarn test && yarn lint && npx tsc --noEmit && rm -rf .next && yarn build'"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.205",
     "@anthropic-ai/sdk": "^0.82.0",
     "@huggingface/transformers": "^3.8.1",
     "@wterm/core": "^0.3.0",

--- a/server.mjs
+++ b/server.mjs
@@ -336,28 +336,43 @@ function startJsonlWatcher(sessionName, sessionState, agentId) {
  */
 function detectPermissionFromPane(sessionName) {
   try {
-    const raw = execSync(`tmux capture-pane -p -t "${sessionName}" -S -30`,
+    const raw = execSync(`tmux capture-pane -p -t "${sessionName}" -S -60`,
       { timeout: 2000, encoding: 'utf-8' })
-    const lines = raw.split('\n').map(l => l.replace(/\s+$/, ''))
-    const tail = lines.slice(-18)
-    const text = tail.join('\n')
-    const looksLikePrompt =
-      /do you want to proceed|do you want to|would you like|yes, and don'?t ask|esc to (cancel|interrupt)/i.test(text) ||
-      /❯\s*\d+\.\s/.test(text)
-    if (!looksLikePrompt) return null
-    // Extract numbered options, tolerating box-drawing borders Claude Code
-    // draws around the menu (e.g. "│ ❯ 1. Yes │", "│   2. No │").
-    const options = []
-    for (const l of tail) {
-      const m = l.match(/^[\s❯>▶*│┃|]*(\d+)\.\s+(.+?)\s*[│┃|]?\s*$/)
-      if (m) {
-        const label = m[2].replace(/[│┃|╮╯╰╭]/g, '').replace(/\s+/g, ' ').trim()
-        if (label) options.push({ key: m[1], label, value: /^no\b|decline|cancel/i.test(label) ? 'no' : 'yes' })
-      }
+    // Strip box-drawing borders Claude Code wraps the menu in, and trailing ws.
+    const lines = raw.split('\n').map(l => l.replace(/[│┃╎╏┆┇]/g, ' ').replace(/\s+$/, ''))
+    // Scan a generous lower region (the live prompt sits near the bottom, but a
+    // long message + the task list can push it up ~30+ lines). Anchor on
+    // STRUCTURE, not a fixed line count.
+    const region = lines.slice(-45)
+    const text = region.join('\n')
+
+    // An ACTIVE permission/choice prompt is identified by permission-SPECIFIC
+    // signals — its footer, the exact "do you want to proceed" phrasing, or the
+    // ❯ selector on a numbered option. Generic "would you like…?" is NOT used
+    // (it appears in ordinary prose and caused false positives). "esc to
+    // interrupt" is excluded — that means Claude is just working.
+    const activeMarker =
+      /tab to amend|ctrl\+e to explain|esc to cancel|do you want to proceed|would you like to proceed|yes, and don'?t ask/i
+    const hasSelector = /[❯▶]\s*\d+\.\s/.test(text)
+    if (!activeMarker.test(text) && !hasSelector) return null
+
+    // Collect SHORT numbered options (a real menu, not prose "1. Long sentence…").
+    const optRe = /^[\s❯>▶*]*(\d+)\.\s+(.+?)\s*$/
+    const byKey = new Map()
+    for (const l of region) {
+      const m = l.match(optRe)
+      if (!m) continue
+      const key = m[1]
+      const label = m[2].replace(/\s+/g, ' ').trim()
+      if (!label || label.length > 90) continue  // skip prose
+      // Keep the LAST occurrence (the live menu, not an old one in history)
+      byKey.set(key, { key, label, value: /^no\b|decline|cancel|don'?t/i.test(label) ? 'no' : 'yes' })
     }
-    if (options.length === 0) return null
+    const options = Array.from(byKey.values()).sort((a, b) => Number(a.key) - Number(b.key))
+    if (options.length < 2) return null  // a genuine menu has ≥2 choices
+
     const qMatch = text.match(/((?:Do you want|Would you like)[^\n?]*\??)/i)
-    const question = qMatch ? qMatch[1].trim() : 'The agent is asking for permission'
+    const question = qMatch ? qMatch[1].trim() : 'The agent is asking to run a tool'
     return { status: 'permission_request', message: question, description: question, options, source: 'pane' }
   } catch { return null }
 }

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,6 @@
 import { createServer } from 'http'
 import { parse } from 'url'
-import { execSync, execFileSync, execFile, spawn } from 'child_process'
+import { execSync, execFileSync, execFile } from 'child_process'
 import { WebSocketServer } from 'ws'
 import WebSocket from 'ws'
 import pty from 'node-pty'
@@ -17,6 +17,10 @@ import {
   readHookState,
   hookStateFilePath,
 } from './lib/chat-transcript.mjs'
+import {
+  getOrCreateStreamSession,
+  destroyAllStreamSessions,
+} from './lib/streaming-runtime.mjs'
 import {
   sessionActivity,
   terminalSessions,
@@ -1512,52 +1516,29 @@ async function startServer(handleRequest) {
     })
   })
 
-  // ── Streaming chat PoC ────────────────────────────────────────────────
-  // Experimental: drives Claude Code in stream-json mode (NOT tmux). One
-  // persistent `claude` process per connection, in the agent's working dir,
-  // on the user's subscription. Send = JSON to stdin; receive = NDJSON events
-  // forwarded to the browser. Completely isolated from the /term path.
-  // Persistent per-agent streaming sessions: one claude process kept alive per
-  // agent, its full event stream buffered so a returning client replays the
-  // whole conversation and continues the SAME live session (context intact).
-  // agentKey -> { proc, cwd, hasToken, events:[envelopeStrings], clients:Set,
-  //              idleTimer, exited, stdoutBuf }
-  const streamSessions = new Map()
-  const STREAM_IDLE_MS = 15 * 60 * 1000  // kill a session 15 min after the last client leaves
-  const STREAM_BUFFER_MAX = 5000         // cap buffered events (older ones drop)
-
-  function streamResolveToken() {
-    const env = { ...process.env }
-    delete env.ANTHROPIC_API_KEY  // never let an API key silently override the subscription
-    if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      try {
-        const tokenFile = path.join(os.homedir(), '.aimaestro', 'claude-oauth-token')
-        if (fs.existsSync(tokenFile)) {
-          const t = fs.readFileSync(tokenFile, 'utf-8').trim()
-          if (t) env.CLAUDE_CODE_OAUTH_TOKEN = t
-        }
-      } catch { /* ignore */ }
-    }
-    return env
-  }
-
-  function streamBufferAndBroadcast(session, envelope, exceptWs = null) {
-    session.events.push(envelope)
-    if (session.events.length > STREAM_BUFFER_MAX) session.events.shift()
-    session.clients.forEach((c) => {
-      if (c !== exceptWs && c.readyState === 1) { try { c.send(envelope) } catch { /* client gone */ } }
-    })
-  }
-
+  // ── Streaming chat (Agent SDK runtime) ───────────────────────────────
+  // Drives Claude via the Agent SDK in stream-json mode (NOT tmux). One
+  // persistent per-agent SDK session (lib/streaming-runtime.mjs): resume-aware,
+  // subscription auth, canUseTool permission cards. Isolated from /term.
   const streamChatWss = new WebSocketServer({ noServer: true })
   streamChatWss.on('connection', async (ws, query) => {
     const agentKey = (query.agentId || query.name || '').toString()
-    let workingDir = null
+    let workingDir = null, agentName = null, resumeSessionId = null
     try {
       const { getAgent, getAgentByName } = await import('./lib/agent-registry.ts')
-      const agent = (query.agentId && getAgent(query.agentId)) ||
-        (query.name && getAgentByName(query.name))
+      const agent = (query.agentId && getAgent(query.agentId)) || (query.name && getAgentByName(query.name))
       workingDir = getAgentWorkingDir(agent)
+      agentName = agent?.name || agent?.alias || (query.name || null)
+      // Phase 1: resume the agent's latest conversation so streaming continues
+      // whatever it was doing — BUT only if it is NOT currently live in tmux
+      // (resuming an active terminal session would put two processes on one
+      // session_id). If a live tmux session exists, start fresh.
+      let terminalLive = false
+      try { execFileSync('tmux', ['has-session', '-t', agentName || agentKey], { stdio: 'ignore', timeout: 2000 }); terminalLive = true } catch { /* not live */ }
+      if (!terminalLive) {
+        const latest = resolveJsonlPath(agent)
+        if (latest && latest.name.endsWith('.jsonl')) resumeSessionId = latest.name.slice(0, -6)
+      }
     } catch { /* fall through */ }
 
     if (!workingDir || !agentKey) {
@@ -1566,115 +1547,39 @@ async function startServer(handleRequest) {
       return
     }
 
-    let session = streamSessions.get(agentKey)
-    if (session && session.exited) { streamSessions.delete(agentKey); session = null }
-
-    // ── New session: spawn the persistent claude process ──────────────────
-    if (!session) {
-      const env = streamResolveToken()
-      let proc
-      try {
-        proc = spawn('claude', [
-          '--input-format', 'stream-json',
-          '--output-format', 'stream-json',
-          '--verbose',
-          '--include-partial-messages',  // token-by-token text deltas
-          '-p',
-          '--permission-mode', 'acceptEdits',
-        ], { cwd: workingDir, env, stdio: ['pipe', 'pipe', 'pipe'] })
-      } catch (err) {
-        try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Failed to launch claude: ' + err.message })) } catch {}
-        ws.close(1011, 'spawn failed')
-        return
-      }
-
-      session = {
-        proc, cwd: workingDir, hasToken: !!env.CLAUDE_CODE_OAUTH_TOKEN,
-        events: [], clients: new Set(), idleTimer: null, exited: false, stdoutBuf: '',
-      }
-      streamSessions.set(agentKey, session)
-      console.log(`[StreamChat] Spawned persistent claude (pid ${proc.pid}) for ${agentKey} in ${workingDir} (token: ${session.hasToken})`)
-
-      // Wire stdout ONCE — buffer + broadcast to all clients of this session
-      proc.stdout.on('data', (chunk) => {
-        session.stdoutBuf += chunk.toString()
-        let nl
-        while ((nl = session.stdoutBuf.indexOf('\n')) !== -1) {
-          const line = session.stdoutBuf.slice(0, nl).trim()
-          session.stdoutBuf = session.stdoutBuf.slice(nl + 1)
-          if (!line) continue
-          let event
-          try { event = JSON.parse(line) } catch { continue }
-          streamBufferAndBroadcast(session, JSON.stringify({ type: 'stream:event', event }))
-        }
+    let session
+    try {
+      session = getOrCreateStreamSession(agentKey, {
+        cwd: workingDir,
+        agentId: query.agentId || null,
+        agentName,
+        resumeSessionId,
       })
-      proc.stderr.on('data', (chunk) => {
-        const msg = chunk.toString().trim()
-        if (msg) console.warn(`[StreamChat pid ${proc.pid}] stderr: ${msg.slice(0, 200)}`)
-      })
-      proc.on('exit', (code, signal) => {
-        console.log(`[StreamChat] claude exited (pid ${proc.pid}, ${agentKey}, code ${code}, signal ${signal})`)
-        session.exited = true
-        streamBufferAndBroadcast(session, JSON.stringify({ type: 'stream:exit', code, signal }))
-      })
-    } else if (session.idleTimer) {
-      // Returning client — cancel the pending idle-kill
-      clearTimeout(session.idleTimer)
-      session.idleTimer = null
+    } catch (err) {
+      try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Failed to start streaming session: ' + (err && err.message || err) })) } catch {}
+      ws.close(1011, 'runtime error')
+      return
     }
 
-    // Register this client and send ready + full replay so the UI rebuilds
-    session.clients.add(ws)
-    const resumed = session.events.length > 0
-    if (ws.readyState === 1) {
-      try {
-        ws.send(JSON.stringify({ type: 'stream:ready', cwd: session.cwd, hasToken: session.hasToken, resumed }))
-        for (const envelope of session.events) ws.send(envelope)
-        ws.send(JSON.stringify({ type: 'stream:replay-done' }))
-      } catch { /* client gone */ }
-    }
+    session.attach(ws)
 
     ws.on('message', (data) => {
       let msg
       try { msg = JSON.parse(data.toString()) } catch { return }
-      if (msg.type === 'ping') {
-        if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'pong' }))
+      if (msg.type === 'ping') { if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'pong' })); return }
+      if (msg.type === 'send' && typeof msg.text === 'string' && msg.text.trim()) {
+        if (session.exited) { if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'stream:error', error: 'Session ended — reopen to start a new one' })); return }
+        session.push(msg.text)
         return
       }
-      if (msg.type === 'send' && typeof msg.text === 'string' && msg.text.trim()) {
-        if (session.exited) {
-          if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'stream:error', error: 'Session ended — reopen to start a new one' }))
-          return
-        }
-        // Record the user turn in the buffer + mirror to OTHER clients, so
-        // returning/second clients rebuild it (claude's stdout doesn't echo
-        // the user's own input). Then feed it to the live process.
-        streamBufferAndBroadcast(session, JSON.stringify({ type: 'stream:user', text: msg.text }))
-        const userMsg = { type: 'user', message: { role: 'user', content: msg.text } }
-        try {
-          session.proc.stdin.write(JSON.stringify(userMsg) + '\n')
-        } catch (err) {
-          if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'stream:error', error: 'Write to claude failed: ' + err.message }))
-        }
+      if (msg.type === 'permissionDecision' && msg.requestId) {
+        session.resolvePermission(msg.requestId, msg.decision, msg.message)
+        return
       }
     })
 
-    const detach = () => {
-      session.clients.delete(ws)
-      // Last client left — keep the process alive briefly, then idle-kill so
-      // switching tabs preserves the session but abandoned ones don't leak.
-      if (session.clients.size === 0 && !session.idleTimer && !session.exited) {
-        session.idleTimer = setTimeout(() => {
-          console.log(`[StreamChat] Idle-killing ${agentKey} (pid ${session.proc.pid})`)
-          try { session.proc.stdin.end() } catch {}
-          try { session.proc.kill('SIGTERM') } catch {}
-          setTimeout(() => { try { session.proc.kill('SIGKILL') } catch {} }, 2000)
-          streamSessions.delete(agentKey)
-        }, STREAM_IDLE_MS)
-      }
-    }
-    ws.on('close', detach)
-    ws.on('error', detach)
+    ws.on('close', () => session.detach(ws))
+    ws.on('error', () => session.detach(ws))
   })
 
   server.on('upgrade', (request, socket, head) => {
@@ -2503,6 +2408,9 @@ async function startServer(handleRequest) {
       const { stopScheduler } = await import('./lib/schedule-executor.ts')
       stopScheduler()
     } catch { /* ignore */ }
+
+    // Kill all streaming (SDK) sessions
+    try { destroyAllStreamSessions() } catch { /* ignore */ }
 
     // Kill all PTY processes FIRST and synchronously
     const sessionCount = terminalSessions.size

--- a/server.mjs
+++ b/server.mjs
@@ -264,6 +264,18 @@ function startJsonlWatcher(sessionName, sessionState, agentId) {
       const current = resolveJsonlPath(agent)
       if (!current || current.path === sessionState.jsonlFilePath) return
 
+      // Flap guard: sibling .jsonl files (subagent/sidechain transcripts) can
+      // out-mtime the main conversation while BOTH are being written. Only
+      // rotate when the watched file has gone quiet (no writes for 60s) —
+      // a real /clear or new conversation, not a busy sidechain.
+      if (sessionState.jsonlFilePath) {
+        try {
+          const watchedMtime = fs.statSync(sessionState.jsonlFilePath).mtimeMs
+          if (Date.now() - watchedMtime < 60000) return
+          if (current.mtime.getTime() <= watchedMtime) return
+        } catch { /* watched file deleted — rotate */ }
+      }
+
       console.log(`[Chat] Conversation rotated for ${sessionName}: ${sessionState.jsonlFilePath} → ${current.path}`)
       if (sessionState.jsonlFilePath) {
         try { fs.unwatchFile(sessionState.jsonlFilePath) } catch { /* ignore */ }
@@ -1945,6 +1957,17 @@ async function startServer(handleRequest) {
     // and therefore every other session's output — for up to 5s per connect.
     execFile('tmux', tmuxArgs(['set-option', '-t', sessionName, 'mouse', 'off']), { timeout: 2000 }, (err) => {
       if (err) console.warn(`[PTY] Failed to set mouse off for ${sessionName}:`, err.message)
+    })
+
+    // Disable the alternate screen for agent sessions. Claude Code runs on the
+    // alt screen, and tmux keeps ZERO history for alt-screen panes — so there
+    // was nothing to scroll into (copy-mode blocked after a few lines) and
+    // capture-pane replays were one screenful. With alternate-screen off, the
+    // transcript accumulates in tmux history like a normal terminal (iTerm2
+    // behaves this way by default). Takes effect the next time the app enters
+    // the alt screen — i.e. after the claude process in the session restarts.
+    execFile('tmux', tmuxArgs(['set-option', '-w', '-t', sessionName, 'alternate-screen', 'off']), { timeout: 2000 }, (err) => {
+      if (err) console.warn(`[PTY] Failed to set alternate-screen off for ${sessionName}:`, err.message)
     })
 
     // Track connection as activity (so newly opened sessions show as active)

--- a/server.mjs
+++ b/server.mjs
@@ -1517,34 +1517,18 @@ async function startServer(handleRequest) {
   // persistent `claude` process per connection, in the agent's working dir,
   // on the user's subscription. Send = JSON to stdin; receive = NDJSON events
   // forwarded to the browser. Completely isolated from the /term path.
-  const streamChatWss = new WebSocketServer({ noServer: true })
-  streamChatWss.on('connection', async (ws, query) => {
-    let workingDir = null
-    try {
-      const { getAgent, getAgentByName } = await import('./lib/agent-registry.ts')
-      const agent = (query.agentId && getAgent(query.agentId)) ||
-        (query.name && getAgentByName(query.name))
-      workingDir = getAgentWorkingDir(agent)
-    } catch { /* fall through */ }
+  // Persistent per-agent streaming sessions: one claude process kept alive per
+  // agent, its full event stream buffered so a returning client replays the
+  // whole conversation and continues the SAME live session (context intact).
+  // agentKey -> { proc, cwd, hasToken, events:[envelopeStrings], clients:Set,
+  //              idleTimer, exited, stdoutBuf }
+  const streamSessions = new Map()
+  const STREAM_IDLE_MS = 15 * 60 * 1000  // kill a session 15 min after the last client leaves
+  const STREAM_BUFFER_MAX = 5000         // cap buffered events (older ones drop)
 
-    if (!workingDir) {
-      try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Agent has no working directory' })) } catch {}
-      ws.close(1008, 'no working directory')
-      return
-    }
-
-    // Subscription auth: never pass ANTHROPIC_API_KEY (it silently overrides
-    // the subscription and bills the API). Strip it defensively.
+  function streamResolveToken() {
     const env = { ...process.env }
-    delete env.ANTHROPIC_API_KEY
-
-    // HEADLESS AUTH (macOS): a background server (pm2 daemon) cannot reach the
-    // macOS Keychain where the interactive `claude /login` stores subscription
-    // credentials — so a spawned claude reports "Not logged in". The reliable
-    // headless path is a long-lived token from `claude setup-token`, injected
-    // as CLAUDE_CODE_OAUTH_TOKEN. Read it from the env, or from a file the user
-    // drops at ~/.aimaestro/claude-oauth-token. (Same mechanism avogado-backend
-    // uses; on Linux the ~/.claude/.credentials.json file works without this.)
+    delete env.ANTHROPIC_API_KEY  // never let an API key silently override the subscription
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
       try {
         const tokenFile = path.join(os.homedir(), '.aimaestro', 'claude-oauth-token')
@@ -1554,53 +1538,101 @@ async function startServer(handleRequest) {
         }
       } catch { /* ignore */ }
     }
-    const hasHeadlessToken = !!env.CLAUDE_CODE_OAUTH_TOKEN
+    return env
+  }
 
-    let proc
+  function streamBufferAndBroadcast(session, envelope, exceptWs = null) {
+    session.events.push(envelope)
+    if (session.events.length > STREAM_BUFFER_MAX) session.events.shift()
+    session.clients.forEach((c) => {
+      if (c !== exceptWs && c.readyState === 1) { try { c.send(envelope) } catch { /* client gone */ } }
+    })
+  }
+
+  const streamChatWss = new WebSocketServer({ noServer: true })
+  streamChatWss.on('connection', async (ws, query) => {
+    const agentKey = (query.agentId || query.name || '').toString()
+    let workingDir = null
     try {
-      proc = spawn('claude', [
-        '--input-format', 'stream-json',
-        '--output-format', 'stream-json',
-        '--verbose',
-        '--include-partial-messages',  // token-by-token text deltas
-        '-p',
-        '--permission-mode', 'acceptEdits',
-      ], { cwd: workingDir, env, stdio: ['pipe', 'pipe', 'pipe'] })
-    } catch (err) {
-      try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Failed to launch claude: ' + err.message })) } catch {}
-      ws.close(1011, 'spawn failed')
+      const { getAgent, getAgentByName } = await import('./lib/agent-registry.ts')
+      const agent = (query.agentId && getAgent(query.agentId)) ||
+        (query.name && getAgentByName(query.name))
+      workingDir = getAgentWorkingDir(agent)
+    } catch { /* fall through */ }
+
+    if (!workingDir || !agentKey) {
+      try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Agent has no working directory' })) } catch {}
+      ws.close(1008, 'no working directory')
       return
     }
 
-    console.log(`[StreamChat] Spawned claude (pid ${proc.pid}) in ${workingDir} (headlessToken: ${hasHeadlessToken})`)
-    try { ws.send(JSON.stringify({ type: 'stream:ready', cwd: workingDir, hasToken: hasHeadlessToken })) } catch {}
+    let session = streamSessions.get(agentKey)
+    if (session && session.exited) { streamSessions.delete(agentKey); session = null }
 
-    // Parse NDJSON from stdout, forward each event to the browser
-    let buf = ''
-    proc.stdout.on('data', (chunk) => {
-      buf += chunk.toString()
-      let nl
-      while ((nl = buf.indexOf('\n')) !== -1) {
-        const line = buf.slice(0, nl).trim()
-        buf = buf.slice(nl + 1)
-        if (!line) continue
-        let event
-        try { event = JSON.parse(line) } catch { continue }
-        if (ws.readyState === 1) {
-          try { ws.send(JSON.stringify({ type: 'stream:event', event })) } catch {}
+    // ── New session: spawn the persistent claude process ──────────────────
+    if (!session) {
+      const env = streamResolveToken()
+      let proc
+      try {
+        proc = spawn('claude', [
+          '--input-format', 'stream-json',
+          '--output-format', 'stream-json',
+          '--verbose',
+          '--include-partial-messages',  // token-by-token text deltas
+          '-p',
+          '--permission-mode', 'acceptEdits',
+        ], { cwd: workingDir, env, stdio: ['pipe', 'pipe', 'pipe'] })
+      } catch (err) {
+        try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Failed to launch claude: ' + err.message })) } catch {}
+        ws.close(1011, 'spawn failed')
+        return
+      }
+
+      session = {
+        proc, cwd: workingDir, hasToken: !!env.CLAUDE_CODE_OAUTH_TOKEN,
+        events: [], clients: new Set(), idleTimer: null, exited: false, stdoutBuf: '',
+      }
+      streamSessions.set(agentKey, session)
+      console.log(`[StreamChat] Spawned persistent claude (pid ${proc.pid}) for ${agentKey} in ${workingDir} (token: ${session.hasToken})`)
+
+      // Wire stdout ONCE — buffer + broadcast to all clients of this session
+      proc.stdout.on('data', (chunk) => {
+        session.stdoutBuf += chunk.toString()
+        let nl
+        while ((nl = session.stdoutBuf.indexOf('\n')) !== -1) {
+          const line = session.stdoutBuf.slice(0, nl).trim()
+          session.stdoutBuf = session.stdoutBuf.slice(nl + 1)
+          if (!line) continue
+          let event
+          try { event = JSON.parse(line) } catch { continue }
+          streamBufferAndBroadcast(session, JSON.stringify({ type: 'stream:event', event }))
         }
-      }
-    })
-    proc.stderr.on('data', (chunk) => {
-      const msg = chunk.toString().trim()
-      if (msg) console.warn(`[StreamChat pid ${proc.pid}] stderr: ${msg.slice(0, 200)}`)
-    })
-    proc.on('exit', (code, signal) => {
-      console.log(`[StreamChat] claude exited (pid ${proc.pid}, code ${code}, signal ${signal})`)
-      if (ws.readyState === 1) {
-        try { ws.send(JSON.stringify({ type: 'stream:exit', code, signal })) } catch {}
-      }
-    })
+      })
+      proc.stderr.on('data', (chunk) => {
+        const msg = chunk.toString().trim()
+        if (msg) console.warn(`[StreamChat pid ${proc.pid}] stderr: ${msg.slice(0, 200)}`)
+      })
+      proc.on('exit', (code, signal) => {
+        console.log(`[StreamChat] claude exited (pid ${proc.pid}, ${agentKey}, code ${code}, signal ${signal})`)
+        session.exited = true
+        streamBufferAndBroadcast(session, JSON.stringify({ type: 'stream:exit', code, signal }))
+      })
+    } else if (session.idleTimer) {
+      // Returning client — cancel the pending idle-kill
+      clearTimeout(session.idleTimer)
+      session.idleTimer = null
+    }
+
+    // Register this client and send ready + full replay so the UI rebuilds
+    session.clients.add(ws)
+    const resumed = session.events.length > 0
+    if (ws.readyState === 1) {
+      try {
+        ws.send(JSON.stringify({ type: 'stream:ready', cwd: session.cwd, hasToken: session.hasToken, resumed }))
+        for (const envelope of session.events) ws.send(envelope)
+        ws.send(JSON.stringify({ type: 'stream:replay-done' }))
+      } catch { /* client gone */ }
+    }
 
     ws.on('message', (data) => {
       let msg
@@ -1610,23 +1642,39 @@ async function startServer(handleRequest) {
         return
       }
       if (msg.type === 'send' && typeof msg.text === 'string' && msg.text.trim()) {
-        // Write a stream-json user message to the persistent process's stdin
+        if (session.exited) {
+          if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'stream:error', error: 'Session ended — reopen to start a new one' }))
+          return
+        }
+        // Record the user turn in the buffer + mirror to OTHER clients, so
+        // returning/second clients rebuild it (claude's stdout doesn't echo
+        // the user's own input). Then feed it to the live process.
+        streamBufferAndBroadcast(session, JSON.stringify({ type: 'stream:user', text: msg.text }))
         const userMsg = { type: 'user', message: { role: 'user', content: msg.text } }
         try {
-          proc.stdin.write(JSON.stringify(userMsg) + '\n')
+          session.proc.stdin.write(JSON.stringify(userMsg) + '\n')
         } catch (err) {
           if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'stream:error', error: 'Write to claude failed: ' + err.message }))
         }
       }
     })
 
-    const cleanup = () => {
-      try { proc.stdin.end() } catch {}
-      try { proc.kill('SIGTERM') } catch {}
-      setTimeout(() => { try { proc.kill('SIGKILL') } catch {} }, 2000)
+    const detach = () => {
+      session.clients.delete(ws)
+      // Last client left — keep the process alive briefly, then idle-kill so
+      // switching tabs preserves the session but abandoned ones don't leak.
+      if (session.clients.size === 0 && !session.idleTimer && !session.exited) {
+        session.idleTimer = setTimeout(() => {
+          console.log(`[StreamChat] Idle-killing ${agentKey} (pid ${session.proc.pid})`)
+          try { session.proc.stdin.end() } catch {}
+          try { session.proc.kill('SIGTERM') } catch {}
+          setTimeout(() => { try { session.proc.kill('SIGKILL') } catch {} }, 2000)
+          streamSessions.delete(agentKey)
+        }, STREAM_IDLE_MS)
+      }
     }
-    ws.on('close', () => { console.log(`[StreamChat] WS closed, killing pid ${proc.pid}`); cleanup() })
-    ws.on('error', () => cleanup())
+    ws.on('close', detach)
+    ws.on('error', detach)
   })
 
   server.on('upgrade', (request, socket, head) => {

--- a/server.mjs
+++ b/server.mjs
@@ -310,6 +310,19 @@ function startJsonlWatcher(sessionName, sessionState, agentId) {
       sessionState._hookStateWatcher = true
       console.log(`[Chat] Started hookState watcher for ${sessionName}: ${hookStateFile}`)
     }
+
+    // Periodic permission poll: the hook file / post-tool_use bursts miss many
+    // prompts (a permission menu appears BEFORE any JSONL tool_use is written),
+    // so poll the pane directly while a chat client is watching. broadcastHookState
+    // reads the hook AND falls back to the pane, and dedupes, so this only pushes
+    // on an actual change. Guarantees prompts surface within ~2.5s.
+    if (!sessionState._permissionPollTimer) {
+      sessionState._permissionPollTimer = setInterval(() => {
+        if (sessionState.chatClients && sessionState.chatClients.size > 0) {
+          broadcastHookState(sessionName, sessionState)
+        }
+      }, 2500)
+    }
   }).catch(err => {
     console.error(`[Chat] Failed to start JSONL watcher for ${sessionName}:`, err.message)
   })
@@ -523,6 +536,10 @@ function cleanupSession(sessionName, sessionState, reason = 'unknown', ptyAlread
     } catch { /* ignore */ }
     sessionState.jsonlWatcher = null
   }
+  if (sessionState._permissionPollTimer) {
+    clearInterval(sessionState._permissionPollTimer)
+    sessionState._permissionPollTimer = null
+  }
   if (sessionState.jsonlRotationTimer) {
     clearInterval(sessionState.jsonlRotationTimer)
     sessionState.jsonlRotationTimer = null
@@ -584,24 +601,30 @@ function handleClientDisconnect(ws, sessionName, sessionState, reason = 'close')
   sessionState.clients.delete(ws)
   sessionState.chatClients?.delete(ws)
 
-  console.log(`[PTY] Client disconnected from ${sessionName} (${reason}). Remaining clients: ${sessionState.clients.size}`)
+  const chatCount = sessionState.chatClients?.size || 0
+  console.log(`[PTY] Client disconnected from ${sessionName} (${reason}). Remaining clients: ${sessionState.clients.size} (chat: ${chatCount})`)
 
-  // If no clients remain, schedule cleanup
-  if (sessionState.clients.size === 0) {
-    console.log(`[PTY] Last client disconnected from ${sessionName}, scheduling cleanup in ${PTY_CLEANUP_GRACE_MS / 1000}s`)
+  // Only schedule cleanup when NO clients of ANY kind remain. A chat-only
+  // client (no terminal attached) must keep the session alive — otherwise the
+  // hookState/permission watchers get torn down under an open chat and
+  // permission prompts stop reaching it.
+  if (sessionState.clients.size === 0 && chatCount === 0) {
+    console.log(`[PTY] Last client (terminal+chat) disconnected from ${sessionName}, scheduling cleanup in ${PTY_CLEANUP_GRACE_MS / 1000}s`)
 
-    // Clear any existing cleanup timer
     if (sessionState.cleanupTimer) {
       clearTimeout(sessionState.cleanupTimer)
     }
 
-    // Schedule cleanup after grace period
     sessionState.cleanupTimer = setTimeout(() => {
-      // Double-check no clients reconnected
-      if (sessionState.clients.size === 0) {
+      // Double-check nothing reconnected (terminal OR chat)
+      if (sessionState.clients.size === 0 && (sessionState.chatClients?.size || 0) === 0) {
         cleanupSession(sessionName, sessionState, 'no_clients_after_grace_period')
       }
     }, PTY_CLEANUP_GRACE_MS)
+  } else if (sessionState.cleanupTimer) {
+    // A client (e.g. chat) is still here — cancel any pending cleanup.
+    clearTimeout(sessionState.cleanupTimer)
+    sessionState.cleanupTimer = null
   }
 }
 
@@ -619,9 +642,9 @@ function startOrphanedPtyCleanup() {
         return
       }
 
-      // Check for sessions with no clients and no pending cleanup timer
-      // These are orphaned - they have a PTY but no way to clean it up
-      if (sessionState.clients.size === 0 && !sessionState.cleanupTimer) {
+      // Check for sessions with no clients (terminal OR chat) and no pending
+      // cleanup timer. A live chat client keeps the session alive.
+      if (sessionState.clients.size === 0 && (sessionState.chatClients?.size || 0) === 0 && !sessionState.cleanupTimer) {
         console.log(`[PTY] Found orphaned session: ${sessionName}`)
         cleanupSession(sessionName, sessionState, 'orphan_cleanup', false)
         orphanedCount++
@@ -1809,12 +1832,14 @@ async function startServer(handleRequest) {
       })
 
       ws.on('close', () => {
-        sessionState.chatClients?.delete(ws)
         console.log(`[Chat] Chat-only client disconnected from ${sessionName}`)
+        // Route through the shared disconnect so cleanup is scheduled only when
+        // BOTH terminal and chat clients are gone (and the permission poll stops).
+        handleClientDisconnect(ws, sessionName, sessionState, 'chat-close')
       })
 
       ws.on('error', () => {
-        sessionState.chatClients?.delete(ws)
+        handleClientDisconnect(ws, sessionName, sessionState, 'chat-error')
       })
 
       return // Skip all PTY/terminal setup below

--- a/server.mjs
+++ b/server.mjs
@@ -626,7 +626,8 @@ function getAgentIdForSession(sessionName) {
  * 2. Capture pane baseline.
  * 3. Write text to a temp file, load into tmux buffer, paste into pane.
  * 4. Poll until the tail of the text appears in the pane (paste-probe).
- * 5. Send Enter only after verification (or after timeout).
+ * 5. Send Enter ONLY after verification. On probe timeout: clear the staged
+ *    text (C-u) and fail — never Enter-anyway (risked truncated submissions).
  *
  * Returns { ok, error? }
  */
@@ -695,18 +696,33 @@ async function sendChatMessage(sessionName, message) {
 
   // 5. Paste-probe: poll until text tail appears in pane
   const probe = pasteTailProbe(message)
+  let verified = true
   if (probe) {
-    const baselineCount = (baseline.match(new RegExp(probe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
+    verified = false
+    const probeRe = new RegExp(probe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')
+    const baselineCount = (baseline.match(probeRe) || []).length
     const deadline = Date.now() + PASTE_PROBE_TIMEOUT_MS
     while (Date.now() < deadline) {
       const captured = capturePaneCompact(sessionName)
-      const currentCount = (captured.match(new RegExp(probe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
-      if (currentCount > baselineCount) break
+      const currentCount = (captured.match(probeRe) || []).length
+      if (currentCount > baselineCount) { verified = true; break }
       await new Promise(r => setTimeout(r, PASTE_PROBE_INTERVAL_MS))
     }
   }
 
-  // 6. Send Enter (C-m is more reliable than Enter through tmux)
+  // 6. If the paste never appeared, DO NOT press Enter. Pressing it anyway
+  // (the old behavior) could submit a truncated message or confirm whatever
+  // dialog is actually on screen — silently. Clear the staged text (C-u
+  // deletes to line start in both Claude Code's input box and readline) so a
+  // retry doesn't double the text, and report failure so the client shows
+  // the pending bubble as failed with a Retry button.
+  if (!verified) {
+    try { execSync(`tmux send-keys -t "${sessionName}" C-u`, { timeout: 2000 }) } catch { /* best effort */ }
+    console.warn(`[Chat] Paste-probe failed for ${sessionName} — message NOT submitted`)
+    return { ok: false, error: 'Message could not be confirmed in the terminal — nothing was sent. The agent may be busy or showing a dialog; check the Terminal tab, then retry.' }
+  }
+
+  // 7. Send Enter (C-m is more reliable than Enter through tmux)
   try {
     execSync(`tmux send-keys -t "${sessionName}" C-m`, { timeout: 3000 })
   } catch (err) {
@@ -1613,6 +1629,9 @@ async function startServer(handleRequest) {
                 }
               } else {
                 if (ws.readyState === 1) {
+                  // sendFailed carries the original text so the client can mark
+                  // the exact pending bubble as failed (with Retry) immediately
+                  ws.send(JSON.stringify({ type: 'chat:sendFailed', message: parsed.message, error: result.error }))
                   ws.send(JSON.stringify({ type: 'chat:error', error: result.error }))
                 }
               }
@@ -2087,6 +2106,9 @@ async function startServer(handleRequest) {
                 }
               } else {
                 if (ws.readyState === 1) {
+                  // sendFailed carries the original text so the client can mark
+                  // the exact pending bubble as failed (with Retry) immediately
+                  ws.send(JSON.stringify({ type: 'chat:sendFailed', message: parsed.message, error: result.error }))
                   ws.send(JSON.stringify({ type: 'chat:error', error: result.error }))
                 }
               }

--- a/server.mjs
+++ b/server.mjs
@@ -1967,6 +1967,16 @@ async function startServer(handleRequest) {
     // Helper: prepend custom-socket args for tmux invocations on this session
     const tmuxArgs = (args) => (socketPath ? ['-S', socketPath, ...args] : args)
 
+    // Capability handshake: clients must NOT send new protocol frames (like
+    // tmux-scroll) to servers that don't understand them — old servers write
+    // unknown messages straight into the PTY, typing literal JSON into the
+    // agent's prompt. This frame reaches the client through proxies too, so
+    // the client learns the capabilities of the END server (remote hosts on
+    // old versions simply never send it → client falls back gracefully).
+    if (ws.readyState === 1) {
+      try { ws.send(JSON.stringify({ type: 'server-caps', tmuxScroll: true })) } catch { /* ignore */ }
+    }
+
     // Disable tmux mouse mode per-session so xterm.js handles mouse natively.
     // Without this, ~/.tmux.conf "set -g mouse on" causes tmux to intercept
     // click-drag (yellow copy-mode selection instead of browser clipboard).
@@ -2113,6 +2123,14 @@ async function startServer(handleRequest) {
                 }
               }
             }
+            return
+          }
+
+          // Unknown protocol frame (JSON with a type field we don't handle):
+          // DROP it — never write it to the PTY. Old servers typed frames like
+          // {"type":"tmux-scroll"} into the agent's prompt as literal text.
+          if (parsed && typeof parsed.type === 'string') {
+            console.warn(`[WS] Dropping unknown protocol frame '${parsed.type}' for ${sessionName}`)
             return
           }
         } catch {

--- a/server.mjs
+++ b/server.mjs
@@ -7,10 +7,16 @@ import pty from 'node-pty'
 import os from 'os'
 import fs from 'fs'
 import path from 'path'
-import crypto from 'crypto'
 import { getHostById, isSelf } from './lib/hosts-config-server.mjs'
 import { hostHints } from './lib/host-hints-server.mjs'
 import { getOrCreateBuffer, removeBuffer } from './lib/cerebellum/session-bridge.mjs'
+import {
+  resolveJsonlPath,
+  getAgentWorkingDir,
+  parseJsonlLines,
+  readHookState,
+  hookStateFilePath,
+} from './lib/chat-transcript.mjs'
 import {
   sessionActivity,
   terminalSessions,
@@ -166,103 +172,8 @@ function killPtyProcess(ptyProcess, sessionName, alreadyExited = false) {
 // CHAT PROTOCOL HELPERS — getChatHistory, JSONL watcher, broadcast updates
 // =============================================================================
 
-/**
- * Resolve the JSONL conversation file path for an agent.
- * Returns null if not found.
- */
-function resolveJsonlPath(agent) {
-  const workingDir = agent?.workingDirectory ||
-                     agent?.sessions?.[0]?.workingDirectory ||
-                     agent?.preferences?.defaultWorkingDirectory
-  if (!workingDir) return null
-
-  const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-  const projectDirName = workingDir.replace(/[/_]/g, '-')
-  const conversationDir = path.join(claudeProjectsDir, projectDirName)
-
-  if (!fs.existsSync(conversationDir)) return null
-
-  const files = fs.readdirSync(conversationDir)
-    .filter(f => f.endsWith('.jsonl'))
-    .map(f => ({
-      name: f,
-      path: path.join(conversationDir, f),
-      mtime: fs.statSync(path.join(conversationDir, f)).mtime
-    }))
-    .sort((a, b) => b.mtime.getTime() - a.mtime.getTime())
-
-  return files.length > 0 ? files[0] : null
-}
-
-/**
- * Read hook state file for an agent's working directory.
- */
-function readHookState(workingDir) {
-  if (!workingDir) return null
-  const stateDir = path.join(os.homedir(), '.aimaestro', 'chat-state')
-  const cwdHash = crypto.createHash('md5').update(workingDir || '').digest('hex').substring(0, 16)
-  const stateFile = path.join(stateDir, `${cwdHash}.json`)
-  try {
-    if (fs.existsSync(stateFile)) {
-      const content = fs.readFileSync(stateFile, 'utf-8')
-      const state = JSON.parse(content)
-      const isWaitingState = state.status === 'waiting_for_input' || state.status === 'permission_request'
-      if (!isWaitingState) {
-        const stateAge = Date.now() - new Date(state.updatedAt).getTime()
-        if (stateAge > 60000) return null
-      }
-      return state
-    }
-  } catch { /* ignore */ }
-  return null
-}
-
-/**
- * Parse JSONL lines into message objects (same logic as agents-chat-service).
- */
-function parseJsonlLines(lines, limit = 100) {
-  const messages = []
-  for (const line of lines) {
-    if (!line.trim()) continue
-    try {
-      const message = JSON.parse(line)
-
-      // Skip tool-result user messages (invisible in chat, waste message budget)
-      if (message.type === 'user' && message.toolUseResult) continue
-
-      // Convert compact_boundary system messages to summary type
-      if (message.type === 'system' &&
-          (message.subtype === 'compact_boundary' || message.subtype === 'microcompact_boundary')) {
-        messages.push({
-          type: 'summary',
-          summary: message.content || 'Conversation compacted',
-          timestamp: message.timestamp,
-          uuid: message.uuid,
-        })
-        continue
-      }
-
-      // Extract thinking blocks from assistant messages
-      if (message.type === 'assistant' && message.message?.content) {
-        const content = message.message.content
-        if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block.type === 'thinking' && block.thinking) {
-              messages.push({
-                type: 'thinking',
-                thinking: block.thinking,
-                timestamp: message.timestamp,
-                uuid: message.uuid
-              })
-            }
-          }
-        }
-      }
-      messages.push(message)
-    } catch { /* skip malformed */ }
-  }
-  return messages.slice(-limit)
-}
+// resolveJsonlPath / parseJsonlLines / readHookState now live in
+// lib/chat-transcript.mjs (shared with the TypeScript services — do not fork).
 
 /**
  * Get chat history for a session (messages + hookState).
@@ -285,9 +196,7 @@ async function getChatHistory(sessionName, agentId) {
   const lines = fileContent.split('\n')
   const messages = parseJsonlLines(lines, 200)
 
-  const workingDir = agent.workingDirectory ||
-                     agent.sessions?.[0]?.workingDirectory ||
-                     agent.preferences?.defaultWorkingDirectory
+  const workingDir = getAgentWorkingDir(agent)
   let hookState = readHookState(workingDir)
 
   // If the file no longer has permission_request but the server remembers one
@@ -321,40 +230,61 @@ function startJsonlWatcher(sessionName, sessionState, agentId) {
     const agent = (agentId && getAgent(agentId)) || getAgentByName(sessionName)
     if (!agent) return
 
-    const file = resolveJsonlPath(agent)
-    if (!file) return
-
-    sessionState.jsonlFilePath = file.path
-    try {
-      const stat = fs.statSync(file.path)
-      sessionState.jsonlFileSize = stat.size
-    } catch {
-      sessionState.jsonlFileSize = 0
+    const watchJsonlFile = (filePath) => {
+      sessionState.jsonlFilePath = filePath
+      sessionState.jsonlPartialLine = ''
+      try {
+        sessionState.jsonlFileSize = fs.statSync(filePath).size
+      } catch {
+        sessionState.jsonlFileSize = 0
+      }
+      // Poll every 1s — low overhead, reliable on macOS where fs.watch is flaky
+      fs.watchFile(filePath, { interval: 1000 }, (curr) => {
+        if (curr.size > sessionState.jsonlFileSize) {
+          broadcastJsonlUpdates(sessionName, sessionState)
+        }
+        // Handle file truncation (conversation rewritten in place)
+        if (curr.size < sessionState.jsonlFileSize) {
+          sessionState.jsonlFileSize = 0
+          broadcastJsonlUpdates(sessionName, sessionState)
+        }
+      })
+      console.log(`[Chat] Started JSONL watcher for ${sessionName}: ${filePath}`)
     }
 
-    // Poll every 1s — low overhead, reliable on macOS where fs.watch is flaky
-    fs.watchFile(file.path, { interval: 1000 }, (curr, prev) => {
-      if (curr.size > sessionState.jsonlFileSize) {
-        console.log(`[Chat] JSONL change detected for ${sessionName}: ${sessionState.jsonlFileSize} → ${curr.size} (${sessionState.chatClients?.size || 0} clients)`)
-        broadcastJsonlUpdates(sessionName, sessionState)
+    const file = resolveJsonlPath(agent)
+    if (file) watchJsonlFile(file.path)
+
+    // Re-resolve the transcript path periodically: Claude Code starts a NEW
+    // .jsonl file on /clear or new conversations. The old watcher would keep
+    // watching the stale file forever and chat silently stopped updating.
+    // On rotation: unwatch old file, send full fresh history, watch new file.
+    sessionState.jsonlRotationTimer = setInterval(() => {
+      if (!sessionState.chatClients || sessionState.chatClients.size === 0) return
+      const current = resolveJsonlPath(agent)
+      if (!current || current.path === sessionState.jsonlFilePath) return
+
+      console.log(`[Chat] Conversation rotated for ${sessionName}: ${sessionState.jsonlFilePath} → ${current.path}`)
+      if (sessionState.jsonlFilePath) {
+        try { fs.unwatchFile(sessionState.jsonlFilePath) } catch { /* ignore */ }
       }
-      // Handle file truncation (new conversation started)
-      if (curr.size < sessionState.jsonlFileSize) {
-        sessionState.jsonlFileSize = 0
-        broadcastJsonlUpdates(sessionName, sessionState)
-      }
-    })
+      watchJsonlFile(current.path)
+
+      getChatHistory(sessionName, agentId).then((history) => {
+        const msg = JSON.stringify({ type: 'chat:history', data: history })
+        sessionState.chatClients.forEach(ws => {
+          if (ws.readyState === 1) { try { ws.send(msg) } catch { /* ignore */ } }
+        })
+      }).catch(() => { /* next tick will retry */ })
+    }, 10000)
+
     sessionState.jsonlWatcher = true
-    console.log(`[Chat] Started JSONL watcher for ${sessionName}: ${file.path}`)
 
     // Watch hook state file for real-time permission/status updates
-    const workingDir = agent.workingDirectory ||
-                       agent.sessions?.[0]?.workingDirectory ||
-                       agent.preferences?.defaultWorkingDirectory
+    const workingDir = getAgentWorkingDir(agent)
     if (workingDir) {
       sessionState._hookStateWorkingDir = workingDir
-      const cwdHash = crypto.createHash('md5').update(workingDir).digest('hex').substring(0, 16)
-      const hookStateFile = path.join(os.homedir(), '.aimaestro', 'chat-state', `${cwdHash}.json`)
+      const hookStateFile = hookStateFilePath(workingDir)
       sessionState._hookStateFile = hookStateFile
 
       // Use fs.watchFile (1s poll) instead of setInterval — same reliability as JSONL watcher
@@ -530,13 +460,21 @@ function cleanupSession(sessionName, sessionState, reason = 'unknown', ptyAlread
     killPtyProcess(sessionState.ptyProcess, sessionName, ptyAlreadyExited)
   }
 
-  // Stop JSONL file watcher
+  // Stop JSONL file watcher + rotation re-resolve timer
   if (sessionState.jsonlWatcher) {
     try {
       fs.unwatchFile(sessionState.jsonlFilePath)
     } catch { /* ignore */ }
     sessionState.jsonlWatcher = null
   }
+  if (sessionState.jsonlRotationTimer) {
+    clearInterval(sessionState.jsonlRotationTimer)
+    sessionState.jsonlRotationTimer = null
+  }
+
+  // Release the cerebellum ring buffer for this session (was a map-key leak:
+  // entries were only ever removed for __call voice sessions)
+  try { removeBuffer(sessionName) } catch { /* ignore */ }
 
   // Stop hook state file watcher
   if (sessionState._hookStateWatcher && sessionState._hookStateFile) {
@@ -1995,33 +1933,19 @@ async function startServer(handleRequest) {
       }
     }
 
+    // Helper: prepend custom-socket args for tmux invocations on this session
+    const tmuxArgs = (args) => (socketPath ? ['-S', socketPath, ...args] : args)
+
     // Disable tmux mouse mode per-session so xterm.js handles mouse natively.
     // Without this, ~/.tmux.conf "set -g mouse on" causes tmux to intercept
-    // click-drag (yellow copy-mode selection instead of browser clipboard) and
-    // wheel events (tmux copy-mode instead of app-native scrolling).
-    try {
-      const tmuxBase = socketPath ? `tmux -S "${socketPath}"` : 'tmux'
-      execSync(`${tmuxBase} set-option -t "${sessionName}" mouse off`, { timeout: 2000, stdio: 'pipe' })
-    } catch (e) {
-      console.warn(`[PTY] Failed to set mouse off for ${sessionName}:`, e.message)
-    }
-
-    // Capture FULL pane content (scrollback + visible area) with ANSI color codes.
-    // We send this as a single snapshot and intentionally DON'T add the client to the
-    // PTY broadcast set yet — the PTY's initial `tmux attach` redraw would duplicate
-    // the visible area. By delaying broadcast join, the redraw is discarded.
-    try {
-      const tmuxBase = socketPath ? `tmux -S "${socketPath}"` : 'tmux'
-      const paneContent = execSync(
-        `${tmuxBase} capture-pane -t "${sessionName}" -e -p -S -5000 2>/dev/null`,
-        { encoding: 'utf8', timeout: 3000 }
-      )
-      if (paneContent && paneContent.trim() && ws.readyState === 1) {
-        ws.send(paneContent.replace(/\n/g, '\r\n'))
-      }
-    } catch (e) {
-      // capture failed — client will get content once added to broadcast
-    }
+    // click-drag (yellow copy-mode selection instead of browser clipboard).
+    // Alt-screen wheel scrolling is handled via the 'tmux-scroll' control
+    // message below, which drives tmux copy-mode server-side.
+    // Async execFile: these used to be execSync and blocked the event loop —
+    // and therefore every other session's output — for up to 5s per connect.
+    execFile('tmux', tmuxArgs(['set-option', '-t', sessionName, 'mouse', 'off']), { timeout: 2000 }, (err) => {
+      if (err) console.warn(`[PTY] Failed to set mouse off for ${sessionName}:`, err.message)
+    })
 
     // Track connection as activity (so newly opened sessions show as active)
     trackSessionActivity(sessionName)
@@ -2034,15 +1958,31 @@ async function startServer(handleRequest) {
       sessionState.cleanupTimer = null
     }
 
-    // Add client to broadcast AFTER the PTY's initial redraw has passed (discarded).
-    // 150ms is enough for the tmux attach redraw to fire and be ignored.
-    // After this, the client receives all live PTY output going forward.
-    setTimeout(() => {
-      sessionState.clients.add(ws)
-      if (ws.readyState === 1) {
-        ws.send(JSON.stringify({ type: 'history-complete' }))
+    // Capture FULL pane content (scrollback + visible area) with ANSI color codes.
+    // We send this as a single snapshot and intentionally DON'T add the client to the
+    // PTY broadcast set yet — the PTY's initial `tmux attach` redraw would duplicate
+    // the visible area. By delaying broadcast join, the redraw is discarded.
+    execFile(
+      'tmux',
+      tmuxArgs(['capture-pane', '-t', sessionName, '-e', '-p', '-S', '-5000']),
+      { encoding: 'utf8', timeout: 3000, maxBuffer: 32 * 1024 * 1024 },
+      (err, paneContent) => {
+        if (err) {
+          console.warn(`[PTY] History capture failed for ${sessionName}:`, err.message)
+        } else if (paneContent && paneContent.trim() && ws.readyState === 1) {
+          try { ws.send(paneContent.replace(/\n/g, '\r\n')) } catch { /* client gone */ }
+        }
+        // Add client to broadcast AFTER the PTY's initial redraw has passed (discarded).
+        // 150ms is enough for the tmux attach redraw to fire and be ignored.
+        // After this, the client receives all live PTY output going forward.
+        setTimeout(() => {
+          sessionState.clients.add(ws)
+          if (ws.readyState === 1) {
+            ws.send(JSON.stringify({ type: 'history-complete' }))
+          }
+        }, 150)
       }
-    }, 150)
+    )
 
     // Handle client input
     ws.on('message', async (data) => {
@@ -2061,6 +2001,25 @@ async function startServer(handleRequest) {
 
           if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
             sessionState.ptyProcess.resize(parsed.cols, parsed.rows)
+            return
+          }
+
+          // Alt-screen scrollback: the client sends wheel deltas while the app
+          // is on the alternate screen (Claude Code, vim, less). xterm.js has no
+          // alt-screen scrollback — the real history lives in tmux. Enter
+          // copy-mode (-e = auto-exit when scrolled back to the bottom) and
+          // scroll there. Negative lines = up (into history).
+          if (parsed.type === 'tmux-scroll' && typeof parsed.lines === 'number' && parsed.lines !== 0) {
+            const n = String(Math.min(Math.abs(Math.trunc(parsed.lines)), 100))
+            if (parsed.lines < 0) {
+              execFile('tmux', tmuxArgs(['copy-mode', '-e', '-t', sessionName]), { timeout: 2000 }, () => {
+                execFile('tmux', tmuxArgs(['send-keys', '-t', sessionName, '-X', '-N', n, 'scroll-up']), { timeout: 2000 }, () => { /* ignore */ })
+              })
+            } else {
+              // scroll-down is only meaningful inside copy-mode; if the pane is
+              // already at the live view the command fails harmlessly.
+              execFile('tmux', tmuxArgs(['send-keys', '-t', sessionName, '-X', '-N', n, 'scroll-down']), { timeout: 2000 }, () => { /* ignore */ })
+            }
             return
           }
 

--- a/server.mjs
+++ b/server.mjs
@@ -1538,6 +1538,24 @@ async function startServer(handleRequest) {
     const env = { ...process.env }
     delete env.ANTHROPIC_API_KEY
 
+    // HEADLESS AUTH (macOS): a background server (pm2 daemon) cannot reach the
+    // macOS Keychain where the interactive `claude /login` stores subscription
+    // credentials — so a spawned claude reports "Not logged in". The reliable
+    // headless path is a long-lived token from `claude setup-token`, injected
+    // as CLAUDE_CODE_OAUTH_TOKEN. Read it from the env, or from a file the user
+    // drops at ~/.aimaestro/claude-oauth-token. (Same mechanism avogado-backend
+    // uses; on Linux the ~/.claude/.credentials.json file works without this.)
+    if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+      try {
+        const tokenFile = path.join(os.homedir(), '.aimaestro', 'claude-oauth-token')
+        if (fs.existsSync(tokenFile)) {
+          const t = fs.readFileSync(tokenFile, 'utf-8').trim()
+          if (t) env.CLAUDE_CODE_OAUTH_TOKEN = t
+        }
+      } catch { /* ignore */ }
+    }
+    const hasHeadlessToken = !!env.CLAUDE_CODE_OAUTH_TOKEN
+
     let proc
     try {
       proc = spawn('claude', [
@@ -1554,8 +1572,8 @@ async function startServer(handleRequest) {
       return
     }
 
-    console.log(`[StreamChat] Spawned claude (pid ${proc.pid}) in ${workingDir}`)
-    try { ws.send(JSON.stringify({ type: 'stream:ready', cwd: workingDir })) } catch {}
+    console.log(`[StreamChat] Spawned claude (pid ${proc.pid}) in ${workingDir} (headlessToken: ${hasHeadlessToken})`)
+    try { ws.send(JSON.stringify({ type: 'stream:ready', cwd: workingDir, hasToken: hasHeadlessToken })) } catch {}
 
     // Parse NDJSON from stdout, forward each event to the browser
     let buf = ''

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,6 @@
 import { createServer } from 'http'
 import { parse } from 'url'
-import { execSync, execFileSync, execFile } from 'child_process'
+import { execSync, execFileSync, execFile, spawn } from 'child_process'
 import { WebSocketServer } from 'ws'
 import WebSocket from 'ws'
 import pty from 'node-pty'
@@ -1512,10 +1512,113 @@ async function startServer(handleRequest) {
     })
   })
 
+  // ── Streaming chat PoC ────────────────────────────────────────────────
+  // Experimental: drives Claude Code in stream-json mode (NOT tmux). One
+  // persistent `claude` process per connection, in the agent's working dir,
+  // on the user's subscription. Send = JSON to stdin; receive = NDJSON events
+  // forwarded to the browser. Completely isolated from the /term path.
+  const streamChatWss = new WebSocketServer({ noServer: true })
+  streamChatWss.on('connection', async (ws, query) => {
+    let workingDir = null
+    try {
+      const { getAgent, getAgentByName } = await import('./lib/agent-registry.ts')
+      const agent = (query.agentId && getAgent(query.agentId)) ||
+        (query.name && getAgentByName(query.name))
+      workingDir = getAgentWorkingDir(agent)
+    } catch { /* fall through */ }
+
+    if (!workingDir) {
+      try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Agent has no working directory' })) } catch {}
+      ws.close(1008, 'no working directory')
+      return
+    }
+
+    // Subscription auth: never pass ANTHROPIC_API_KEY (it silently overrides
+    // the subscription and bills the API). Strip it defensively.
+    const env = { ...process.env }
+    delete env.ANTHROPIC_API_KEY
+
+    let proc
+    try {
+      proc = spawn('claude', [
+        '--input-format', 'stream-json',
+        '--output-format', 'stream-json',
+        '--verbose',
+        '--include-partial-messages',  // token-by-token text deltas
+        '-p',
+        '--permission-mode', 'acceptEdits',
+      ], { cwd: workingDir, env, stdio: ['pipe', 'pipe', 'pipe'] })
+    } catch (err) {
+      try { ws.send(JSON.stringify({ type: 'stream:error', error: 'Failed to launch claude: ' + err.message })) } catch {}
+      ws.close(1011, 'spawn failed')
+      return
+    }
+
+    console.log(`[StreamChat] Spawned claude (pid ${proc.pid}) in ${workingDir}`)
+    try { ws.send(JSON.stringify({ type: 'stream:ready', cwd: workingDir })) } catch {}
+
+    // Parse NDJSON from stdout, forward each event to the browser
+    let buf = ''
+    proc.stdout.on('data', (chunk) => {
+      buf += chunk.toString()
+      let nl
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim()
+        buf = buf.slice(nl + 1)
+        if (!line) continue
+        let event
+        try { event = JSON.parse(line) } catch { continue }
+        if (ws.readyState === 1) {
+          try { ws.send(JSON.stringify({ type: 'stream:event', event })) } catch {}
+        }
+      }
+    })
+    proc.stderr.on('data', (chunk) => {
+      const msg = chunk.toString().trim()
+      if (msg) console.warn(`[StreamChat pid ${proc.pid}] stderr: ${msg.slice(0, 200)}`)
+    })
+    proc.on('exit', (code, signal) => {
+      console.log(`[StreamChat] claude exited (pid ${proc.pid}, code ${code}, signal ${signal})`)
+      if (ws.readyState === 1) {
+        try { ws.send(JSON.stringify({ type: 'stream:exit', code, signal })) } catch {}
+      }
+    })
+
+    ws.on('message', (data) => {
+      let msg
+      try { msg = JSON.parse(data.toString()) } catch { return }
+      if (msg.type === 'ping') {
+        if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'pong' }))
+        return
+      }
+      if (msg.type === 'send' && typeof msg.text === 'string' && msg.text.trim()) {
+        // Write a stream-json user message to the persistent process's stdin
+        const userMsg = { type: 'user', message: { role: 'user', content: msg.text } }
+        try {
+          proc.stdin.write(JSON.stringify(userMsg) + '\n')
+        } catch (err) {
+          if (ws.readyState === 1) ws.send(JSON.stringify({ type: 'stream:error', error: 'Write to claude failed: ' + err.message }))
+        }
+      }
+    })
+
+    const cleanup = () => {
+      try { proc.stdin.end() } catch {}
+      try { proc.kill('SIGTERM') } catch {}
+      setTimeout(() => { try { proc.kill('SIGKILL') } catch {} }, 2000)
+    }
+    ws.on('close', () => { console.log(`[StreamChat] WS closed, killing pid ${proc.pid}`); cleanup() })
+    ws.on('error', () => cleanup())
+  })
+
   server.on('upgrade', (request, socket, head) => {
     const { pathname, query } = parse(request.url, true)
 
-    if (pathname === '/term') {
+    if (pathname === '/stream-chat') {
+      streamChatWss.handleUpgrade(request, socket, head, (ws) => {
+        streamChatWss.emit('connection', ws, query)
+      })
+    } else if (pathname === '/term') {
       wss.handleUpgrade(request, socket, head, (ws) => {
         wss.emit('connection', ws, request, query)
       })

--- a/server.mjs
+++ b/server.mjs
@@ -694,35 +694,27 @@ async function sendChatMessage(sessionName, message) {
   }
   try { fs.unlinkSync(tmpFile) } catch {}
 
-  // 5. Paste-probe: poll until text tail appears in pane
+  // 5. Paste-probe: best-effort wait for the text tail to appear in the pane.
+  // This is ADVISORY ONLY — the probe has false negatives (Claude Code's input
+  // box renders pasted text in ways capture-pane doesn't always match), so we
+  // must NOT gate submission on it. We wait up to the timeout to let the paste
+  // settle before Enter, then send Enter regardless. (A previous version failed
+  // the send on an unverified probe, which silently dropped messages that had
+  // actually pasted fine.)
   const probe = pasteTailProbe(message)
-  let verified = true
   if (probe) {
-    verified = false
     const probeRe = new RegExp(probe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')
     const baselineCount = (baseline.match(probeRe) || []).length
     const deadline = Date.now() + PASTE_PROBE_TIMEOUT_MS
     while (Date.now() < deadline) {
       const captured = capturePaneCompact(sessionName)
       const currentCount = (captured.match(probeRe) || []).length
-      if (currentCount > baselineCount) { verified = true; break }
+      if (currentCount > baselineCount) break
       await new Promise(r => setTimeout(r, PASTE_PROBE_INTERVAL_MS))
     }
   }
 
-  // 6. If the paste never appeared, DO NOT press Enter. Pressing it anyway
-  // (the old behavior) could submit a truncated message or confirm whatever
-  // dialog is actually on screen — silently. Clear the staged text (C-u
-  // deletes to line start in both Claude Code's input box and readline) so a
-  // retry doesn't double the text, and report failure so the client shows
-  // the pending bubble as failed with a Retry button.
-  if (!verified) {
-    try { execSync(`tmux send-keys -t "${sessionName}" C-u`, { timeout: 2000 }) } catch { /* best effort */ }
-    console.warn(`[Chat] Paste-probe failed for ${sessionName} — message NOT submitted`)
-    return { ok: false, error: 'Message could not be confirmed in the terminal — nothing was sent. The agent may be busy or showing a dialog; check the Terminal tab, then retry.' }
-  }
-
-  // 7. Send Enter (C-m is more reliable than Enter through tmux)
+  // 6. Send Enter (C-m is more reliable than Enter through tmux)
   try {
     execSync(`tmux send-keys -t "${sessionName}" C-m`, { timeout: 3000 })
   } catch (err) {

--- a/server.mjs
+++ b/server.mjs
@@ -316,6 +316,40 @@ function startJsonlWatcher(sessionName, sessionState, agentId) {
 }
 
 /**
+ * Detect a permission / choice menu directly from the tmux pane, as a fallback
+ * for when the Claude Code hook doesn't surface it (many prompts were never
+ * showing in chat because they relied solely on the hook). Parses the numbered
+ * menu into the same shape as hookState so the chat renders a card either way.
+ */
+function detectPermissionFromPane(sessionName) {
+  try {
+    const raw = execSync(`tmux capture-pane -p -t "${sessionName}" -S -30`,
+      { timeout: 2000, encoding: 'utf-8' })
+    const lines = raw.split('\n').map(l => l.replace(/\s+$/, ''))
+    const tail = lines.slice(-18)
+    const text = tail.join('\n')
+    const looksLikePrompt =
+      /do you want to proceed|do you want to|would you like|yes, and don'?t ask|esc to (cancel|interrupt)/i.test(text) ||
+      /❯\s*\d+\.\s/.test(text)
+    if (!looksLikePrompt) return null
+    // Extract numbered options, tolerating box-drawing borders Claude Code
+    // draws around the menu (e.g. "│ ❯ 1. Yes │", "│   2. No │").
+    const options = []
+    for (const l of tail) {
+      const m = l.match(/^[\s❯>▶*│┃|]*(\d+)\.\s+(.+?)\s*[│┃|]?\s*$/)
+      if (m) {
+        const label = m[2].replace(/[│┃|╮╯╰╭]/g, '').replace(/\s+/g, ' ').trim()
+        if (label) options.push({ key: m[1], label, value: /^no\b|decline|cancel/i.test(label) ? 'no' : 'yes' })
+      }
+    }
+    if (options.length === 0) return null
+    const qMatch = text.match(/((?:Do you want|Would you like)[^\n?]*\??)/i)
+    const question = qMatch ? qMatch[1].trim() : 'The agent is asking for permission'
+    return { status: 'permission_request', message: question, description: question, options, source: 'pane' }
+  } catch { return null }
+}
+
+/**
  * Read hookState and broadcast to chat clients if changed.
  * Extracted so it can be called from the file watcher AND from broadcastJsonlUpdates
  * (on tool_use messages that precede permission prompts).
@@ -324,7 +358,13 @@ function broadcastHookState(sessionName, sessionState) {
   if (!sessionState.chatClients || sessionState.chatClients.size === 0) return
   const workingDir = sessionState._hookStateWorkingDir
   if (!workingDir) return
-  const state = readHookState(workingDir)
+  let state = readHookState(workingDir)
+  // Fallback: if the hook didn't surface a permission prompt but the pane is
+  // clearly showing one, build a card from the pane so it ALWAYS shows in chat.
+  if (state?.status !== 'permission_request') {
+    const fromPane = detectPermissionFromPane(sessionName)
+    if (fromPane) state = fromPane
+  }
   // Remember permission_request states so we can serve them on history re-requests
   if (state?.status === 'permission_request') {
     sessionState._lastPermission = state
@@ -743,6 +783,37 @@ async function sendChatMessage(sessionName, message) {
     return { ok: false, error: 'Text pasted but Enter failed: ' + err.message }
   }
 
+  return { ok: true }
+}
+
+/**
+ * Answer a permission / choice menu (a single key like "1", "2", "3", "y").
+ *
+ * This is DIFFERENT from sendChatMessage on purpose:
+ *  - It does NOT refuse when a prompt is pending — it IS the answer to the
+ *    prompt (sendChatMessage's guard was silently swallowing button clicks).
+ *  - It sends the RAW KEYSTROKE via send-keys, not a paste-buffer line. A
+ *    Claude Code menu selects on the keypress of the digit; pasting "1\n" does
+ *    not reliably select option 1.
+ * A multi-character answer (typed feedback) falls back to sendChatMessage.
+ */
+async function sendPermissionResponse(sessionName, key) {
+  const k = String(key ?? '').trim()
+  if (!/^[0-9a-z]$/i.test(k)) {
+    // Not a single menu key — treat as typed feedback via the normal path.
+    return sendChatMessage(sessionName, key)
+  }
+  exitCopyMode(sessionName)
+  try {
+    // Raw keypress — what a human presses at the menu. Number selects+confirms.
+    execSync(`tmux send-keys -t "${sessionName}" -l "${k}"`, { timeout: 3000 })
+  } catch (err) {
+    return { ok: false, error: 'Failed to send response: ' + err.message }
+  }
+  // The prompt is answered — clear the remembered permission so normal sends
+  // (and the sticky card) release.
+  const sessionState = terminalSessions.get(sessionName)
+  if (sessionState) sessionState._lastPermission = null
   return { ok: true }
 }
 
@@ -1701,6 +1772,19 @@ async function startServer(handleRequest) {
               }
             }
             startJsonlWatcher(sessionName, sessionState, parsed.agentId)
+          } else if (parsed.type === 'chat:permissionResponse') {
+            // Answer a pending permission/choice menu with a raw keystroke.
+            // Bypasses the send guard (this IS the answer) and clears the card.
+            if (parsed.key != null) {
+              const result = await sendPermissionResponse(sessionName, parsed.key)
+              if (ws.readyState === 1) {
+                if (result.ok) ws.send(JSON.stringify({ type: 'chat:permissionAnswered', key: parsed.key }))
+                else ws.send(JSON.stringify({ type: 'chat:error', error: result.error }))
+              }
+              for (const delay of [400, 1000, 2000, 4000, 8000]) {
+                setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), delay)
+              }
+            }
           } else if (parsed.type === 'chat:send') {
             if (parsed.message) {
               const result = await sendChatMessage(sessionName, parsed.message)
@@ -2185,6 +2269,20 @@ async function startServer(handleRequest) {
             }
             // Start JSONL file watcher for this session if not already watching
             startJsonlWatcher(sessionName, sessionState, parsed.agentId)
+            return
+          }
+
+          if (parsed.type === 'chat:permissionResponse') {
+            if (parsed.key != null) {
+              const result = await sendPermissionResponse(sessionName, parsed.key)
+              if (ws.readyState === 1) {
+                if (result.ok) ws.send(JSON.stringify({ type: 'chat:permissionAnswered', key: parsed.key }))
+                else ws.send(JSON.stringify({ type: 'chat:error', error: result.error }))
+              }
+              for (const delay of [400, 1000, 2000, 4000, 8000]) {
+                setTimeout(() => broadcastJsonlUpdates(sessionName, sessionState), delay)
+              }
+            }
             return
           }
 

--- a/server.mjs
+++ b/server.mjs
@@ -666,7 +666,25 @@ function isAgentAtPermissionPrompt(sessionName) {
   } catch { return false }
 }
 
+/** Exit tmux copy-mode if the pane is in it. The terminal scroll feature
+ *  (tmux-scroll → copy-mode) can leave a pane in copy-mode; while there,
+ *  paste-buffer shows text but Enter (C-m) is consumed by copy-mode instead
+ *  of submitting to the program. Safe to call when not in copy-mode. */
+function exitCopyMode(sessionName) {
+  try {
+    const inMode = execSync(`tmux display-message -p -t "${sessionName}" '#{pane_in_mode}'`,
+      { timeout: 2000, encoding: 'utf-8' }).trim()
+    if (inMode === '1') {
+      execSync(`tmux send-keys -t "${sessionName}" -X cancel`, { timeout: 2000 })
+    }
+  } catch { /* best effort */ }
+}
+
 async function sendChatMessage(sessionName, message) {
+  // 0. Ensure the pane isn't in copy-mode (scrolling leaves it there) — else
+  // the paste shows but Enter never submits.
+  exitCopyMode(sessionName)
+
   // 1. Check hookState first (fast path)
   const sessionState = terminalSessions.get(sessionName)
   if (sessionState?._lastPermission?.status === 'permission_request') {

--- a/services/agents-chat-service.ts
+++ b/services/agents-chat-service.ts
@@ -14,16 +14,10 @@ import {
   wrapAsBracketedPaste,
 } from '@/lib/meeting-inject-queue'
 import * as fs from 'fs'
-import * as path from 'path'
-import * as crypto from 'crypto'
-import os from 'os'
 import { type ServiceResult, notFound, invalidRequest, missingField } from '@/services/service-errors'
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-function hashCwd(cwd: string): string {
-  return crypto.createHash('md5').update(cwd || '').digest('hex').substring(0, 16)
-}
+// Shared transcript logic — single source of truth with server.mjs (do not fork;
+// the underscore path-encoding bug had to be fixed in 3 copies once already)
+import { resolveJsonlPathForDir, parseJsonlLines, readHookState } from '@/lib/chat-transcript.mjs'
 
 // ── Public Functions ────────────────────────────────────────────────────────
 
@@ -49,127 +43,36 @@ export async function getConversationMessages(
     return invalidRequest('Agent has no working directory configured')
   }
 
-  // Find the Claude conversation directory for this project
-  const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects')
-  const projectDirName = workingDir.replace(/[/_]/g, '-')
-  const conversationDir = path.join(claudeProjectsDir, projectDirName)
-
-  if (!fs.existsSync(conversationDir)) {
+  // Find the current conversation JSONL (shared logic with server.mjs)
+  const currentConversation = resolveJsonlPathForDir(workingDir)
+  if (!currentConversation) {
     return {
       data: {
         success: true,
         messages: [],
         conversationFile: null,
-        message: 'No conversation directory found for this project'
+        message: 'No conversation found for this project'
       },
       status: 200
     }
   }
-
-  // Find the most recently modified .jsonl file
-  const files = fs.readdirSync(conversationDir)
-    .filter(f => f.endsWith('.jsonl'))
-    .map(f => ({
-      name: f,
-      path: path.join(conversationDir, f),
-      mtime: fs.statSync(path.join(conversationDir, f)).mtime
-    }))
-    .sort((a, b) => b.mtime.getTime() - a.mtime.getTime())
-
-  if (files.length === 0) {
-    return {
-      data: {
-        success: true,
-        messages: [],
-        conversationFile: null,
-        message: 'No conversation files found'
-      },
-      status: 200
-    }
-  }
-
-  const currentConversation = files[0]
 
   // Read and parse the JSONL file
   const fileContent = fs.readFileSync(currentConversation.path, 'utf-8')
-  const lines = fileContent.split('\n').filter(line => line.trim())
+  const lines = fileContent.split('\n')
 
-  const sinceTime = since ? new Date(since).getTime() : 0
-  const messages: any[] = []
-
-  for (const line of lines) {
-    try {
-      const message = JSON.parse(line)
-
-      if (since && message.timestamp) {
-        const msgTime = new Date(message.timestamp).getTime()
-        if (msgTime <= sinceTime) continue
-      }
-
-      // Skip tool-result user messages (invisible in chat, waste message budget)
-      if (message.type === 'user' && message.toolUseResult) continue
-
-      // Convert compact_boundary system messages to summary type
-      if (message.type === 'system' &&
-          (message.subtype === 'compact_boundary' || message.subtype === 'microcompact_boundary')) {
-        messages.push({
-          type: 'summary',
-          summary: message.content || 'Conversation compacted',
-          timestamp: message.timestamp,
-          uuid: message.uuid,
-        })
-        continue
-      }
-
-      // Extract thinking blocks from assistant messages
-      if (message.type === 'assistant' && message.message?.content) {
-        const content = message.message.content
-        if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block.type === 'thinking' && block.thinking) {
-              messages.push({
-                type: 'thinking',
-                thinking: block.thinking,
-                timestamp: message.timestamp,
-                uuid: message.uuid
-              })
-            }
-          }
-        }
-      }
-
-      messages.push(message)
-    } catch {
-      // Skip malformed lines
-    }
+  let messages: any[] = parseJsonlLines(lines, Number.MAX_SAFE_INTEGER)
+  if (since) {
+    const sinceTime = new Date(since).getTime()
+    messages = messages.filter(m =>
+      !m.timestamp || new Date(m.timestamp).getTime() > sinceTime
+    )
   }
 
   const limitedMessages = messages.slice(-limit)
 
-  // Read hook state file
-  let hookState: any = null
-  if (workingDir) {
-    const stateDir = path.join(os.homedir(), '.aimaestro', 'chat-state')
-    const cwdHash = hashCwd(workingDir)
-    const stateFile = path.join(stateDir, `${cwdHash}.json`)
-
-    try {
-      if (fs.existsSync(stateFile)) {
-        const stateContent = fs.readFileSync(stateFile, 'utf-8')
-        hookState = JSON.parse(stateContent)
-
-        const isWaitingState = hookState.status === 'waiting_for_input' || hookState.status === 'permission_request'
-        if (!isWaitingState) {
-          const stateAge = Date.now() - new Date(hookState.updatedAt).getTime()
-          if (stateAge > 60000) {
-            hookState = null
-          }
-        }
-      }
-    } catch {
-      // Ignore state read errors
-    }
-  }
+  // Read hook state file (shared logic with server.mjs)
+  const hookState: any = readHookState(workingDir)
 
   // Capture tmux to detect prompts waiting for input
   let terminalPrompt: string | null = null

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -1840,6 +1840,18 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
             const cliMode = PERMISSION_MODE_TO_CLI[effectiveMode]
             fullCommand = `${fullCommand} --permission-mode ${cliMode}`
           }
+
+          // Force the inline renderer so terminal SCROLLBACK works. Claude Code's
+          // fullscreen/alternate-screen renderer (rolled out as default across
+          // 2.1.11x→2.1.20x) keeps ZERO tmux history — the pane shows
+          // alternate_on=1, history_size=0, so there is nothing to scroll and
+          // capture-pane returns one screenful. Setting this env var returns
+          // Claude's output to the normal buffer, restoring scrollback in the
+          // web terminal. (Escape hatch: AIMAESTRO_KEEP_ALT_SCREEN=true keeps
+          // fullscreen for users who don't need scroll.)
+          if (process.env.AIMAESTRO_KEEP_ALT_SCREEN !== 'true') {
+            fullCommand = `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 ${fullCommand}`
+          }
         }
 
         // Small delay to let the session initialize

--- a/services/plugin-builder-service.ts
+++ b/services/plugin-builder-service.ts
@@ -17,7 +17,7 @@ import path from 'path'
 import os from 'os'
 import { execFile } from 'child_process'
 import { randomUUID } from 'crypto'
-import matter from 'gray-matter'
+import { safeMatter } from '@/lib/safe-matter'
 import { type ServiceResult, missingField, notFound, invalidField, invalidRequest, operationFailed } from '@/services/service-errors'
 import type {
   PluginBuildConfig,
@@ -630,7 +630,7 @@ async function findSkillsInDir(dir: string): Promise<RepoSkillInfo[]> {
         const fullPath = path.join(currentDir, entry.name)
         if (entry.isFile() && entry.name === 'SKILL.md') {
           const content = await fs.readFile(fullPath, 'utf-8')
-          const parsed = matter(content)
+          const parsed = safeMatter(content)
           const frontmatter = parsed.data as Record<string, unknown>
           const skillFolder = path.basename(path.dirname(fullPath))
           const relativePath = path.relative(dir, path.dirname(fullPath))

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.4",
+  "version": "0.36.5",
   "releaseDate": "2026-07-09",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.60",
+  "version": "0.35.61",
   "releaseDate": "2026-07-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.63",
-  "releaseDate": "2026-07-07",
+  "version": "0.35.64",
+  "releaseDate": "2026-07-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.2",
+  "version": "0.36.3",
   "releaseDate": "2026-07-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.0",
+  "version": "0.36.1",
   "releaseDate": "2026-07-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.55",
+  "version": "0.35.56",
   "releaseDate": "2026-07-05",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.62",
+  "version": "0.35.63",
   "releaseDate": "2026-07-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.1",
+  "version": "0.36.2",
   "releaseDate": "2026-07-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.59",
-  "releaseDate": "2026-07-06",
+  "version": "0.35.60",
+  "releaseDate": "2026-07-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.8",
+  "version": "0.36.9",
   "releaseDate": "2026-07-24",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.3",
-  "releaseDate": "2026-07-08",
+  "version": "0.36.4",
+  "releaseDate": "2026-07-09",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.61",
+  "version": "0.35.62",
   "releaseDate": "2026-07-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.9",
+  "version": "0.36.10",
   "releaseDate": "2026-07-24",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.6",
-  "releaseDate": "2026-07-16",
+  "version": "0.36.7",
+  "releaseDate": "2026-07-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.54",
-  "releaseDate": "2026-06-05",
+  "version": "0.35.55",
+  "releaseDate": "2026-07-05",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.56",
+  "version": "0.35.57",
   "releaseDate": "2026-07-05",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.64",
+  "version": "0.36.0",
   "releaseDate": "2026-07-08",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.7",
-  "releaseDate": "2026-07-20",
+  "version": "0.36.8",
+  "releaseDate": "2026-07-24",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.35.57",
-  "releaseDate": "2026-07-05",
+  "version": "0.35.58",
+  "releaseDate": "2026-07-06",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.5",
-  "releaseDate": "2026-07-09",
+  "version": "0.36.6",
+  "releaseDate": "2026-07-16",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.58",
+  "version": "0.35.59",
   "releaseDate": "2026-07-06",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,60 @@
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.205.tgz#ac8883cae4e8275273a1e74ef6a35a4fe7e8808c"
+  integrity sha512-lrfJ4eVtzfPkCpbSkBOGSMQCBbvmW6nbPzgHE4IwMN3scZlpuFMUFqh2aaJa/X2SAcWD9H2S0t2WWvSRgM7BjA==
+
+"@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.205.tgz#04f1ff12d41f1a8685f83dc99e91ab99a194d910"
+  integrity sha512-G6ETPmL5mNzJ2DFsWxG3jmsmrXgZX1N2ZCJvxaGUUpjTsKZJ4Tup1cWYvcd/m7o5fYZmx9REmgzTwsAIc1fdPQ==
+
+"@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.205.tgz#1df6175bf43731ba97df695fbb13cb952a474b8a"
+  integrity sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ==
+
+"@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.205.tgz#cbd21a8bb45d9f915c18d3876e51814fddf4c8ce"
+  integrity sha512-CXzySK3PV3EizCRPXnxPqeaAtgrBFDnMFOVpMe36oC3U16yDb1b1tAJGqZi/7uFrVvAiaXvnSFxhUWnDDSaO+A==
+
+"@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.205.tgz#e4b747f4589ea8198217fe76082ad4c9c6eec0de"
+  integrity sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg==
+
+"@anthropic-ai/claude-agent-sdk-linux-x64@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.205.tgz#b743bb7f3e322e716f7b99bf001c2ad2dcd5bbfd"
+  integrity sha512-siS+1iNqBSlGFZZvJY6+mhzZ/6/ec/TbX9GMuwmTF0E6fxGhIIp797jJxR1q8r6FAq7d39mEoRNhC0Ffo60uNQ==
+
+"@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.205.tgz#efac3120a369addeb3f04b6f28e96008864a5c63"
+  integrity sha512-SpP5zF68weFez/6pKrGzq/UVAJDMDNphWqmkLfOpWTDBL5xy6XlIZw5Bl4EXoVnfi2VLFkwuffNeFe+9SdX7kw==
+
+"@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.205.tgz#2a63a88df50108fd39d0e852e9104129f664dd7f"
+  integrity sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg==
+
+"@anthropic-ai/claude-agent-sdk@0.3.205":
+  version "0.3.205"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.205.tgz#4913398010ca3f6852a0f9e01addc84d7110489e"
+  integrity sha512-ft6iBw9kXudsusiXNpeybIPBJ07Z3tqp1ROSg5cEJqgA+9i+JJj2sRfQth+QD+lyenbbAU8yPieLxIimvfBhtw==
+  optionalDependencies:
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-darwin-x64" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-linux-arm64" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-linux-x64" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-win32-arm64" "0.3.205"
+    "@anthropic-ai/claude-agent-sdk-win32-x64" "0.3.205"
+
 "@anthropic-ai/sdk@^0.82.0":
   version "0.82.0"
   resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.82.0.tgz#68e993d75bdf03a8d8b6c2896464bf460d735fbf"


### PR DESCRIPTION
Consolidated UX/reliability work on the terminal and chat experiences, plus a new streaming execution mode and a security fix. Version **0.36.10**.

## Highlights

### 🔒 Security
- **RCE via gray-matter JS frontmatter (GHSA-g7qj-fhxp-6chc)** — untrusted `SKILL.md` parsing could execute arbitrary code via the unauthenticated `scan-repo` endpoint. Fixed with `lib/safe-matter.ts` (engines that throw). Reported by tonghuaroot.

### ✅ Chat permission reliability (the main fix)
Tool-permission prompts often didn't appear in chat, and clicking a button never reached the agent — forcing users to bounce between chat and terminal. Root causes, all fixed:
- Permission responses were **blocked by the permission guard** (the answer to the prompt was refused *because* of the prompt) and pasted as text instead of a keystroke → new raw-keystroke `chat:permissionResponse` path.
- The **session was destroyed under an open chat** (cleanup counted only terminal clients) → cleanup now requires both terminal and chat clients gone; added a 2.5s permission poll.
- Prompts **buried under output** were missed → structure-anchored `detectPermissionFromPane` over a 45-line region (no false positives on prose/working states).
- Applies to desktop, mobile, and tablet chat. Streaming uses the SDK `canUseTool` path (unaffected).

### 🖥️ Terminal scrollback
- Claude Code's fullscreen (alt-screen) renderer, now default, kept zero tmux history → agents launch with `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`, restoring scrollback (escape hatch `AIMAESTRO_KEEP_ALT_SCREEN=true`).

### ⚡ Streaming execution mode (new, opt-in)
- Per-agent Agent-SDK `stream-json` runtime: structured streaming chat, permission cards (`canUseTool`), session resume, persistent sessions. Chosen at wake (Terminal | Streaming). Additive — terminal agents untouched.

### 🧹 Terminal + chat UX phase 0
- Message wrapping, send reliability, scroll-stick, reconnect fixes, unified paste, opt-in copy-on-select, idle-heartbeat false-positive fix, consolidated transcript logic.

See `CHANGELOG.md` for the full per-area breakdown.

## Verification
- `yarn test` — 792 passing
- `yarn build` — clean
- Permission flow verified live against a running agent (card rendered, click proceeded the agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)