### PR TITLE
feat(amp): did:key on the wire + 100% DID coverage + node guard (v0.36.22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.21-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.22-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/types/amp.ts
+++ b/lib/types/amp.ts
@@ -117,6 +117,11 @@ export interface AMPEnvelope {
   /** Sender's AMP address: name@tenant.provider */
   from: string
 
+  /** Sender's canonical self-certifying identity (did:key), derived from its
+   *  public key. Lets the recipient bind the message to the sender's key-identity
+   *  independently of the mutable address. */
+  from_did?: string | null
+
   /** Recipient's AMP address: name@tenant.provider */
   to: string
 
@@ -572,6 +577,8 @@ export interface AMPAgentResolveResponse {
   public_key: string
   key_algorithm: 'Ed25519' | 'RSA' | 'ECDSA'
   fingerprint: string
+  /** Canonical self-certifying identity (did:key) derived from public_key. */
+  did?: string | null
   online: boolean
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.21",
+  "version": "0.36.22",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/amp-identity-repair.mjs
+++ b/scripts/amp-identity-repair.mjs
@@ -188,11 +188,29 @@ for (const p of remintList) {
 }
 for (const p of normalizeList) {
   try {
-    const pubPem = fs.existsSync(path.join(p.dir, 'keys', 'public.pem')) ? fs.readFileSync(path.join(p.dir, 'keys', 'public.pem')) : null
-    writeIdentity(p, p.diskFp, pubPem)   // keep the (already unique) key; align address + registry + server key
+    // prefer the client signing key; fall back to the server verify-key so agents
+    // that have a registered key but no local client key still get a fingerprint + did
+    const clientPub = path.join(p.dir, 'keys', 'public.pem')
+    const serverPub = path.join(SERVER_KEYS(p.id), 'public.pem')
+    const pubPem = fs.existsSync(clientPub) ? fs.readFileSync(clientPub)
+                 : (fs.existsSync(serverPub) ? fs.readFileSync(serverPub) : null)
+    const fp = pubPem ? fpOfPub(pubPem) : p.diskFp   // fp from the actual key we found
+    writeIdentity(p, fp, pubPem)   // align address + registry fp + server key + did
     ok++; console.log(`  ✓ normalize  ${p.name}`)
   } catch (e) { fail++; console.log(`  ✗ ${p.name}: ${String(e.message || e).slice(0, 140)}`) }
 }
+// Registry-based did backfill: catch agents that have a registered key but no
+// client AMP dir (system/test agents) — the dir-based loops above never see them.
+for (const ra of registry) {
+  if (ra?.metadata?.amp?.fingerprint && !ra?.metadata?.amp?.did) {
+    const sp = path.join(SERVER_KEYS(ra.id), 'public.pem')
+    if (fs.existsSync(sp)) {
+      try { ra.metadata.amp.did = didOfPub(fs.readFileSync(sp)); ok++; console.log(`  ✓ did-backfill ${ra.name}`) }
+      catch (e) { console.log(`  ✗ did-backfill ${ra.name}: ${String(e.message || e).slice(0, 80)}`) }
+    }
+  }
+}
+
 // write registry back atomically
 const tmp = `${REGISTRY}.tmp-${stamp}`
 fs.writeFileSync(tmp, JSON.stringify(registry, null, 2))

--- a/scripts/start-with-ssh.sh
+++ b/scripts/start-with-ssh.sh
@@ -30,6 +30,18 @@ else
     echo "[AI Maestro] ℹ Tmux server not running (will use correct config when started)"
 fi
 
+# Step 3b: Ensure Node >= 18 (the claude-agent-sdk crash-loops on older node).
+# No-op where the ambient node is already >= 18; only reaches for nvm if it's too old.
+NODE_MAJOR=$(node -v 2>/dev/null | sed 's/v\([0-9]*\).*/\1/')
+if [ -z "$NODE_MAJOR" ] || [ "$NODE_MAJOR" -lt 18 ] 2>/dev/null; then
+    if [ -s "$HOME/.nvm/nvm.sh" ]; then
+        echo "[AI Maestro] Node $(node -v 2>/dev/null || echo missing) too old — switching to nvm default/LTS"
+        . "$HOME/.nvm/nvm.sh"
+        nvm use default >/dev/null 2>&1 || nvm use --lts >/dev/null 2>&1 || nvm use node >/dev/null 2>&1
+    fi
+fi
+echo "[AI Maestro] Node: $(node -v 2>/dev/null || echo missing)"
+
 # Step 4: Start the actual server
 echo "[AI Maestro] Starting server..."
 exec ./node_modules/.bin/tsx server.mjs

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -924,6 +924,7 @@ export async function routeMessage(
       version: 'amp/0.1',
       id: messageId,
       from: senderAddress,
+      from_did: (senderAgent?.metadata?.amp?.did as string) || null,
       to: body.to,
       subject: body.subject,
       priority: body.priority || 'normal',
@@ -1621,6 +1622,7 @@ export function resolveAgentAddress(
         public_key: keyPair?.publicPem || '',
         key_algorithm: 'Ed25519',
         fingerprint: keyPair?.fingerprint || (byAddress.metadata?.amp?.fingerprint as string) || '',
+        did: deriveDidKey(keyPair?.publicHex) || (byAddress.metadata?.amp?.did as string) || null,
         online: byAddress.sessions?.some((s: any) => s.status === 'online') || false,
       } as AMPAgentResolveResponse,
       status: 200
@@ -1637,6 +1639,7 @@ export function resolveAgentAddress(
       public_key: keyPair?.publicPem || '',
       key_algorithm: 'Ed25519',
       fingerprint: keyPair?.fingerprint || (agent.metadata?.amp?.fingerprint as string) || '',
+      did: deriveDidKey(keyPair?.publicHex) || (agent.metadata?.amp?.did as string) || null,
       online: agent.sessions?.some((s: any) => s.status === 'online') || false,
     } as AMPAgentResolveResponse,
     status: 200

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.21",
+  "version": "0.36.22",
   "releaseDate": "2026-08-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Exposes did:key in the resolve endpoint and message envelope (from_did); backfills the last keyless agents via server-key fallback (73/73 did:key-bound); and hardens start-with-ssh.sh so an old ambient node switches to nvm's node>=18 (fixes mac-mini reboot crash-loop, no-op elsewhere). 824 tests pass; resolve did verified live.