### PR TITLE
fix: AMP identity contamination repair + conformance guards (v0.36.20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.16-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.17-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.19-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.20-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.18-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.19-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.14-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.15-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.17-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.18-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.15-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.16-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/channels/.claude-plugin/marketplace.json
+++ b/channels/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "aimaestro-channels",
+  "owner": {
+    "name": "23blocks",
+    "email": "hello@23blocks.com"
+  },
+  "metadata": {
+    "description": "AI Maestro channel plugins — reliable idle-agent wake via MCP turn-injection (no tmux keystrokes).",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "amp",
+      "source": "./amp-plugin",
+      "description": "AMP channel — injects inbox messages straight into an idle agent's Claude Code session so it wakes and processes them.",
+      "version": "0.1.0",
+      "author": {
+        "name": "23blocks"
+      },
+      "homepage": "https://github.com/23blocks-OS/ai-maestro",
+      "license": "MIT",
+      "keywords": ["channel", "amp", "notifications", "wake"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/lib/amp-inbox-writer.ts
+++ b/lib/amp-inbox-writer.ts
@@ -251,42 +251,37 @@ export async function initAgentAMPHome(agentName: string, agentId?: string): Pro
       }
     }
   } catch {
-    // Agent config doesn't exist — create from machine config or defaults
-    const machineConfig = path.join(AMP_DIR, 'config.json')
+    // Agent config doesn't exist — create a CLEAN one. CRITICAL: do NOT inherit
+    // the machine's identity. Reuse only non-identity structure (version/tenant/
+    // provider); the agent's address + keypair are its OWN, minted by amp-init.
+    // Cloning the machine config's `address` is what stamped many agents with the
+    // machine/agents-web address (see scripts/amp-identity-audit.mjs).
+    let base: Record<string, unknown> = { version: 'amp/0.1' }
     try {
-      const configData = JSON.parse(await fs.readFile(machineConfig, 'utf-8'))
-      configData.agent = configData.agent || {}
-      configData.agent.name = agentName
-      if (agentId) configData.agent.id = agentId
-      await fs.writeFile(agentConfig, JSON.stringify(configData, null, 2))
-    } catch {
-      const minimalConfig: Record<string, unknown> = {
-        version: 'amp/0.1',
-        agent: { name: agentName, ...(agentId ? { id: agentId } : {}) },
-        created_at: new Date().toISOString()
+      const m = JSON.parse(await fs.readFile(path.join(AMP_DIR, 'config.json'), 'utf-8'))
+      base = {
+        version: m.version || 'amp/0.1',
+        ...(m.tenant ? { tenant: m.tenant } : {}),
+        ...(m.provider ? { provider: m.provider } : {}),
       }
-      await fs.writeFile(agentConfig, JSON.stringify(minimalConfig, null, 2))
-    }
-  }
-
-  // Copy machine-level keys if agent doesn't have them yet
-  try {
-    await fs.access(path.join(agentKeys, 'private.pem'))
-  } catch {
-    const machineKeys = path.join(AMP_DIR, 'keys')
-    try {
-      const privateKey = await fs.readFile(path.join(machineKeys, 'private.pem'))
-      const publicKey = await fs.readFile(path.join(machineKeys, 'public.pem'))
-      await fs.writeFile(path.join(agentKeys, 'private.pem'), privateKey)
-      await fs.writeFile(path.join(agentKeys, 'public.pem'), publicKey)
     } catch {
-      // No machine keys — agent will need to run amp-init
+      // No machine config — minimal is fine
     }
+    await fs.writeFile(agentConfig, JSON.stringify({
+      ...base,
+      // NO `address` here — a shared/inherited address is identity contamination.
+      // amp-init sets the agent's own address when it registers.
+      agent: { name: agentName, ...(agentId ? { id: agentId } : {}) },
+      created_at: new Date().toISOString(),
+    }, null, 2))
   }
 
-  // NOTE: Machine-level registrations are NOT copied to agents.
-  // Each agent gets its own registration via /api/v1/register with its own API key.
-  // Copying machine-level keys caused identity contamination (wrong sender addresses).
+  // CRITICAL: every agent MUST have its OWN unique Ed25519 keypair. We deliberately
+  // do NOT copy the machine keypair here. Copying it made N agents share ONE
+  // cryptographic identity (all signing as the machine/agents-web) — the exact bug
+  // scripts/amp-identity-audit.mjs detects. If the agent has no keys yet, that is
+  // correct: amp-init.sh mints a unique keypair and registers it. Inbox delivery
+  // only needs the directory, which exists by now — no keys required to receive.
 
   // Update the name→UUID index
   if (agentId) {

--- a/lib/amp-known-keys.ts
+++ b/lib/amp-known-keys.ts
@@ -34,10 +34,15 @@ function ledgerPath(base?: string): string {
 function load(base?: string): Ledger {
   try { return JSON.parse(fs.readFileSync(ledgerPath(base), 'utf8')) } catch { return {} }
 }
+let saveSeq = 0
 function save(l: Ledger, base?: string): void {
   const p = ledgerPath(base)
   fs.mkdirSync(path.dirname(p), { recursive: true })
-  fs.writeFileSync(p, JSON.stringify(l, null, 2))
+  // atomic write: temp file + rename, so a concurrent reader never sees a
+  // half-written ledger. (pid+counter keeps the temp name unique without a clock.)
+  const tmp = `${p}.tmp-${process.pid}-${saveSeq++}`
+  fs.writeFileSync(tmp, JSON.stringify(l, null, 2))
+  fs.renameSync(tmp, p)
 }
 
 /** Pure classification — testable without the filesystem. */
@@ -53,18 +58,17 @@ export function checkKnownKey(address: string, fingerprint: string, base?: strin
 }
 
 /**
- * Record a fingerprint for an address. Records on first contact and refreshes
- * lastSeen when unchanged. Refuses to silently overwrite a DIFFERENT fingerprint
- * (that is a conflict — use rotateKnownKey after verifying rotation proof).
- * Returns the status that applied.
+ * Record a fingerprint for an address. Persists only on first contact (TOFU); the
+ * `ok` path is a no-op write to keep this off the per-message hot path. Refuses to
+ * silently overwrite a DIFFERENT fingerprint (that is a conflict — use
+ * rotateKnownKey after verifying rotation proof). Returns the status that applied.
  */
 export function recordKnownKey(address: string, fingerprint: string, now: string, base?: string): KeyStatus {
   const l = load(base)
   const k = address.toLowerCase()
-  const e = l[k]
-  const status = classifyKey(e?.fingerprint, fingerprint)
+  const status = classifyKey(l[k]?.fingerprint, fingerprint)
   if (status === 'first_contact') { l[k] = { fingerprint, firstSeen: now, lastSeen: now }; save(l, base) }
-  else if (status === 'ok') { e!.lastSeen = now; save(l, base) }
+  // 'ok'       → already known, no write (avoid a disk write on every message)
   // 'conflict' → do NOT overwrite; caller handles (refuse + alert)
   return status
 }

--- a/lib/amp-known-keys.ts
+++ b/lib/amp-known-keys.ts
@@ -1,0 +1,79 @@
+/**
+ * AMP Identity Conflict Detection (key-swap / TOFU ledger).
+ *
+ * Implements the normative control in AMP spec 07-security "Identity Conflict
+ * Detection": maintain a local cache of each address's last-known public-key
+ * fingerprint, and refuse to communicate with an address whose key changed
+ * unexpectedly (`key_conflict`, HTTP 409). First contact is Trust-On-First-Use.
+ *
+ * This is the control that would have caught the fleet contamination where 71
+ * agents' keys were silently overwritten with one shared key — an unexplained
+ * fingerprint change for every one of them.
+ *
+ * A legitimate key rotation (old key signs new key, per 07-security "Key
+ * Revocation") calls `rotateKnownKey()` to update the ledger; anything else is a
+ * conflict the operator must resolve.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export type KeyStatus = 'ok' | 'first_contact' | 'conflict'
+export interface KeyCheck {
+  status: KeyStatus
+  knownFingerprint?: string
+  presented: string
+}
+interface Entry { fingerprint: string; firstSeen: string; lastSeen: string }
+type Ledger = Record<string, Entry>
+
+function ledgerPath(base?: string): string {
+  const root = base || process.env.AIMAESTRO_KNOWN_KEYS_DIR || path.join(os.homedir(), '.aimaestro', 'amp')
+  return path.join(root, 'known-keys.json')
+}
+function load(base?: string): Ledger {
+  try { return JSON.parse(fs.readFileSync(ledgerPath(base), 'utf8')) } catch { return {} }
+}
+function save(l: Ledger, base?: string): void {
+  const p = ledgerPath(base)
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, JSON.stringify(l, null, 2))
+}
+
+/** Pure classification — testable without the filesystem. */
+export function classifyKey(known: string | undefined, presented: string): KeyStatus {
+  if (!known) return 'first_contact'
+  return known === presented ? 'ok' : 'conflict'
+}
+
+/** Check a presented fingerprint for an address against the ledger. Read-only. */
+export function checkKnownKey(address: string, fingerprint: string, base?: string): KeyCheck {
+  const known = load(base)[address.toLowerCase()]?.fingerprint
+  return { status: classifyKey(known, fingerprint), knownFingerprint: known, presented: fingerprint }
+}
+
+/**
+ * Record a fingerprint for an address. Records on first contact and refreshes
+ * lastSeen when unchanged. Refuses to silently overwrite a DIFFERENT fingerprint
+ * (that is a conflict — use rotateKnownKey after verifying rotation proof).
+ * Returns the status that applied.
+ */
+export function recordKnownKey(address: string, fingerprint: string, now: string, base?: string): KeyStatus {
+  const l = load(base)
+  const k = address.toLowerCase()
+  const e = l[k]
+  const status = classifyKey(e?.fingerprint, fingerprint)
+  if (status === 'first_contact') { l[k] = { fingerprint, firstSeen: now, lastSeen: now }; save(l, base) }
+  else if (status === 'ok') { e!.lastSeen = now; save(l, base) }
+  // 'conflict' → do NOT overwrite; caller handles (refuse + alert)
+  return status
+}
+
+/** Explicit, authorized rotation (old key signed the new key). Updates the ledger. */
+export function rotateKnownKey(address: string, newFingerprint: string, now: string, base?: string): void {
+  const l = load(base)
+  const k = address.toLowerCase()
+  const firstSeen = l[k]?.firstSeen || now
+  l[k] = { fingerprint: newFingerprint, firstSeen, lastSeen: now }
+  save(l, base)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.18",
+  "version": "0.36.19",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.14",
+  "version": "0.36.15",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.19",
+  "version": "0.36.20",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.16",
+  "version": "0.36.17",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.15",
+  "version": "0.36.16",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.17",
+  "version": "0.36.18",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/amp-identity-audit.mjs
+++ b/scripts/amp-identity-audit.mjs
@@ -13,10 +13,21 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { execFileSync } from 'node:child_process'
 
 const B = path.join(os.homedir(), '.agent-messaging', 'agents')
 const isUuid = (s) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/.test(s)
 const addrOf = (c) => (c && (c.agent?.address || c.address)) || null
+// SHA256:base64 fingerprint of a dir's on-disk public key — the real identity.
+const diskFp = (dir) => {
+  const f = path.join(dir, 'keys', 'public.pem')
+  if (!fs.existsSync(f)) return null
+  try {
+    const der = execFileSync('openssl', ['pkey', '-pubin', '-in', f, '-outform', 'DER'])
+    const bin = execFileSync('openssl', ['dgst', '-sha256', '-binary'], { input: der })
+    return 'SHA256:' + Buffer.from(bin).toString('base64')
+  } catch { return null }
+}
 
 async function loadRegistry() {
   const r = await fetch('http://localhost:23000/api/agents')
@@ -40,8 +51,17 @@ for (const a of reg) {
   ;(regByAddr.get(addr) || regByAddr.set(addr, []).get(addr)).push(a)
 }
 
+// registry-side shared FINGERPRINTS (the actual identity — one key across many agents)
+const regByFp = new Map()
+for (const a of reg) {
+  const fp = (a.metadata?.amp || a.amp || {}).fingerprint
+  if (!fp) continue
+  ;(regByFp.get(fp) || regByFp.set(fp, []).get(fp)).push(a)
+}
+
 const entries = fs.existsSync(B) ? fs.readdirSync(B) : []
 const diskByAddr = new Map()   // address -> [dir]
+const diskByKey = new Map()    // on-disk key fingerprint -> [dir]
 const mismatches = []
 const realNameDirs = []
 const noConfig = []
@@ -54,6 +74,8 @@ for (const e of entries) {
     if (!st.isSymbolicLink()) realNameDirs.push(e)
     continue
   }
+  const fp = diskFp(p)
+  if (fp) (diskByKey.get(fp) || diskByKey.set(fp, []).get(fp)).push(e)
   const cfg = readConfig(p)
   const addr = addrOf(cfg)
   if (!addr) { noConfig.push(e); continue }
@@ -67,11 +89,15 @@ for (const e of entries) {
 
 const dupDisk = [...diskByAddr.entries()].filter(([, d]) => d.length > 1)
 const dupReg = [...regByAddr.entries()].filter(([, a]) => a.length > 1)
+const dupKey = [...diskByKey.entries()].filter(([, d]) => d.length > 1)
+const dupRegFp = [...regByFp.entries()].filter(([, a]) => a.length > 1)
 
 const report = {
   registryAgents: reg.length,
   diskDirs: entries.length,
   mismatches,
+  sharedKeysOnDisk: dupKey.map(([fp, d]) => ({ fingerprint: fp, count: d.length, dirs: d.map((x) => x.slice(0, 8)) })),
+  sharedFingerprintsInRegistry: dupRegFp.map(([fp, a]) => ({ fingerprint: fp, count: a.length, agents: a.map((y) => y.name) })),
   duplicateAddressesOnDisk: dupDisk.map(([a, d]) => ({ address: a, dirs: d })),
   duplicateAddressesInRegistry: dupReg.map(([a, x]) => ({ address: a, agents: x.map((y) => y.name) })),
   realNameDirs: realNameDirs.length,
@@ -82,6 +108,12 @@ if (process.argv.includes('--json')) { console.log(JSON.stringify(report, null, 
 
 console.log('════════ AMP IDENTITY AUDIT ════════')
 console.log(`registry agents: ${report.registryAgents}   |   disk dirs: ${report.diskDirs}`)
+console.log('')
+console.log(`🔑 SHARED KEYS on disk — one keypair across multiple agents: ${dupKey.length}`)
+dupKey.slice(0, 10).forEach(([fp, d]) => console.log(`    ${fp.slice(0, 28)}…  →  ${d.length} dirs`))
+console.log('')
+console.log(`🔑 SHARED FINGERPRINTS in registry — one identity across agents: ${dupRegFp.length}`)
+dupRegFp.slice(0, 10).forEach(([fp, a]) => console.log(`    ${fp.slice(0, 28)}…  →  ${a.length} agents`))
 console.log('')
 console.log(`✗ registry↔disk MISMATCHES: ${mismatches.length}`)
 mismatches.slice(0, 30).forEach((m) => console.log(`    ${m.name} (${m.id.slice(0, 8)})  reg=${m.registry}  disk=${m.disk}`))
@@ -94,6 +126,7 @@ dupReg.slice(0, 30).forEach(([a, x]) => console.log(`    ${a}  →  ${x.map((y) 
 console.log('')
 console.log(`○ real name-dirs (should be symlinks): ${report.realNameDirs}`)
 console.log(`○ uuid dirs with no/invalid config: ${report.uuidDirsNoConfig}`)
-const clean = mismatches.length === 0 && dupDisk.length === 0 && dupReg.length === 0
+const clean = mismatches.length === 0 && dupDisk.length === 0 && dupReg.length === 0 && dupKey.length === 0 && dupRegFp.length === 0
 console.log('')
-console.log(clean ? '✅ No mismatches or shared identities.' : '❌ Identity issues found — repair needed.')
+console.log(clean ? '✅ No shared keys, fingerprints, addresses, or mismatches.' : '❌ Identity issues found — repair needed.')
+process.exit(clean ? 0 : 1)

--- a/scripts/amp-identity-audit.mjs
+++ b/scripts/amp-identity-audit.mjs
@@ -16,11 +16,11 @@ import path from 'node:path'
 import { execFileSync } from 'node:child_process'
 
 const B = path.join(os.homedir(), '.agent-messaging', 'agents')
+const SERVER = path.join(os.homedir(), '.aimaestro', 'agents')   // server-side verify-key store
 const isUuid = (s) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/.test(s)
 const addrOf = (c) => (c && (c.agent?.address || c.address)) || null
-// SHA256:base64 fingerprint of a dir's on-disk public key — the real identity.
-const diskFp = (dir) => {
-  const f = path.join(dir, 'keys', 'public.pem')
+// SHA256:base64 fingerprint of a public.pem — the real identity.
+const fpOf = (f) => {
   if (!fs.existsSync(f)) return null
   try {
     const der = execFileSync('openssl', ['pkey', '-pubin', '-in', f, '-outform', 'DER'])
@@ -28,6 +28,8 @@ const diskFp = (dir) => {
     return 'SHA256:' + Buffer.from(bin).toString('base64')
   } catch { return null }
 }
+const diskFp = (dir) => fpOf(path.join(dir, 'keys', 'public.pem'))
+const serverFp = (id) => fpOf(path.join(SERVER, id, 'keys', 'public.pem'))
 
 async function loadRegistry() {
   const r = await fetch('http://localhost:23000/api/agents')
@@ -92,6 +94,18 @@ const dupReg = [...regByAddr.entries()].filter(([, a]) => a.length > 1)
 const dupKey = [...diskByKey.entries()].filter(([, d]) => d.length > 1)
 const dupRegFp = [...regByFp.entries()].filter(([, a]) => a.length > 1)
 
+// Server-side verify-key store (~/.aimaestro/agents/<id>/keys): must be UNIQUE and
+// must MATCH the client signing key, or signature verification fails/collides.
+const serverByKey = new Map()
+const keyStoreMismatch = []
+for (const a of reg) {
+  const sfp = serverFp(a.id)
+  if (sfp) (serverByKey.get(sfp) || serverByKey.set(sfp, []).get(sfp)).push(a.name)
+  const cfp = diskFp(path.join(B, a.id))
+  if (sfp && cfp && sfp !== cfp) keyStoreMismatch.push({ name: a.name, client: cfp.slice(0, 20), server: sfp.slice(0, 20) })
+}
+const dupServerKey = [...serverByKey.entries()].filter(([, n]) => n.length > 1)
+
 const report = {
   registryAgents: reg.length,
   diskDirs: entries.length,
@@ -115,6 +129,12 @@ console.log('')
 console.log(`🔑 SHARED FINGERPRINTS in registry — one identity across agents: ${dupRegFp.length}`)
 dupRegFp.slice(0, 10).forEach(([fp, a]) => console.log(`    ${fp.slice(0, 28)}…  →  ${a.length} agents`))
 console.log('')
+console.log(`🔑 SHARED SERVER verify-keys — one key across agents: ${dupServerKey.length}`)
+dupServerKey.slice(0, 10).forEach(([fp, a]) => console.log(`    ${fp.slice(0, 28)}…  →  ${a.length} agents`))
+console.log('')
+console.log(`🔑 client↔server KEY-STORE mismatches (signatures would fail): ${keyStoreMismatch.length}`)
+keyStoreMismatch.slice(0, 10).forEach((m) => console.log(`    ${m.name}  client=${m.client}  server=${m.server}`))
+console.log('')
 console.log(`✗ registry↔disk MISMATCHES: ${mismatches.length}`)
 mismatches.slice(0, 30).forEach((m) => console.log(`    ${m.name} (${m.id.slice(0, 8)})  reg=${m.registry}  disk=${m.disk}`))
 console.log('')
@@ -126,7 +146,7 @@ dupReg.slice(0, 30).forEach(([a, x]) => console.log(`    ${a}  →  ${x.map((y) 
 console.log('')
 console.log(`○ real name-dirs (should be symlinks): ${report.realNameDirs}`)
 console.log(`○ uuid dirs with no/invalid config: ${report.uuidDirsNoConfig}`)
-const clean = mismatches.length === 0 && dupDisk.length === 0 && dupReg.length === 0 && dupKey.length === 0 && dupRegFp.length === 0
+const clean = mismatches.length === 0 && dupDisk.length === 0 && dupReg.length === 0 && dupKey.length === 0 && dupRegFp.length === 0 && dupServerKey.length === 0 && keyStoreMismatch.length === 0
 console.log('')
 console.log(clean ? '✅ No shared keys, fingerprints, addresses, or mismatches.' : '❌ Identity issues found — repair needed.')
 process.exit(clean ? 0 : 1)

--- a/scripts/amp-identity-audit.mjs
+++ b/scripts/amp-identity-audit.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * AMP identity audit — reconcile the AI Maestro registry (source of truth) with
+ * the on-disk AMP store (~/.agent-messaging/agents/*). Reports:
+ *   - mismatches: a uuid dir's config identity ≠ the registry identity
+ *   - DUPLICATE addresses: one AMP address claimed by >1 uuid dir or >1 agent
+ *     (the actual "shared identity" bug — must be zero)
+ *   - real name-dirs that should be symlinks to uuid dirs (migration debt)
+ *   - uuid dirs with no/invalid config
+ *
+ * Read-only. Use --json for machine output.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const B = path.join(os.homedir(), '.agent-messaging', 'agents')
+const isUuid = (s) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/.test(s)
+const addrOf = (c) => (c && (c.agent?.address || c.address)) || null
+
+async function loadRegistry() {
+  const r = await fetch('http://localhost:23000/api/agents')
+  const { agents = [] } = await r.json()
+  return agents
+}
+
+function readConfig(dir) {
+  try { return JSON.parse(fs.readFileSync(path.join(dir, 'config.json'), 'utf8')) } catch { return null }
+}
+
+const reg = await loadRegistry()
+const regById = new Map(reg.map((a) => [a.id, a]))
+const regAddr = (a) => (a.metadata?.amp || a.amp || {}).address || null
+
+// registry-side duplicate addresses
+const regByAddr = new Map()
+for (const a of reg) {
+  const addr = regAddr(a)
+  if (!addr) continue
+  ;(regByAddr.get(addr) || regByAddr.set(addr, []).get(addr)).push(a)
+}
+
+const entries = fs.existsSync(B) ? fs.readdirSync(B) : []
+const diskByAddr = new Map()   // address -> [dir]
+const mismatches = []
+const realNameDirs = []
+const noConfig = []
+
+for (const e of entries) {
+  const p = path.join(B, e)
+  let st
+  try { st = fs.lstatSync(p) } catch { continue }
+  if (!isUuid(e)) {
+    if (!st.isSymbolicLink()) realNameDirs.push(e)
+    continue
+  }
+  const cfg = readConfig(p)
+  const addr = addrOf(cfg)
+  if (!addr) { noConfig.push(e); continue }
+  ;(diskByAddr.get(addr) || diskByAddr.set(addr, []).get(addr)).push(e)
+  const ra = regById.get(e)
+  if (ra) {
+    const rAddr = regAddr(ra)
+    if (rAddr && rAddr !== addr) mismatches.push({ id: e, name: ra.name, registry: rAddr, disk: addr })
+  }
+}
+
+const dupDisk = [...diskByAddr.entries()].filter(([, d]) => d.length > 1)
+const dupReg = [...regByAddr.entries()].filter(([, a]) => a.length > 1)
+
+const report = {
+  registryAgents: reg.length,
+  diskDirs: entries.length,
+  mismatches,
+  duplicateAddressesOnDisk: dupDisk.map(([a, d]) => ({ address: a, dirs: d })),
+  duplicateAddressesInRegistry: dupReg.map(([a, x]) => ({ address: a, agents: x.map((y) => y.name) })),
+  realNameDirs: realNameDirs.length,
+  uuidDirsNoConfig: noConfig.length,
+}
+
+if (process.argv.includes('--json')) { console.log(JSON.stringify(report, null, 2)); process.exit(0) }
+
+console.log('════════ AMP IDENTITY AUDIT ════════')
+console.log(`registry agents: ${report.registryAgents}   |   disk dirs: ${report.diskDirs}`)
+console.log('')
+console.log(`✗ registry↔disk MISMATCHES: ${mismatches.length}`)
+mismatches.slice(0, 30).forEach((m) => console.log(`    ${m.name} (${m.id.slice(0, 8)})  reg=${m.registry}  disk=${m.disk}`))
+console.log('')
+console.log(`⚠ SHARED IDENTITY — same address, multiple disk dirs: ${dupDisk.length}`)
+dupDisk.slice(0, 30).forEach(([a, d]) => console.log(`    ${a}  →  ${d.map((x) => x.slice(0, 8)).join(', ')}`))
+console.log('')
+console.log(`⚠ SHARED IDENTITY — same address, multiple registry agents: ${dupReg.length}`)
+dupReg.slice(0, 30).forEach(([a, x]) => console.log(`    ${a}  →  ${x.map((y) => y.name).join(', ')}`))
+console.log('')
+console.log(`○ real name-dirs (should be symlinks): ${report.realNameDirs}`)
+console.log(`○ uuid dirs with no/invalid config: ${report.uuidDirsNoConfig}`)
+const clean = mismatches.length === 0 && dupDisk.length === 0 && dupReg.length === 0
+console.log('')
+console.log(clean ? '✅ No mismatches or shared identities.' : '❌ Identity issues found — repair needed.')

--- a/scripts/amp-identity-repair.mjs
+++ b/scripts/amp-identity-repair.mjs
@@ -110,8 +110,13 @@ const bakReg = `${REGISTRY}.bak-${stamp}`
 if (!fs.existsSync(bakDir)) { fs.cpSync(B, bakDir, { recursive: true }); console.log(`\nBackup (store):    ${bakDir}`) }
 if (!fs.existsSync(bakReg)) { fs.copyFileSync(REGISTRY, bakReg); console.log(`Backup (registry): ${bakReg}`) }
 
-// writes on-disk config + registry entry to a given fingerprint + address
-const writeIdentity = (p, fp) => {
+// The SERVER verifies signatures against ~/.aimaestro/agents/<id>/keys/public.pem
+// (lib/amp-keys.ts loadKeyPair), a SEPARATE store from the client's signing keys
+// in ~/.agent-messaging. Both must hold the same keypair or every signature fails.
+const SERVER_KEYS = (id) => path.join(HOME, '.aimaestro', 'agents', id, 'keys')
+
+// writes on-disk config + registry entry + SERVER public key to a given fingerprint
+const writeIdentity = (p, fp, pubPem) => {
   const cfg = readCfg(p.dir) || {}
   if (cfg.agent) { cfg.agent.address = p.correctAddr; cfg.agent.fingerprint = fp }
   cfg.address = p.correctAddr
@@ -122,6 +127,12 @@ const writeIdentity = (p, fp) => {
   ra.metadata.amp = ra.metadata.amp || {}
   ra.metadata.amp.fingerprint = fp
   if (!p.registryHadAddr) { ra.metadata.amp.address = p.correctAddr; ra.metadata.amp.tenant = ra.metadata.amp.tenant || TENANT }
+  // sync the server-side verification key to the agent's new public key
+  if (pubPem) {
+    const sk = SERVER_KEYS(p.id)
+    fs.mkdirSync(sk, { recursive: true })
+    fs.writeFileSync(path.join(sk, 'public.pem'), pubPem)
+  }
 }
 
 let ok = 0, fail = 0
@@ -134,13 +145,15 @@ for (const p of remintList) {
     execFileSync('openssl', ['genpkey', '-algorithm', 'ed25519', '-out', priv])   // fresh unique keypair
     execFileSync('openssl', ['pkey', '-in', priv, '-pubout', '-out', pub])
     fs.chmodSync(priv, 0o600)
-    writeIdentity(p, fpOfPub(fs.readFileSync(pub)))
+    const pubPem = fs.readFileSync(pub)
+    writeIdentity(p, fpOfPub(pubPem), pubPem)
     ok++; console.log(`  ✓ re-mint    ${p.name}`)
   } catch (e) { fail++; console.log(`  ✗ ${p.name}: ${String(e.message || e).slice(0, 140)}`) }
 }
 for (const p of normalizeList) {
   try {
-    writeIdentity(p, p.diskFp)   // keep the (already unique) key; align address + registry fp
+    const pubPem = fs.existsSync(path.join(p.dir, 'keys', 'public.pem')) ? fs.readFileSync(path.join(p.dir, 'keys', 'public.pem')) : null
+    writeIdentity(p, p.diskFp, pubPem)   // keep the (already unique) key; align address + registry + server key
     ok++; console.log(`  ✓ normalize  ${p.name}`)
   } catch (e) { fail++; console.log(`  ✗ ${p.name}: ${String(e.message || e).slice(0, 140)}`) }
 }

--- a/scripts/amp-identity-repair.mjs
+++ b/scripts/amp-identity-repair.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * AMP identity repair — gives every contaminated agent a UNIQUE cryptographic
+ * identity, reconciling the on-disk AMP store with the AI Maestro registry.
+ *
+ * Why not amp-init? The contamination jams amp-init's own resolution: when many
+ * dirs share one address, amp-init can't disambiguate which agent to re-mint
+ * (even with --id). So we mint directly with openssl and update both stores.
+ *
+ * For each agent whose on-disk keypair is SHARED across dirs, whose registry
+ * fingerprint is SHARED across agents, or whose on-disk address is wrong, we:
+ *   1. generate a fresh Ed25519 keypair -> <dir>/keys/{private,public}.pem
+ *   2. compute its fingerprint (SHA256:base64, the registry format)
+ *   3. set the registry entry's metadata.amp.fingerprint to the fresh one
+ *   4. set the on-disk config.json address to the registry address + fingerprint
+ * so on-disk key <-> registry fingerprint <-> address are consistent and unique.
+ *
+ * DRY-RUN by default. --apply executes, backing up the AMP store AND registry.json
+ * first. Registry address stays as-is (already unique/correct); only fingerprints
+ * that were shared get rotated. Run the audit afterward to prove 0 shared keys.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const APPLY = process.argv.includes('--apply')
+const ONLY = (process.argv.find((a) => a.startsWith('--only=')) || '').slice(7) // optional single agent id, for piloting
+const HOME = os.homedir()
+const B = path.join(HOME, '.agent-messaging', 'agents')
+const REGISTRY = path.join(HOME, '.aimaestro', 'agents', 'registry.json')
+const isUuid = (s) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/.test(s)
+const addrOf = (c) => (c && (c.agent?.address || c.address)) || null
+
+// SHA256:base64 fingerprint of a PEM public key — matches the registry format.
+const fpOfPub = (pubPem) => {
+  const der = execFileSync('openssl', ['pkey', '-pubin', '-outform', 'DER'], { input: pubPem })
+  const b64 = execFileSync('openssl', ['dgst', '-sha256', '-binary'], { input: der })
+  return 'SHA256:' + Buffer.from(b64).toString('base64')
+}
+const diskFp = (dir) => {
+  const f = path.join(dir, 'keys', 'public.pem')
+  if (!fs.existsSync(f)) return null
+  try { return fpOfPub(fs.readFileSync(f)) } catch { return null }
+}
+const readCfg = (dir) => { try { return JSON.parse(fs.readFileSync(path.join(dir, 'config.json'), 'utf8')) } catch { return null } }
+
+// Registry (source of truth for addresses).
+const registry = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'))
+const regById = new Map(registry.map((a) => [a.id, a]))
+const regAddr = (a) => a?.metadata?.amp?.address || null
+const regFp = (a) => a?.metadata?.amp?.fingerprint || null
+// Default tenant = the most common amp.tenant in the registry (for deriving
+// addresses of agents the registry never recorded an amp.address for).
+const tenantCounts = new Map()
+for (const a of registry) { const t = a?.metadata?.amp?.tenant; if (t) tenantCounts.set(t, (tenantCounts.get(t) || 0) + 1) }
+const TENANT = [...tenantCounts.entries()].sort((x, y) => y[1] - x[1])[0]?.[0] || 'rnd23blocks'
+const deriveAddr = (name) => `${name.toLowerCase()}@${TENANT}.aimaestro.local`
+
+// How many dirs share each on-disk key, and how many registry agents share each fingerprint?
+const uuidDirs = fs.readdirSync(B).filter(isUuid)
+const diskFpCount = new Map()
+for (const d of uuidDirs) { const fp = diskFp(path.join(B, d)); if (fp) diskFpCount.set(fp, (diskFpCount.get(fp) || 0) + 1) }
+const regFpCount = new Map()
+for (const a of registry) { const fp = regFp(a); if (fp) regFpCount.set(fp, (regFpCount.get(fp) || 0) + 1) }
+
+const remintList = []     // real identity corruption: new key + registry fp + address
+const normalizeList = []  // key is fine (unique); just fix config/registry address casing/gap
+for (const d of uuidDirs) {
+  if (ONLY && d !== ONLY) continue
+  const dir = path.join(B, d)
+  const ra = regById.get(d)
+  if (!ra) continue                              // orphan uuid, not a registry agent
+  const registryHadAddr = !!regAddr(ra)
+  const correct = regAddr(ra) || deriveAddr(ra.name)
+  const dfp = diskFp(dir)
+  const cfg = readCfg(dir)
+  const diskAddr = addrOf(cfg)
+  const sharedKey = dfp && diskFpCount.get(dfp) > 1
+  const sharedRegFp = regFp(ra) && regFpCount.get(regFp(ra)) > 1
+  const noKey = !dfp
+  const wrongAddrCI = diskAddr && diskAddr.toLowerCase() !== correct.toLowerCase()
+  const wrongAddrExact = diskAddr && diskAddr !== correct
+  if (sharedKey || sharedRegFp || noKey || wrongAddrCI) {
+    remintList.push({ id: d, name: ra.name, dir, correctAddr: correct, registryHadAddr,
+      reason: [sharedKey && 'shared-key', sharedRegFp && 'shared-registry-fp', noKey && 'no-key', wrongAddrCI && `wrong-addr(${diskAddr})`].filter(Boolean).join(',') })
+  } else if (wrongAddrExact || !registryHadAddr || regFp(ra) !== dfp) {
+    normalizeList.push({ id: d, name: ra.name, dir, correctAddr: correct, registryHadAddr, diskFp: dfp,
+      reason: [wrongAddrExact && 'addr-case', !registryHadAddr && 'registry-gap', regFp(ra) !== dfp && 'registry-fp-drift'].filter(Boolean).join(',') })
+  }
+}
+
+console.log(`\n════════ AMP IDENTITY REPAIR ${APPLY ? '(APPLY)' : '(DRY-RUN)'} ════════`)
+console.log(`Registry agents: ${registry.length}   |   uuid dirs: ${uuidDirs.length}   |   default tenant: ${TENANT}`)
+console.log(`\nRe-mint (fresh unique key): ${remintList.length}`)
+for (const p of remintList) console.log(`  RE-MINT    ${p.name}  (${p.id.slice(0, 8)})  [${p.reason}]  → ${p.correctAddr}${p.registryHadAddr ? '' : '  (+registry addr)'}`)
+console.log(`\nNormalize only (keep key, fix address/registry): ${normalizeList.length}`)
+for (const p of normalizeList) console.log(`  NORMALIZE  ${p.name}  (${p.id.slice(0, 8)})  [${p.reason}]  → ${p.correctAddr}`)
+
+if (!APPLY) {
+  console.log('\n(dry-run — nothing changed. Re-run with --apply; backups are taken first.)')
+  console.log('(pilot a single agent with --only=<agent-id> --apply before the full run.)')
+  process.exit(0)
+}
+
+// ---- APPLY ----
+const stamp = process.env.REPAIR_STAMP || 'repair'   // caller passes a timestamp; Date.now() unavailable in some runtimes
+const bakDir = `${B}.bak-${stamp}`
+const bakReg = `${REGISTRY}.bak-${stamp}`
+if (!fs.existsSync(bakDir)) { fs.cpSync(B, bakDir, { recursive: true }); console.log(`\nBackup (store):    ${bakDir}`) }
+if (!fs.existsSync(bakReg)) { fs.copyFileSync(REGISTRY, bakReg); console.log(`Backup (registry): ${bakReg}`) }
+
+// writes on-disk config + registry entry to a given fingerprint + address
+const writeIdentity = (p, fp) => {
+  const cfg = readCfg(p.dir) || {}
+  if (cfg.agent) { cfg.agent.address = p.correctAddr; cfg.agent.fingerprint = fp }
+  cfg.address = p.correctAddr
+  cfg.fingerprint = fp
+  fs.writeFileSync(path.join(p.dir, 'config.json'), JSON.stringify(cfg, null, 2))
+  const ra = regById.get(p.id)
+  ra.metadata = ra.metadata || {}
+  ra.metadata.amp = ra.metadata.amp || {}
+  ra.metadata.amp.fingerprint = fp
+  if (!p.registryHadAddr) { ra.metadata.amp.address = p.correctAddr; ra.metadata.amp.tenant = ra.metadata.amp.tenant || TENANT }
+}
+
+let ok = 0, fail = 0
+for (const p of remintList) {
+  try {
+    const keysDir = path.join(p.dir, 'keys')
+    fs.mkdirSync(keysDir, { recursive: true })
+    const priv = path.join(keysDir, 'private.pem')
+    const pub = path.join(keysDir, 'public.pem')
+    execFileSync('openssl', ['genpkey', '-algorithm', 'ed25519', '-out', priv])   // fresh unique keypair
+    execFileSync('openssl', ['pkey', '-in', priv, '-pubout', '-out', pub])
+    fs.chmodSync(priv, 0o600)
+    writeIdentity(p, fpOfPub(fs.readFileSync(pub)))
+    ok++; console.log(`  ✓ re-mint    ${p.name}`)
+  } catch (e) { fail++; console.log(`  ✗ ${p.name}: ${String(e.message || e).slice(0, 140)}`) }
+}
+for (const p of normalizeList) {
+  try {
+    writeIdentity(p, p.diskFp)   // keep the (already unique) key; align address + registry fp
+    ok++; console.log(`  ✓ normalize  ${p.name}`)
+  } catch (e) { fail++; console.log(`  ✗ ${p.name}: ${String(e.message || e).slice(0, 140)}`) }
+}
+// write registry back atomically
+const tmp = `${REGISTRY}.tmp-${stamp}`
+fs.writeFileSync(tmp, JSON.stringify(registry, null, 2))
+fs.renameSync(tmp, REGISTRY)
+
+console.log(`\nRe-minted: ${ok} ok, ${fail} failed.`)
+console.log('Restart AI Maestro so it reloads the registry, then verify:')
+console.log('  pm2 restart ai-maestro && node scripts/amp-identity-audit.mjs')

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -37,7 +37,7 @@ import os from 'os'
 import { loadAgents, createAgent, getAgent, getAgentByName, getAgentByNameAnyHost, updateAgent, deleteAgent, markAgentAsAMPRegistered, checkMeshAgentExists, getAMPRegisteredAgents } from '@/lib/agent-registry'
 import { authenticateRequest, createApiKey, hashApiKey, extractApiKeyFromHeader, revokeApiKey, rotateApiKey, revokeAllKeysForAgent } from '@/lib/amp-auth'
 import { saveKeyPair, loadKeyPair, calculateFingerprint, verifySignature, generateKeyPair } from '@/lib/amp-keys'
-import { checkKnownKey, recordKnownKey } from '@/lib/amp-known-keys'
+import { checkKnownKey, recordKnownKey, rotateKnownKey } from '@/lib/amp-known-keys'
 import { canonicalStringify } from '@/lib/amp-canonical-json'
 import { queueMessage, getPendingMessages, acknowledgeMessage, acknowledgeMessages, cleanupAllExpiredMessages } from '@/lib/amp-relay'
 import { deliver } from '@/lib/message-delivery'
@@ -1784,6 +1784,15 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
       amp: existingAmpMeta,
     }
   } as any)
+
+  // Keep the Identity Conflict Detection ledger in sync so this AUTHORIZED
+  // rotation (the old key signed the new one — verified above) is not later
+  // flagged as a key-swap. Without this, conflict detection would refuse the
+  // rotated agent's next message (the footgun this closes).
+  const rotatedAddress = (auth.address as string) || (existingAmpMeta.address as string)
+  if (rotatedAddress) {
+    try { rotateKnownKey(rotatedAddress, newKeyPair.fingerprint, new Date().toISOString()) } catch { /* best-effort */ }
+  }
 
   return {
     data: {

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -857,6 +857,12 @@ export async function routeMessage(
       }
     }
 
+    // Strict identity mode: require a valid signature and reject mesh address
+    // spoofing outright. Default OFF for backward compatibility — enable with
+    // AMP_REQUIRE_SIGNATURES=1 once all senders sign. Invalid signatures are
+    // rejected regardless of this flag (see below).
+    const STRICT = process.env.AMP_REQUIRE_SIGNATURES === '1' || process.env.AMP_REQUIRE_SIGNATURES === 'true'
+
     // ── Sender Resolution ──────────────────────────────────────────────
     const isMeshForwarded = !!forwardedFrom && auth.agentId?.startsWith('mesh-')
     const senderAgent = isMeshForwarded ? null : getAgent(auth.agentId!)
@@ -878,7 +884,15 @@ export async function routeMessage(
         const fwdHost = getHostById(forwardedFrom!)
         const expectedHostName = fwdHost?.name || forwardedFrom
         if (senderParsed.tenant !== forwardedFrom && senderParsed.tenant !== expectedHostName) {
-          console.warn(`[AMP Route] Sender address tenant "${senderParsed.tenant}" does not match forwarding host "${forwardedFrom}" -- possible address spoofing`)
+          const spoofMsg = `Sender address tenant "${senderParsed.tenant}" does not match forwarding host "${forwardedFrom}" -- possible address spoofing`
+          if (STRICT) {
+            console.warn(`[AMP Route] REJECTED — ${spoofMsg}`)
+            return {
+              data: { error: 'unauthorized', message: spoofMsg, details: { senderTenant: senderParsed.tenant, forwardingHost: forwardedFrom } },
+              status: 403
+            }
+          }
+          console.warn(`[AMP Route] ${spoofMsg}`)
         }
       }
     }
@@ -914,7 +928,14 @@ export async function routeMessage(
       reply_to: senderAddress,
     }
 
-    // ── Signature Handling ─────────────────────────────────────────────
+    // ── Signature Verification ─────────────────────────────────────────
+    // A signature proves the sender holds the private key for its address. Rules:
+    //  • present + verifiable + INVALID  → REJECT (403). A bad signature is a
+    //    forgery/corruption, never a legit client — never deliver it (was warn-only).
+    //  • present + no local key to check → can't verify; reject in STRICT, else pass.
+    //  • absent                          → reject in STRICT, else pass (Phase-1 default).
+    // Mesh-forwarded messages carry no local keypair; they're gated by the
+    // trusted-host + address-tenant check above, not by this local key check.
     const senderKeyPair = isMeshForwarded ? null : loadKeyPair(auth.agentId!)
 
     if (body.signature) {
@@ -929,14 +950,28 @@ export async function routeMessage(
           body.priority || 'normal', body.in_reply_to || '', payloadHash
         ].join('|')
 
-        const isValid = verifySignature(signatureData, body.signature, senderKeyPair.publicHex)
-        if (!isValid) {
-          console.warn(`[AMP Route] Invalid signature from ${envelope.from}`)
-        } else {
-          console.log(`[AMP Route] Verified signature from ${envelope.from}`)
+        if (!verifySignature(signatureData, body.signature, senderKeyPair.publicHex)) {
+          console.warn(`[AMP Route] REJECTED — invalid signature from ${envelope.from}`)
+          return {
+            data: { error: 'invalid_signature', message: 'Message signature failed verification', details: { from: envelope.from } },
+            status: 403
+          }
+        }
+        console.log(`[AMP Route] Verified signature from ${envelope.from}`)
+      } else if (STRICT && !isMeshForwarded) {
+        console.warn(`[AMP Route] REJECTED — no registered key to verify signature from ${envelope.from}`)
+        return {
+          data: { error: 'invalid_signature', message: 'Cannot verify signature: no registered key for sender', details: { from: envelope.from } },
+          status: 403
         }
       }
       envelope.signature = body.signature
+    } else if (STRICT && !isMeshForwarded) {
+      console.warn(`[AMP Route] REJECTED — unsigned message from ${envelope.from} (AMP_REQUIRE_SIGNATURES enabled)`)
+      return {
+        data: { error: 'invalid_signature', message: 'A valid signature is required', details: { from: envelope.from } },
+        status: 403
+      }
     } else {
       console.log(`[AMP Route] No signature provided by ${envelope.from}`)
     }

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -37,6 +37,7 @@ import os from 'os'
 import { loadAgents, createAgent, getAgent, getAgentByName, getAgentByNameAnyHost, updateAgent, deleteAgent, markAgentAsAMPRegistered, checkMeshAgentExists, getAMPRegisteredAgents } from '@/lib/agent-registry'
 import { authenticateRequest, createApiKey, hashApiKey, extractApiKeyFromHeader, revokeApiKey, rotateApiKey, revokeAllKeysForAgent } from '@/lib/amp-auth'
 import { saveKeyPair, loadKeyPair, calculateFingerprint, verifySignature, generateKeyPair } from '@/lib/amp-keys'
+import { checkKnownKey, recordKnownKey } from '@/lib/amp-known-keys'
 import { canonicalStringify } from '@/lib/amp-canonical-json'
 import { queueMessage, getPendingMessages, acknowledgeMessage, acknowledgeMessages, cleanupAllExpiredMessages } from '@/lib/amp-relay'
 import { deliver } from '@/lib/message-delivery'
@@ -937,6 +938,28 @@ export async function routeMessage(
     // Mesh-forwarded messages carry no local keypair; they're gated by the
     // trusted-host + address-tenant check above, not by this local key check.
     const senderKeyPair = isMeshForwarded ? null : loadKeyPair(auth.agentId!)
+
+    // ── Identity Conflict Detection (AMP 07-security) ──────────────────
+    // The sender's registered key fingerprint must match what we've seen before
+    // for this address (TOFU). An unexplained change is a key-swap / contamination
+    // signal — refuse until resolved. This is the runtime control that would have
+    // caught the fleet-wide shared-key incident.
+    if (senderKeyPair?.publicHex && !isMeshForwarded) {
+      const senderFp = calculateFingerprint(senderKeyPair.publicHex)
+      const conflict = checkKnownKey(senderAddress, senderFp)
+      if (conflict.status === 'conflict') {
+        console.warn(`[AMP Route] REJECTED — key_conflict for ${senderAddress}: known ${conflict.knownFingerprint?.slice(0, 20)}…, presented ${senderFp.slice(0, 20)}…`)
+        return {
+          data: {
+            error: 'key_conflict',
+            message: `Sender ${senderAddress} public key changed from its known fingerprint; resolve the conflict (or rotate with proof) before messaging`,
+            details: { address: senderAddress, knownFingerprint: conflict.knownFingerprint, presentedFingerprint: senderFp }
+          },
+          status: 409
+        }
+      }
+      recordKnownKey(senderAddress, senderFp, now)
+    }
 
     if (body.signature) {
       if (senderKeyPair?.publicHex) {

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -709,6 +709,26 @@ export async function registerAgent(
       ? `${normalizedName}@${body.scope.repo}.${body.scope.platform}.${providerDomain}`
       : `${normalizedName}@${providerDomain}`
 
+    // STRUCTURAL GUARD: an AMP address must belong to exactly one agent. Reject if
+    // a *different* agent already owns it. Together with the duplicate-key check
+    // above, this makes shared identity impossible via the registration path — the
+    // contamination that scripts/amp-identity-audit.mjs was built to catch entered
+    // by copying key files underneath this layer, never through here.
+    const addressOwner = getAMPRegisteredAgents().find((a: any) =>
+      ((a.metadata?.amp?.address as string) || '').toLowerCase() === fullAddress.toLowerCase() &&
+      a.id !== agent.id
+    )
+    if (addressOwner) {
+      return {
+        data: {
+          error: 'address_already_registered',
+          message: `AMP address '${fullAddress}' is already owned by a different agent`,
+          details: { address: fullAddress, ownerId: addressOwner.id }
+        },
+        status: 409
+      }
+    }
+
     markAgentAsAMPRegistered(agent.id, {
       address: fullAddress,
       tenant,

--- a/services/diagnostics-service.ts
+++ b/services/diagnostics-service.ts
@@ -136,6 +136,46 @@ function checkAgentRegistry(): DiagnosticCheck {
   }
 }
 
+// Invariant: every AMP-registered agent must have a UNIQUE cryptographic identity.
+// A shared fingerprint or address means two agents can sign/receive as each other —
+// the contamination bug where a machine keypair was copied into many agent dirs
+// (root-caused in lib/amp-inbox-writer.ts). This runs at every startup so drift can
+// never sit silently again; scripts/amp-identity-audit.mjs is the deep on-disk check.
+function checkAMPIdentityIntegrity(): DiagnosticCheck {
+  try {
+    const agents = loadAgents().filter((a: any) => !a.deletedAt && a.metadata?.amp?.fingerprint)
+    const byFp = new Map<string, string[]>()
+    const byAddr = new Map<string, string[]>()
+    for (const a of agents) {
+      const fp = a.metadata!.amp!.fingerprint as string
+      const addr = (a.metadata!.amp!.address as string) || ''
+      ;(byFp.get(fp) || byFp.set(fp, []).get(fp)!).push(a.name)
+      if (addr) (byAddr.get(addr.toLowerCase()) || byAddr.set(addr.toLowerCase(), []).get(addr.toLowerCase())!).push(a.name)
+    }
+    const sharedFps = [...byFp.entries()].filter(([, n]) => n.length > 1)
+    const sharedAddrs = [...byAddr.entries()].filter(([, n]) => n.length > 1)
+    if (sharedFps.length || sharedAddrs.length) {
+      return {
+        name: 'amp-identity-integrity',
+        status: 'fail',
+        message: `SHARED IDENTITY detected: ${sharedFps.length} key(s) and ${sharedAddrs.length} address(es) reused across agents — run scripts/amp-identity-repair.mjs`,
+        details: {
+          sharedFingerprints: sharedFps.map(([fp, n]) => ({ fingerprint: fp.slice(0, 24), agents: n })),
+          sharedAddresses: sharedAddrs.map(([addr, n]) => ({ address: addr, agents: n })),
+        },
+      }
+    }
+    return {
+      name: 'amp-identity-integrity',
+      status: 'pass',
+      message: `${agents.length} AMP agents, all identities unique`,
+      details: { ampAgents: agents.length },
+    }
+  } catch (error: any) {
+    return { name: 'amp-identity-integrity', status: 'warn', message: `Could not verify: ${error.message}` }
+  }
+}
+
 function checkNodeVersion(): DiagnosticCheck {
   const version = process.version
   const major = parseInt(version.slice(1).split('.')[0], 10)
@@ -287,6 +327,7 @@ export async function runDiagnostics(): Promise<ServiceResult<DiagnosticReport>>
 
   checks.push(tmux, nodePty)
   checks.push(checkAgentRegistry())
+  checks.push(checkAMPIdentityIntegrity())
   checks.push(checkNodeVersion())
   checks.push(diskSpace)
 

--- a/services/service-errors.ts
+++ b/services/service-errors.ts
@@ -40,6 +40,7 @@ export type ServiceErrorCode =
   | 'key_already_registered'
   | 'address_already_registered'
   | 'invalid_signature'
+  | 'key_conflict'
   // Generic codes (12)
   | 'already_exists'
   | 'gone'

--- a/services/service-errors.ts
+++ b/services/service-errors.ts
@@ -38,6 +38,7 @@ export type ServiceErrorCode =
   | 'missing_header'
   | 'duplicate_message'
   | 'key_already_registered'
+  | 'address_already_registered'
   // Generic codes (12)
   | 'already_exists'
   | 'gone'

--- a/services/service-errors.ts
+++ b/services/service-errors.ts
@@ -39,6 +39,7 @@ export type ServiceErrorCode =
   | 'duplicate_message'
   | 'key_already_registered'
   | 'address_already_registered'
+  | 'invalid_signature'
   // Generic codes (12)
   | 'already_exists'
   | 'gone'

--- a/tests/amp-known-keys.test.ts
+++ b/tests/amp-known-keys.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { classifyKey, checkKnownKey, recordKnownKey, rotateKnownKey } from '@/lib/amp-known-keys'
+
+const A = 'alice@acme.aimaestro.local'
+const FP1 = 'SHA256:aaaaaaaaaaaaaaaaaaaa'
+const FP2 = 'SHA256:bbbbbbbbbbbbbbbbbbbb' // a DIFFERENT key — the contamination signature
+const NOW = '2026-08-02T00:00:00Z'
+
+describe('AMP Identity Conflict Detection (amp-known-keys)', () => {
+  let base: string
+  beforeEach(() => { base = fs.mkdtempSync(path.join(os.tmpdir(), 'known-keys-')) })
+  afterEach(() => { fs.rmSync(base, { recursive: true, force: true }) })
+
+  it('classifyKey: first_contact / ok / conflict', () => {
+    expect(classifyKey(undefined, FP1)).toBe('first_contact')
+    expect(classifyKey(FP1, FP1)).toBe('ok')
+    expect(classifyKey(FP1, FP2)).toBe('conflict')
+  })
+
+  it('records on first contact (TOFU) and returns ok on the same key', () => {
+    expect(recordKnownKey(A, FP1, NOW, base)).toBe('first_contact')
+    expect(checkKnownKey(A, FP1, base).status).toBe('ok')
+  })
+
+  it('flags a key swap as a conflict and does NOT overwrite the known key', () => {
+    recordKnownKey(A, FP1, NOW, base)
+    // an agent whose key silently changed to a different one (the contamination)
+    const check = checkKnownKey(A, FP2, base)
+    expect(check.status).toBe('conflict')
+    expect(check.knownFingerprint).toBe(FP1)
+    // recording the conflicting key must be refused (ledger keeps the original)
+    expect(recordKnownKey(A, FP2, NOW, base)).toBe('conflict')
+    expect(checkKnownKey(A, FP1, base).status).toBe('ok')
+  })
+
+  it('address match is case-insensitive', () => {
+    recordKnownKey(A, FP1, NOW, base)
+    expect(checkKnownKey('ALICE@ACME.AIMAESTRO.LOCAL', FP1, base).status).toBe('ok')
+  })
+
+  it('rotateKnownKey updates the ledger (authorized rotation) and preserves firstSeen', () => {
+    recordKnownKey(A, FP1, NOW, base)
+    rotateKnownKey(A, FP2, '2026-08-03T00:00:00Z', base)
+    expect(checkKnownKey(A, FP2, base).status).toBe('ok')   // new key now trusted
+    expect(checkKnownKey(A, FP1, base).status).toBe('conflict') // old key now foreign
+  })
+
+  it('unknown address is first_contact', () => {
+    expect(checkKnownKey('bob@acme.aimaestro.local', FP1, base).status).toBe('first_contact')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.19",
+  "version": "0.36.20",
   "releaseDate": "2026-08-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.16",
+  "version": "0.36.17",
   "releaseDate": "2026-08-01",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.17",
+  "version": "0.36.18",
   "releaseDate": "2026-08-01",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.18",
-  "releaseDate": "2026-08-01",
+  "version": "0.36.19",
+  "releaseDate": "2026-08-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.14",
+  "version": "0.36.15",
   "releaseDate": "2026-07-31",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.15",
-  "releaseDate": "2026-07-31",
+  "version": "0.36.16",
+  "releaseDate": "2026-08-01",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary
Repairs a fleet-wide AMP identity contamination (71 agents shared one keypair; 46 shared one registry fingerprint) and adds structural guards so it cannot recur, plus first-slice AMP-conformance work.

## Root cause
`lib/amp-inbox-writer.ts` copied the host machine keypair/address into each agent dir, bypassing registration. Sealed.

## What's in here
- **Repair + audit**: `scripts/amp-identity-repair.mjs`, `scripts/amp-identity-audit.mjs` (both key stores) — fleet re-minted to unique identities; audit exits clean.
- **Guards**: reject invalid signatures (403 `invalid_signature`); address-uniqueness at registration (409 `address_already_registered`); startup identity-integrity diagnostic; strict federation verification (`AMP_REQUIRE_SIGNATURES`).
- **Identity Conflict Detection** (`lib/amp-known-keys.ts`): key-swap/TOFU ledger wired into `routeMessage` → 409 `key_conflict`; synced with the existing proof-of-possession rotation path so legitimate rotations aren't refused. Atomic ledger writes.

## Verification
818/818 tests pass; build clean; tampered signature → 403 and valid → delivered verified live; audit clean on both key stores.

## Companion protocol work
`agentmessaging/agent-identity` F015 (did:key anchor) and `agentmessaging/protocol` (DID canonical id + attestation seam) — separate PRs.

Related: `marketing/ADR-002` (identity conformance & roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)