### PR TITLE
feat(amp): reliable notification delivery — Stop-hook block + streaming push (v0.36.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.11] - 2026-07-30 — Reliable AMP message delivery (Stop-hook + streaming push)
+
+### Fixed
+- **AMP notifications now reach agents without manual "check your inbox"** — The single most common daily annoyance: a message would arrive, but the agent wouldn't act on it until the operator manually typed "check your inbox." Root cause: inbox delivery relied on injecting `additionalContext` at the `idle_prompt` notification, which **cannot start a turn on an already-idle agent** — so the nudge sat there unseen. Two fixes:
+  - *Terminal agents — Stop-hook block delivery* (`plugin` submodule, `ai-maestro-hook.cjs`): the Stop hook now returns `{ decision: "block", reason }` when genuinely-new unread messages exist, forcing the agent to read and respond via the agent-messaging skill **before** it goes idle. Loop-safe: honors `stop_hook_active` (never blocks twice in a row) and dedups on message IDs in a per-cwd store so each message nudges exactly once. Claude-only (`decision:block` is a Claude Code capability); codex/gemini fall through to idle state as before. This is the reliable path — it fires at a clean turn boundary, not mid-render.
+  - *Streaming agents — direct SDK push* (`lib/message-delivery.ts`, `lib/streaming-bridge.mjs`): streaming (Agent SDK) agents have no tmux pane to notify, so an AMP message routed to a streaming agent is now pushed straight into the live SDK input stream via `session.push()`. Reliable regardless of TUI state. The streaming-runtime session map is now backed by `globalThis` so the Next delivery layer and the raw-ESM server share one map (same pattern as `shared-state-bridge`).
+
+### Notes
+- The idle unattended-tmux fallback (two-call `send-keys`: text, 150 ms pause, then Enter) was already in place (`notification-service.ts`) and is unchanged.
+- Scheduling: AI Maestro already ships its own cron scheduler (`lib/schedule-registry.ts` + `lib/schedule-executor.ts`, standard cron expressions, per-agent prompt on a cadence, full REST API). It is **not** wired to Anthropic's cloud "Routines" or the local `cron_*` tools — those remain a separate, future integration. No UI yet.
+
 ## [0.36.6] – [0.36.10] - 2026-07-24 — Permission reliability, terminal scrollback, security
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.36.11] - 2026-07-30 — Reliable AMP message delivery (Stop-hook + streaming push)
+## [0.36.11] – [0.36.12] - 2026-07-30 — Reliable AMP message delivery (Stop-hook + streaming push)
+
+### Tests & hardening [0.36.12]
+- Extracted the Stop-hook delivery decision into a pure `decideStopDelivery()` (+ `filterFreshMessages`, `buildAmpBlockReason`) so the core logic is unit-testable without stdin/fetch plumbing; guarded `main()` behind `require.main === module`. Added `tests/ai-maestro-hook.test.ts` (loop guard, claude-only gate, dedup, urgent formatting, 10-message cap) and `tests/streaming-bridge.test.ts` (push into live session, skip closed/exited, error-swallow). Suite: 812 passing.
+- Fixed `scripts/bump-version.sh`: the `package.json` update keyed on the *previous* version string, so once `package.json` drifted it was silently skipped on every bump (it had sat at 0.29.16 for many releases). Now sets the root version via `node` regardless of prior value — never touches dependency versions.
+
 
 ### Fixed
 - **AMP notifications now reach agents without manual "check your inbox"** — The single most common daily annoyance: a message would arrive, but the agent wouldn't act on it until the operator manually typed "check your inbox." Root cause: inbox delivery relied on injecting `additionalContext` at the `idle_prompt` notification, which **cannot start a turn on an already-idle agent** — so the nudge sat there unseen. Two fixes:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.10-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.11-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/message-delivery.ts
+++ b/lib/message-delivery.ts
@@ -15,6 +15,7 @@ import { writeToAMPInbox } from '@/lib/amp-inbox-writer'
 import { notifyAgent } from '@/lib/notification-service'
 import { applyContentSecurity } from '@/lib/content-security'
 import { deliverViaWebSocket, isAgentConnectedViaWS } from '@/lib/amp-websocket'
+import { pushToStreamSession } from '@/lib/streaming-bridge.mjs'
 import { getAgent } from '@/lib/agent-registry'
 import type { AMPEnvelope, AMPPayload } from '@/lib/types/amp'
 
@@ -80,6 +81,24 @@ export async function deliver(input: DeliveryInput): Promise<DeliveryResult> {
     if (wsOk) {
       console.log(`[Delivery] Also pushed ${envelope.id} via WebSocket to ${recipientAddress}`)
     }
+  }
+
+  // 1d. Push into a live streaming (Agent SDK) session, if the recipient runs
+  // in streaming mode. Streaming agents have no tmux pane to notify, so this is
+  // their delivery channel — the message lands directly in the SDK input stream
+  // and wakes the agent reliably regardless of TUI state. Non-fatal.
+  try {
+    const sender = senderHost && senderHost !== 'local' ? `${senderName}@${senderHost}` : senderName
+    const body = (securedEnvelopePayload.message || '').toString().slice(0, 2000)
+    const streamText =
+      `[AMP] New message from ${sender}${subject ? ` — "${subject}"` : ''}:\n` +
+      `${body}\n\n` +
+      `(Reply using the agent-messaging skill, then continue.)`
+    if (pushToStreamSession(recipientAgentId, streamText)) {
+      console.log(`[Delivery] Pushed ${envelope.id} into streaming session for ${recipientAgentName}`)
+    }
+  } catch (err) {
+    console.warn('[Delivery] Streaming push failed (non-fatal):', err)
   }
 
   // 2. Send tmux notification (non-fatal)

--- a/lib/streaming-bridge.mjs
+++ b/lib/streaming-bridge.mjs
@@ -1,0 +1,47 @@
+/**
+ * Streaming Bridge — cross-module accessor for live SDK sessions.
+ *
+ * lib/streaming-runtime.mjs (raw ESM, imported by server.mjs) owns the actual
+ * Session objects and stores them on `globalThis._streamSessions`. This bridge
+ * is a thin reader that the Next-bundled service/delivery layer imports WITHOUT
+ * pulling in the Claude Agent SDK. It exists so AMP delivery can push a message
+ * into a streaming agent's live session even though the two module graphs
+ * (raw-ESM server vs. webpack-bundled Next) never share instances directly.
+ *
+ * Mirrors the shared-state-bridge.mjs pattern.
+ */
+
+/** @returns the shared agentKey -> Session map (or an empty map if none yet). */
+function sessionMap() {
+  return globalThis._streamSessions || null
+}
+
+/**
+ * Push a synthetic user turn into an agent's live streaming session, if one
+ * exists. Returns true if a session was found and the text was queued.
+ *
+ * Used by the AMP delivery layer to wake a streaming agent the same way a tmux
+ * notification wakes a terminal agent — except this lands directly in the SDK
+ * input stream, so it is reliable regardless of the agent's TUI state.
+ */
+export function pushToStreamSession(agentKey, text) {
+  if (!agentKey || !text) return false
+  const map = sessionMap()
+  if (!map) return false
+  const session = map.get(String(agentKey))
+  if (!session || session.closed || session.exited) return false
+  try {
+    session.push(text)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** True if the agent currently has a live (non-closed) streaming session. */
+export function hasStreamSession(agentKey) {
+  const map = sessionMap()
+  if (!map || !agentKey) return false
+  const s = map.get(String(agentKey))
+  return !!(s && !s.closed && !s.exited)
+}

--- a/lib/streaming-runtime.mjs
+++ b/lib/streaming-runtime.mjs
@@ -23,7 +23,12 @@ const BUFFER_MAX = 5000          // cap buffered events (older drop)
 const PERMISSION_TIMEOUT_MS = 5 * 60 * 1000  // auto-deny a permission after 5 min unanswered
 
 // agentKey -> Session
-const sessions = new Map()
+// Backed by globalThis so the raw-ESM copy imported by server.mjs and the
+// Next-bundled copy imported by the delivery/service layer share ONE map
+// (same pattern as shared-state-bridge.mjs). Without this, an AMP message
+// routed through a Next API route could never find the live SDK session that
+// server.mjs created. See lib/streaming-bridge.mjs for the reader side.
+const sessions = globalThis._streamSessions || (globalThis._streamSessions = new Map())
 
 /** Build a clean env for the SDK subprocess: subscription token, never an API
  *  key. Reads the headless token (macOS daemons can't reach the Keychain). */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.11",
+  "version": "0.36.12",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.29.16",
+  "version": "0.36.11",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -121,11 +121,17 @@ _sed_inplace "$VERSION_FILE" "s|\"releaseDate\": \"[^\"]*\"|\"releaseDate\": \"$
 echo -e "  ${GREEN}✓${NC} version.json"
 FILES_UPDATED=$((FILES_UPDATED + 1))
 
-# 2. package.json
-update_file "$PROJECT_ROOT/package.json" \
-    "\"version\": \"$CURRENT_VERSION\"" \
-    "\"version\": \"$NEW_VERSION\"" \
-    "package.json"
+# 2. package.json — set the ROOT version regardless of its prior value.
+# (The old string-match approach keyed on CURRENT_VERSION, so once package.json
+# drifted from version.json it was silently skipped on every subsequent bump —
+# it sat at 0.29.16 for many releases. node preserves structure + only touches
+# the top-level version field, never dependency versions.)
+if [ -f "$PROJECT_ROOT/package.json" ]; then
+    node -e "const f=process.argv[1];const fs=require('fs');const p=JSON.parse(fs.readFileSync(f,'utf8'));p.version=process.argv[2];fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n');" \
+        "$PROJECT_ROOT/package.json" "$NEW_VERSION"
+    echo -e "  ${GREEN}✓${NC} package.json"
+    FILES_UPDATED=$((FILES_UPDATED + 1))
+fi
 
 # 3. remote-install.sh
 update_file "$PROJECT_ROOT/scripts/remote-install.sh" \

--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -378,6 +378,27 @@ function buildAmpBlockReason(messages) {
     ].filter(Boolean).join('\n');
 }
 
+// Drop messages we've already surfaced (dedup) and those lacking an id.
+function filterFreshMessages(messages, alreadyIds) {
+    const already = new Set(alreadyIds || []);
+    return (messages || []).filter(m => m && m.id && !already.has(m.id));
+}
+
+// Pure Stop-hook decision — no I/O, unit-testable. Returns:
+//   { block: false, freshIds: [] }                        → let the agent go idle
+//   { block: true, response: {...}, freshIds: [...] }     → force a continuation
+function decideStopDelivery({ agent, stopHookActive, messages, alreadyIds }) {
+    // decision:block is a Claude Code capability; never loop (stop_hook_active).
+    if (agent !== 'claude' || stopHookActive) return { block: false, freshIds: [] };
+    const fresh = filterFreshMessages(messages, alreadyIds);
+    if (fresh.length === 0) return { block: false, freshIds: [] };
+    return {
+        block: true,
+        response: { decision: 'block', reason: buildAmpBlockReason(fresh) },
+        freshIds: fresh.map(m => m.id),
+    };
+}
+
 // Main
 async function main() {
     const input = await readStdin();
@@ -580,15 +601,18 @@ async function main() {
             if (agent === 'claude' && !input.stop_hook_active) {
                 try {
                     const unread = await fetchUnreadMessages(cwd);
-                    if (unread && unread.messages.length > 0) {
-                        const already = new Set(loadNotifiedIds(cwd));
-                        const fresh = unread.messages.filter(m => m.id && !already.has(m.id));
-                        if (fresh.length > 0) {
-                            saveNotifiedIds(cwd, [...already, ...fresh.map(m => m.id)]);
-                            debugLog({ event: 'stop_block_delivery', cwd, count: fresh.length });
-                            hookResponse = { decision: 'block', reason: buildAmpBlockReason(fresh) };
-                            blocked = true;
-                        }
+                    const alreadyIds = loadNotifiedIds(cwd);
+                    const decision = decideStopDelivery({
+                        agent,
+                        stopHookActive: input.stop_hook_active,
+                        messages: unread ? unread.messages : [],
+                        alreadyIds,
+                    });
+                    if (decision.block) {
+                        saveNotifiedIds(cwd, [...alreadyIds, ...decision.freshIds]);
+                        debugLog({ event: 'stop_block_delivery', cwd, count: decision.freshIds.length });
+                        hookResponse = decision.response;
+                        blocked = true;
                     }
                 } catch (err) {
                     debugLog({ event: 'stop_block_check_failed', error: err.message });
@@ -655,7 +679,18 @@ async function main() {
     process.exit(0);
 }
 
-main().catch(err => {
-    console.error('[ai-maestro-hook] Error:', err);
-    process.exit(0); // Don't block Claude
-});
+// Only run when invoked directly (node ai-maestro-hook.cjs). When require()'d
+// by the test suite, export the pure decision helpers instead of executing.
+if (require.main === module) {
+    main().catch(err => {
+        console.error('[ai-maestro-hook] Error:', err);
+        process.exit(0); // Don't block Claude
+    });
+}
+
+module.exports = {
+    buildAmpBlockReason,
+    filterFreshMessages,
+    decideStopDelivery,
+    formatMessageSender,
+};

--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -316,6 +316,68 @@ async function drainMeetingInjectQueue(cwd) {
     }
 }
 
+// ── Stop-hook AMP delivery ──────────────────────────────────────────────────
+// Fetch raw unread messages (with IDs) for dedup on the Stop-hook block path.
+// Returns { agentId, messages } or null.
+async function fetchUnreadMessages(cwd) {
+    const agentsResponse = await fetch('http://localhost:23000/api/agents', { signal: AbortSignal.timeout(2500) });
+    if (!agentsResponse.ok) return null;
+    const agentsData = await agentsResponse.json();
+    const agent = resolveAgent(cwd, agentsData.agents || []);
+    if (!agent) { debugLog({ event: 'no_agent_for_cwd', cwd }); return null; }
+
+    const messagesResponse = await fetch(
+        `http://localhost:23000/api/messages?agent=${encodeURIComponent(agent.id)}&box=inbox&status=unread`,
+        { signal: AbortSignal.timeout(2500) }
+    );
+    if (!messagesResponse.ok) return null;
+    const messagesData = await messagesResponse.json();
+    const messages = messagesData.messages || [];
+    if (messages.length === 0) return null;
+    return { agentId: agent.id, messages };
+}
+
+function formatMessageSender(msg) {
+    const name = msg.fromAlias || (msg.from ? msg.from.substring(0, 8) : 'unknown');
+    const host = msg.fromHost ? ` (${msg.fromHost})` : '';
+    return `${name}${host}`;
+}
+
+// Per-cwd dedup so each message triggers the Stop-hook block exactly once.
+function notifiedIdsFile(cwd) {
+    return path.join(os.homedir(), '.aimaestro', 'chat-state', `${hashCwd(cwd)}.notified.json`);
+}
+function loadNotifiedIds(cwd) {
+    try { const a = JSON.parse(fs.readFileSync(notifiedIdsFile(cwd), 'utf8')); return Array.isArray(a) ? a : []; }
+    catch (e) { return []; }
+}
+function saveNotifiedIds(cwd, ids) {
+    try {
+        fs.mkdirSync(path.join(os.homedir(), '.aimaestro', 'chat-state'), { recursive: true });
+        fs.writeFileSync(notifiedIdsFile(cwd), JSON.stringify(ids.slice(-200)));
+    } catch (e) { debugLog({ event: 'save_notified_ids_failed', error: e.message }); }
+}
+
+// Multi-line reason handed back to Claude on a Stop-hook block — its instruction
+// to read + respond before going idle.
+function buildAmpBlockReason(messages) {
+    const urgentCount = messages.filter(m => m.priority === 'urgent').length;
+    const header = messages.length === 1
+        ? `[AMP] You have 1 unread message in your inbox:`
+        : `[AMP] You have ${messages.length} unread messages in your inbox${urgentCount > 0 ? ` (${urgentCount} urgent)` : ''}:`;
+    const lines = messages.slice(0, 10).map((m, i) => {
+        const urgent = m.priority === 'urgent' ? '[URGENT] ' : '';
+        const subj = m.subject ? ` — "${m.subject}"` : '';
+        return `  ${i + 1}. ${urgent}from ${formatMessageSender(m)}${subj}`;
+    });
+    const more = messages.length > 10 ? `  …and ${messages.length - 10} more` : '';
+    return [
+        header, ...lines, more, '',
+        'Read and respond to these now using the agent-messaging skill',
+        '(amp-inbox.sh, amp-read.sh <id>, amp-reply.sh <id> "..."), then continue.',
+    ].filter(Boolean).join('\n');
+}
+
 // Main
 async function main() {
     const input = await readStdin();
@@ -507,16 +569,39 @@ async function main() {
             }
             break;
 
-        case 'Stop':
-            // Claude finished responding - keep this fast (no API calls)
-            // Inbox check happens on idle_prompt notification which fires shortly after
+        case 'Stop': {
+            // The reliable AMP delivery slot. Injecting context on idle_prompt /
+            // UserPromptSubmit cannot start a turn on an already-idle agent — the
+            // failure that forced operators to manually type "check your inbox".
+            // Returning { decision: "block", reason } forces the agent to read +
+            // respond before it goes idle. Loop-safe: honor stop_hook_active
+            // (never block twice in a row) and dedup on message IDs.
+            let blocked = false;
+            if (agent === 'claude' && !input.stop_hook_active) {
+                try {
+                    const unread = await fetchUnreadMessages(cwd);
+                    if (unread && unread.messages.length > 0) {
+                        const already = new Set(loadNotifiedIds(cwd));
+                        const fresh = unread.messages.filter(m => m.id && !already.has(m.id));
+                        if (fresh.length > 0) {
+                            saveNotifiedIds(cwd, [...already, ...fresh.map(m => m.id)]);
+                            debugLog({ event: 'stop_block_delivery', cwd, count: fresh.length });
+                            hookResponse = { decision: 'block', reason: buildAmpBlockReason(fresh) };
+                            blocked = true;
+                        }
+                    }
+                } catch (err) {
+                    debugLog({ event: 'stop_block_check_failed', error: err.message });
+                }
+            }
             writeState(cwd, {
-                status: 'idle',
+                status: blocked ? 'active' : 'idle',
                 message: null,
                 sessionId,
                 transcriptPath
             });
             break;
+        }
 
         case 'SessionStart':
             // Session started - record the session info

--- a/tests/ai-maestro-hook.test.ts
+++ b/tests/ai-maestro-hook.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for scripts/claude-hooks/ai-maestro-hook.cjs — the Stop-hook AMP
+ * delivery decision.
+ *
+ * The hook's I/O (stdin, stdout, fetch to the local API) is integration
+ * territory, but the *decision* — whether a Stop should block to deliver
+ * unread messages — is a pure function (decideStopDelivery) that we can test
+ * exhaustively here. This is the answer to "can we test the whole idea?":
+ * the logic is testable; only the plumbing needs a live hook.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+// Requiring the .cjs is side-effect-free: main() is guarded by require.main.
+const hook = require('../scripts/claude-hooks/ai-maestro-hook.cjs')
+
+const msg = (id: string, over: Record<string, unknown> = {}) => ({
+  id,
+  fromAlias: 'alice',
+  fromHost: 'rnd23blocks',
+  subject: 'Deploy question',
+  priority: 'normal',
+  ...over,
+})
+
+describe('ai-maestro-hook · decideStopDelivery', () => {
+  it('does NOT block for non-claude agents (decision:block is Claude-only)', () => {
+    const d = hook.decideStopDelivery({ agent: 'codex', stopHookActive: false, messages: [msg('1')], alreadyIds: [] })
+    expect(d.block).toBe(false)
+  })
+
+  it('does NOT block when stop_hook_active (loop guard)', () => {
+    const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: true, messages: [msg('1')], alreadyIds: [] })
+    expect(d.block).toBe(false)
+  })
+
+  it('does NOT block when there are no unread messages', () => {
+    const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: false, messages: [], alreadyIds: [] })
+    expect(d.block).toBe(false)
+  })
+
+  it('blocks with a Claude Stop-hook response for fresh unread messages', () => {
+    const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: false, messages: [msg('1'), msg('2')], alreadyIds: [] })
+    expect(d.block).toBe(true)
+    expect(d.response.decision).toBe('block')
+    expect(d.response.reason).toContain('2 unread messages')
+    expect(d.freshIds).toEqual(['1', '2'])
+  })
+
+  it('dedups messages already surfaced, blocking only on the new one', () => {
+    const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: false, messages: [msg('1'), msg('2')], alreadyIds: ['1'] })
+    expect(d.block).toBe(true)
+    expect(d.freshIds).toEqual(['2'])
+    expect(d.response.reason).toContain('1 unread message')
+  })
+
+  it('does NOT block when every unread message was already surfaced', () => {
+    const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: false, messages: [msg('1')], alreadyIds: ['1'] })
+    expect(d.block).toBe(false)
+    expect(d.freshIds).toEqual([])
+  })
+})
+
+describe('ai-maestro-hook · filterFreshMessages', () => {
+  it('drops messages without an id (cannot dedup them)', () => {
+    const out = hook.filterFreshMessages([{ subject: 'no id' }, msg('9')], [])
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe('9')
+  })
+
+  it('tolerates null/undefined inputs', () => {
+    expect(hook.filterFreshMessages(null, null)).toEqual([])
+    expect(hook.filterFreshMessages(undefined, ['x'])).toEqual([])
+  })
+})
+
+describe('ai-maestro-hook · buildAmpBlockReason', () => {
+  it('flags a single urgent message and points at the agent-messaging skill', () => {
+    const reason = hook.buildAmpBlockReason([msg('1', { priority: 'urgent' })])
+    expect(reason).toContain('[URGENT]')
+    expect(reason).toContain('1 unread message in your inbox')
+    expect(reason).toContain('agent-messaging skill')
+    expect(reason).toContain('amp-inbox.sh')
+  })
+
+  it('counts urgent messages in the plural header', () => {
+    const reason = hook.buildAmpBlockReason([msg('1', { priority: 'urgent' }), msg('2')])
+    expect(reason).toContain('2 unread messages')
+    expect(reason).toContain('(1 urgent)')
+  })
+
+  it('caps the listed messages at 10 and notes the remainder', () => {
+    const many = Array.from({ length: 13 }, (_, i) => msg(String(i)))
+    const reason = hook.buildAmpBlockReason(many)
+    expect(reason).toContain('13 unread messages')
+    expect(reason).toContain('…and 3 more')
+  })
+
+  it('renders the sender with host', () => {
+    const reason = hook.buildAmpBlockReason([msg('1')])
+    expect(reason).toContain('from alice (rnd23blocks)')
+  })
+})

--- a/tests/streaming-bridge.test.ts
+++ b/tests/streaming-bridge.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for lib/streaming-bridge.mjs
+ *
+ * The bridge is how the AMP delivery layer pushes a message into a live
+ * streaming (Agent SDK) session that lives in server.mjs's module graph. It
+ * reads the shared globalThis._streamSessions map, so these tests drive that
+ * map directly with fake sessions.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { pushToStreamSession, hasStreamSession } from '@/lib/streaming-bridge.mjs'
+
+interface FakeSession {
+  closed: boolean
+  exited: boolean
+  push: (t: string) => void
+  _pushed: string[]
+}
+
+function fakeSession(over: Partial<FakeSession> = {}): FakeSession {
+  const pushed: string[] = []
+  return { closed: false, exited: false, push: (t: string) => pushed.push(t), _pushed: pushed, ...over }
+}
+
+function setMap(entries: [string, unknown][] = []) {
+  ;(globalThis as any)._streamSessions = new Map(entries)
+}
+
+describe('streaming-bridge', () => {
+  beforeEach(() => setMap())
+
+  it('returns false when the session map does not exist yet', () => {
+    delete (globalThis as any)._streamSessions
+    expect(pushToStreamSession('a', 'x')).toBe(false)
+    expect(hasStreamSession('a')).toBe(false)
+  })
+
+  it('returns false for an unknown agent', () => {
+    expect(pushToStreamSession('nobody', 'x')).toBe(false)
+    expect(hasStreamSession('nobody')).toBe(false)
+  })
+
+  it('pushes text into a live session and reports it', () => {
+    const s = fakeSession()
+    setMap([['a1', s]])
+    expect(pushToStreamSession('a1', 'hello')).toBe(true)
+    expect(s._pushed).toEqual(['hello'])
+    expect(hasStreamSession('a1')).toBe(true)
+  })
+
+  it('coerces a numeric agentKey to string', () => {
+    const s = fakeSession()
+    setMap([['42', s]])
+    expect(pushToStreamSession(42 as unknown as string, 'hi')).toBe(true)
+    expect(s._pushed).toEqual(['hi'])
+  })
+
+  it('skips closed sessions', () => {
+    const s = fakeSession({ closed: true })
+    setMap([['a2', s]])
+    expect(pushToStreamSession('a2', 'x')).toBe(false)
+    expect(hasStreamSession('a2')).toBe(false)
+    expect(s._pushed).toEqual([])
+  })
+
+  it('skips exited sessions', () => {
+    const s = fakeSession({ exited: true })
+    setMap([['a3', s]])
+    expect(pushToStreamSession('a3', 'x')).toBe(false)
+    expect(hasStreamSession('a3')).toBe(false)
+  })
+
+  it('ignores empty agentKey or text', () => {
+    const s = fakeSession()
+    setMap([['a4', s]])
+    expect(pushToStreamSession('', 'x')).toBe(false)
+    expect(pushToStreamSession('a4', '')).toBe(false)
+    expect(s._pushed).toEqual([])
+  })
+
+  it('swallows a throwing push and returns false', () => {
+    setMap([['a5', { closed: false, exited: false, push() { throw new Error('boom') } }]])
+    expect(pushToStreamSession('a5', 'x')).toBe(false)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.10",
-  "releaseDate": "2026-07-24",
+  "version": "0.36.11",
+  "releaseDate": "2026-07-30",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.11",
+  "version": "0.36.12",
   "releaseDate": "2026-07-30",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Fixes the #1 daily pain: AMP messages not acted on until manually typing "check your inbox".

- **Terminal agents**: Stop hook returns `{decision:"block", reason}` for genuinely-new unread messages, forcing read+respond before idle. Loop-safe (stop_hook_active + per-cwd message-ID dedup). Active in-repo hook + plugin submodule (PR #27, merged).
- **Streaming agents**: AMP messages pushed straight into the live SDK input stream (`session.push` via `lib/streaming-bridge.mjs`); streaming session map backed by `globalThis` to share across the Next/ESM boundary.
- **Hardening**: extracted pure `decideStopDelivery` for unit tests; +20 tests (812 passing); fixed `bump-version.sh` package.json drift (was stuck at 0.29.16).

Tests 812/812 pass · build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)