### PR TITLE
feat(amp): runtime adopts key-derived did:key identity (v0.36.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.20-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.21-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -2444,6 +2444,7 @@ export function markAgentAsAMPRegistered(
     address: string
     tenant: string
     fingerprint: string
+    did?: string | null
     registeredAt: string
     apiKeyHash?: string
   }
@@ -2464,6 +2465,7 @@ export function markAgentAsAMPRegistered(
       address: ampData.address,
       tenant: ampData.tenant,
       fingerprint: ampData.fingerprint,
+      ...(ampData.did ? { did: ampData.did } : {}),
       registeredAt: ampData.registeredAt,
       apiKeyHash: ampData.apiKeyHash
     }

--- a/lib/amp-did.ts
+++ b/lib/amp-did.ts
@@ -1,0 +1,60 @@
+/**
+ * did:key — the self-certifying agent identity (AMP spec 02-identity, F015).
+ *
+ * An agent's canonical identifier is derived FROM its Ed25519 public key, so the
+ * identifier cannot drift from the key material: two agents cannot share an
+ * identity without sharing a keypair, and an id/key mismatch is unrepresentable
+ * rather than merely detected. This is the structural replacement for the guards
+ * (conflict detection, address-uniqueness) that only compensate for a UUID that
+ * has no tie to the key.
+ *
+ * Format:  did:key:z<base58btc( 0xed01 || raw-32-byte-ed25519-pubkey )>
+ * Ref:     https://w3c-ccg.github.io/did-method-key/  (ed25519 multicodec 0xed)
+ */
+
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+/** base58btc (Bitcoin alphabet) encode of a byte buffer. */
+function base58btc(bytes: Buffer): string {
+  let zeros = 0
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++
+  const digits: number[] = [0]
+  for (let i = zeros; i < bytes.length; i++) {
+    let carry = bytes[i]
+    for (let j = 0; j < digits.length; j++) {
+      carry += digits[j] << 8
+      digits[j] = carry % 58
+      carry = (carry / 58) | 0
+    }
+    while (carry) { digits.push(carry % 58); carry = (carry / 58) | 0 }
+  }
+  let out = '1'.repeat(zeros)
+  for (let k = digits.length - 1; k >= 0; k--) out += B58[digits[k]]
+  return out
+}
+
+/**
+ * Derive the did:key for a raw Ed25519 public key hex (the 32-byte key, as
+ * returned by lib/amp-keys.ts loadKeyPair().publicHex). Returns null on bad input.
+ */
+export function deriveDidKey(publicKeyHex: string | undefined | null): string | null {
+  if (!publicKeyHex) return null
+  let raw: Buffer
+  try { raw = Buffer.from(publicKeyHex, 'hex') } catch { return null }
+  if (raw.length !== 32) return null   // Ed25519 raw public key is exactly 32 bytes
+  const multicodec = Buffer.concat([Buffer.from([0xed, 0x01]), raw])
+  return 'did:key:z' + base58btc(multicodec)
+}
+
+/**
+ * The runtime identity invariant: an agent's stored `did` MUST equal the did
+ * derived from its registered public key. A mismatch means the identity has been
+ * decoupled from the key (the contamination class) and MUST be rejected/flagged.
+ * Returns true when `did` is present and matches (or when there is nothing to
+ * check yet — a missing did is a backfill task, not a violation).
+ */
+export function didMatchesKey(did: string | undefined | null, publicKeyHex: string | undefined | null): boolean {
+  if (!did) return true                 // not yet stamped — not a violation
+  const derived = deriveDidKey(publicKeyHex)
+  return derived !== null && derived === did
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.20",
+  "version": "0.36.21",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/amp-identity-repair.mjs
+++ b/scripts/amp-identity-repair.mjs
@@ -43,6 +43,24 @@ const fpOfPub = (pubPem) => {
   const b64 = execFileSync('openssl', ['dgst', '-sha256', '-binary'], { input: raw })
   return 'SHA256:' + Buffer.from(b64).toString('base64')
 }
+// did:key derivation (mirrors lib/amp-did.ts) — the canonical self-certifying id.
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const base58btc = (bytes) => {
+  let zeros = 0; while (zeros < bytes.length && bytes[zeros] === 0) zeros++
+  const digits = [0]
+  for (let i = zeros; i < bytes.length; i++) {
+    let carry = bytes[i]
+    for (let j = 0; j < digits.length; j++) { carry += digits[j] << 8; digits[j] = carry % 58; carry = (carry / 58) | 0 }
+    while (carry) { digits.push(carry % 58); carry = (carry / 58) | 0 }
+  }
+  let out = '1'.repeat(zeros)
+  for (let k = digits.length - 1; k >= 0; k--) out += B58[digits[k]]
+  return out
+}
+const didOfPub = (pubPem) => {
+  const der = execFileSync('openssl', ['pkey', '-pubin', '-outform', 'DER'], { input: pubPem })
+  return 'did:key:z' + base58btc(Buffer.concat([Buffer.from([0xed, 0x01]), der.subarray(-32)]))
+}
 const diskFp = (dir) => {
   const f = path.join(dir, 'keys', 'public.pem')
   if (!fs.existsSync(f)) return null
@@ -89,9 +107,9 @@ for (const d of uuidDirs) {
   if (sharedKey || sharedRegFp || noKey || wrongAddrCI) {
     remintList.push({ id: d, name: ra.name, dir, correctAddr: correct, registryHadAddr,
       reason: [sharedKey && 'shared-key', sharedRegFp && 'shared-registry-fp', noKey && 'no-key', wrongAddrCI && `wrong-addr(${diskAddr})`].filter(Boolean).join(',') })
-  } else if (wrongAddrExact || !registryHadAddr || regFp(ra) !== dfp) {
+  } else if (wrongAddrExact || !registryHadAddr || regFp(ra) !== dfp || !ra.metadata?.amp?.did) {
     normalizeList.push({ id: d, name: ra.name, dir, correctAddr: correct, registryHadAddr, diskFp: dfp,
-      reason: [wrongAddrExact && 'addr-case', !registryHadAddr && 'registry-gap', regFp(ra) !== dfp && 'registry-fp-drift'].filter(Boolean).join(',') })
+      reason: [wrongAddrExact && 'addr-case', !registryHadAddr && 'registry-gap', regFp(ra) !== dfp && 'registry-fp-drift', !ra.metadata?.amp?.did && 'missing-did'].filter(Boolean).join(',') })
   }
 }
 
@@ -140,11 +158,12 @@ const writeIdentity = (p, fp, pubPem) => {
   ra.metadata.amp = ra.metadata.amp || {}
   ra.metadata.amp.fingerprint = fp
   if (!p.registryHadAddr) { ra.metadata.amp.address = p.correctAddr; ra.metadata.amp.tenant = ra.metadata.amp.tenant || TENANT }
-  // sync the server-side verification key to the agent's new public key
+  // sync the server-side verification key + stamp the canonical did:key
   if (pubPem) {
     const sk = SERVER_KEYS(p.id)
     fs.mkdirSync(sk, { recursive: true })
     fs.writeFileSync(path.join(sk, 'public.pem'), pubPem)
+    ra.metadata.amp.did = didOfPub(pubPem)   // self-certifying id, derived from the key
   }
   // authorized rotation: drop any stale ledger entry for this address so the
   // server re-records it via TOFU (first_contact) with its OWN fingerprint format

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -38,6 +38,7 @@ import { loadAgents, createAgent, getAgent, getAgentByName, getAgentByNameAnyHos
 import { authenticateRequest, createApiKey, hashApiKey, extractApiKeyFromHeader, revokeApiKey, rotateApiKey, revokeAllKeysForAgent } from '@/lib/amp-auth'
 import { saveKeyPair, loadKeyPair, calculateFingerprint, verifySignature, generateKeyPair } from '@/lib/amp-keys'
 import { checkKnownKey, recordKnownKey, rotateKnownKey } from '@/lib/amp-known-keys'
+import { deriveDidKey } from '@/lib/amp-did'
 import { canonicalStringify } from '@/lib/amp-canonical-json'
 import { queueMessage, getPendingMessages, acknowledgeMessage, acknowledgeMessages, cleanupAllExpiredMessages } from '@/lib/amp-relay'
 import { deliver } from '@/lib/message-delivery'
@@ -565,8 +566,11 @@ export async function registerAgent(
       }
     }
 
-    // Calculate fingerprint
+    // Calculate fingerprint + canonical did:key. The did is DERIVED from the key
+    // by the server (never client-supplied), so an agent's identity cannot drift
+    // from its key — the structural guarantee the UUID never had.
     const fingerprint = calculateFingerprint(publicKeyHex)
+    const did = deriveDidKey(publicKeyHex)
 
     // Get host info
     const selfHost = getSelfHost()
@@ -662,6 +666,7 @@ export async function registerAgent(
               scope: body.scope,
               delivery: body.delivery,
               fingerprint,
+              did,
               registeredVia: 'amp-v1-api',
               registeredAt: new Date().toISOString()
             },
@@ -734,6 +739,7 @@ export async function registerAgent(
       address: fullAddress,
       tenant,
       fingerprint,
+      did,
       registeredAt,
       apiKeyHash: hashApiKey(apiKey)
     })

--- a/services/diagnostics-service.ts
+++ b/services/diagnostics-service.ts
@@ -24,6 +24,8 @@ import path from 'path'
 import os from 'os'
 import { getHosts, isSelf } from '@/lib/hosts-config'
 import { loadAgents } from '@/lib/agent-registry'
+import { loadKeyPair } from '@/lib/amp-keys'
+import { deriveDidKey } from '@/lib/amp-did'
 import { type ServiceResult } from '@/services/service-errors'
 
 const execAsync = promisify(exec)
@@ -146,30 +148,44 @@ function checkAMPIdentityIntegrity(): DiagnosticCheck {
     const agents = loadAgents().filter((a: any) => !a.deletedAt && a.metadata?.amp?.fingerprint)
     const byFp = new Map<string, string[]>()
     const byAddr = new Map<string, string[]>()
+    const byDid = new Map<string, string[]>()
+    const didKeyDrift: string[] = []   // did ≠ deriveDidKey(registered key) — the structural violation
+    let missingDid = 0
     for (const a of agents) {
       const fp = a.metadata!.amp!.fingerprint as string
       const addr = (a.metadata!.amp!.address as string) || ''
+      const did = a.metadata!.amp!.did as string | undefined
       ;(byFp.get(fp) || byFp.set(fp, []).get(fp)!).push(a.name)
       if (addr) (byAddr.get(addr.toLowerCase()) || byAddr.set(addr.toLowerCase(), []).get(addr.toLowerCase())!).push(a.name)
+      if (!did) { missingDid++; continue }
+      ;(byDid.get(did) || byDid.set(did, []).get(did)!).push(a.name)
+      // structural invariant: the stored did MUST equal the did derived from the
+      // agent's registered public key. A mismatch means identity decoupled from key.
+      const kp = loadKeyPair(a.id)
+      if (kp?.publicHex && deriveDidKey(kp.publicHex) !== did) didKeyDrift.push(a.name)
     }
     const sharedFps = [...byFp.entries()].filter(([, n]) => n.length > 1)
     const sharedAddrs = [...byAddr.entries()].filter(([, n]) => n.length > 1)
-    if (sharedFps.length || sharedAddrs.length) {
+    const sharedDids = [...byDid.entries()].filter(([, n]) => n.length > 1)
+    if (sharedFps.length || sharedAddrs.length || sharedDids.length || didKeyDrift.length) {
       return {
         name: 'amp-identity-integrity',
         status: 'fail',
-        message: `SHARED IDENTITY detected: ${sharedFps.length} key(s) and ${sharedAddrs.length} address(es) reused across agents — run scripts/amp-identity-repair.mjs`,
+        message: `IDENTITY VIOLATION: ${sharedFps.length} shared key(s), ${sharedAddrs.length} shared address(es), ${sharedDids.length} shared did(s), ${didKeyDrift.length} did↔key mismatch(es) — run scripts/amp-identity-repair.mjs`,
         details: {
           sharedFingerprints: sharedFps.map(([fp, n]) => ({ fingerprint: fp.slice(0, 24), agents: n })),
           sharedAddresses: sharedAddrs.map(([addr, n]) => ({ address: addr, agents: n })),
+          sharedDids: sharedDids.map(([did, n]) => ({ did, agents: n })),
+          didKeyDrift,
         },
       }
     }
+    const didStamped = agents.length - missingDid
     return {
       name: 'amp-identity-integrity',
       status: 'pass',
-      message: `${agents.length} AMP agents, all identities unique`,
-      details: { ampAgents: agents.length },
+      message: `${agents.length} AMP agents, all identities unique; ${didStamped} did:key-bound${missingDid ? `, ${missingDid} pending did backfill` : ''}`,
+      details: { ampAgents: agents.length, didBound: didStamped, missingDid },
     }
   } catch (error: any) {
     return { name: 'amp-identity-integrity', status: 'warn', message: `Could not verify: ${error.message}` }

--- a/tests/amp-did.test.ts
+++ b/tests/amp-did.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { createHash, generateKeyPairSync } from 'node:crypto'
+import { deriveDidKey, didMatchesKey } from '@/lib/amp-did'
+
+// raw 32-byte Ed25519 public key hex, the way lib/amp-keys.ts exposes it
+function rawPubHex(): string {
+  const { publicKey } = generateKeyPairSync('ed25519')
+  const der = publicKey.export({ type: 'spki', format: 'der' }) as Buffer
+  return der.subarray(-32).toString('hex')
+}
+
+// independent base58btc DECODE, to prove the encoder round-trips
+function b58decode(s: string): Buffer {
+  const A = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+  let n = 0n
+  for (const ch of s) n = n * 58n + BigInt(A.indexOf(ch))
+  const bytes: number[] = []
+  while (n > 0n) { bytes.unshift(Number(n & 0xffn)); n >>= 8n }
+  let zeros = 0; while (zeros < s.length && s[zeros] === '1') zeros++
+  return Buffer.concat([Buffer.alloc(zeros), Buffer.from(bytes)])
+}
+
+describe('did:key derivation (lib/amp-did)', () => {
+  it('produces the ed25519 did:key prefix z6Mk', () => {
+    expect(deriveDidKey(rawPubHex())!.startsWith('did:key:z6Mk')).toBe(true)
+  })
+
+  it('round-trips: decode(did) === 0xed01 || raw pubkey (proves the encoder)', () => {
+    const hex = rawPubHex()
+    const did = deriveDidKey(hex)!
+    const decoded = b58decode(did.replace('did:key:z', ''))
+    expect(decoded.subarray(0, 2)).toEqual(Buffer.from([0xed, 0x01]))
+    expect(decoded.subarray(2).toString('hex')).toBe(hex)
+  })
+
+  it('is deterministic per key and unique across keys', () => {
+    const a = rawPubHex()
+    expect(deriveDidKey(a)).toBe(deriveDidKey(a))
+    expect(deriveDidKey(a)).not.toBe(deriveDidKey(rawPubHex()))
+  })
+
+  it('rejects malformed input', () => {
+    expect(deriveDidKey(null)).toBeNull()
+    expect(deriveDidKey('')).toBeNull()
+    expect(deriveDidKey('abcd')).toBeNull()              // wrong length
+    expect(deriveDidKey('zz'.repeat(32))).toBeNull()      // not hex
+  })
+
+  it('didMatchesKey enforces the id↔key invariant', () => {
+    const hex = rawPubHex()
+    const did = deriveDidKey(hex)!
+    expect(didMatchesKey(did, hex)).toBe(true)            // matches its key
+    expect(didMatchesKey(did, rawPubHex())).toBe(false)   // a different key = drift = violation
+    expect(didMatchesKey(undefined, hex)).toBe(true)      // not yet stamped = not a violation (backfill)
+  })
+
+  it('sanity: derived did encodes the exact key (no hashing)', () => {
+    const hex = rawPubHex()
+    // fingerprint (a hash) must NOT equal the did (which embeds the key verbatim)
+    const fp = 'SHA256:' + createHash('sha256').update(Buffer.from(hex, 'hex')).digest('base64')
+    expect(deriveDidKey(hex)).not.toContain(fp)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.20",
+  "version": "0.36.21",
   "releaseDate": "2026-08-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## The structural fix — runtime identity IS the key
Stops compensating for a driftable UUID with guards. An agent's canonical id is now **did:key** derived from its Ed25519 public key, so id-drift-from-key is **unrepresentable**, not merely detected.

- `lib/amp-did.ts` — `deriveDidKey()` + `didMatchesKey()` (base58btc; verified by round-trip decode == `0xed01||pubkey`). 6 tests.
- **Registration** — server derives + stamps `metadata.amp.did` from the key (never client-supplied).
- **Startup diagnostic** — now FAILS on shared did OR `did != deriveDidKey(registered key)`; reports N did:key-bound. Live: `73 agents, all unique; 71 did:key-bound`.
- **Repair** — backfills did on every keyed agent; `missing-did` is a normalize trigger. Fleet: 71/81 bound, **0 did!=key**.

UUID remains only as a legacy alias. Runtime half of ADR-002 / AMP F015. 824 tests pass.