### PR TITLE
feat(amp): key revocation + replay protection + Agent Card did (v0.36.23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.22-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.23-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/amp-replay.ts
+++ b/lib/amp-replay.ts
@@ -1,0 +1,64 @@
+/**
+ * AMP replay protection (AMP spec 07-security §Replay Protection).
+ *
+ * Recipients MUST reject re-sent captured messages: track seen message IDs
+ * (>= 24h), reject timestamps older than 5 minutes (unless retrieved from a relay
+ * queue) and more than 60 seconds in the future (clock-skew tolerance).
+ *
+ * Locally-originated messages routed via /route are already replay-safe because
+ * the server assigns a fresh id + timestamp. This guard matters on the FEDERATION
+ * deliver path, where a message arrives with its original id + timestamp.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const STALE_MS = 5 * 60 * 1000      // 5 minutes
+const FUTURE_MS = 60 * 1000         // 60 seconds clock-skew tolerance
+const RETAIN_MS = 24 * 60 * 60 * 1000 // seen-id retention
+
+export type ReplayReason = 'duplicate_message' | 'timestamp_expired' | 'timestamp_future'
+export interface ReplayResult { ok: boolean; reason?: ReplayReason }
+type Seen = Record<string, number>   // messageId -> firstSeenMs
+
+function seenPath(base?: string): string {
+  const root = base || process.env.AIMAESTRO_REPLAY_DIR || path.join(os.homedir(), '.aimaestro', 'amp')
+  return path.join(root, 'seen-messages.json')
+}
+function load(base?: string): Seen {
+  try { return JSON.parse(fs.readFileSync(seenPath(base), 'utf8')) } catch { return {} }
+}
+let saveSeq = 0
+function save(s: Seen, base?: string): void {
+  const p = seenPath(base)
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  const tmp = `${p}.tmp-${process.pid}-${saveSeq++}`
+  fs.writeFileSync(tmp, JSON.stringify(s, null, 2))
+  fs.renameSync(tmp, p)
+}
+
+/**
+ * Check a message for replay and record its id if fresh. `nowMs` and `base` are
+ * injectable for tests. Returns {ok:false, reason} to reject, {ok:true} to accept.
+ */
+export function checkReplay(
+  messageId: string, timestampIso: string, opts: { fromRelay?: boolean; nowMs: number; base?: string }
+): ReplayResult {
+  const { fromRelay = false, nowMs, base } = opts
+  const seen = load(base)
+  // prune expired seen ids
+  for (const [id, t] of Object.entries(seen)) if (nowMs - t > RETAIN_MS) delete seen[id]
+
+  if (messageId && seen[messageId] !== undefined) return { ok: false, reason: 'duplicate_message' }
+
+  if (!fromRelay && timestampIso) {
+    const ts = Date.parse(timestampIso)
+    if (!Number.isNaN(ts)) {
+      if (nowMs - ts > STALE_MS) return { ok: false, reason: 'timestamp_expired' }
+      if (ts - nowMs > FUTURE_MS) return { ok: false, reason: 'timestamp_future' }
+    }
+  }
+
+  if (messageId) { seen[messageId] = nowMs; save(seen, base) }
+  return { ok: true }
+}

--- a/lib/amp-revocation.ts
+++ b/lib/amp-revocation.ts
@@ -1,0 +1,71 @@
+/**
+ * AMP key revocation list (AMP spec 07-security §Key Revocation).
+ *
+ * Providers MUST maintain a revocation list of public-key fingerprints and MUST
+ * reject messages signed with a revoked key (`key_revoked`, HTTP 403). A key is
+ * revoked when it is rotated (superseded) or explicitly revoked on compromise.
+ * Entries are retained for at least 90 days. Together with rotation-with-proof
+ * (rotateKeypair) this makes a compromised key actually killable — the missing
+ * half of the rotation story.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export type RevocationReason = 'key_compromise' | 'key_rotation' | 'agent_deregistered' | 'admin_action'
+export interface RevocationEntry {
+  fingerprint: string
+  agent_address: string
+  revoked_at: string
+  reason: RevocationReason
+  superseded_by: string | null
+}
+type List = Record<string, RevocationEntry>
+
+const RETENTION_MS = 90 * 24 * 60 * 60 * 1000   // spec: >= 90 days
+
+function listPath(base?: string): string {
+  const root = base || process.env.AIMAESTRO_REVOCATION_DIR || path.join(os.homedir(), '.aimaestro', 'amp')
+  return path.join(root, 'revoked-keys.json')
+}
+function load(base?: string): List {
+  try { return JSON.parse(fs.readFileSync(listPath(base), 'utf8')) } catch { return {} }
+}
+let saveSeq = 0
+function save(l: List, base?: string): void {
+  const p = listPath(base)
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  const tmp = `${p}.tmp-${process.pid}-${saveSeq++}`
+  fs.writeFileSync(tmp, JSON.stringify(l, null, 2))
+  fs.renameSync(tmp, p)
+}
+
+/** Prune entries older than the retention window. Returns the pruned list. */
+function prune(l: List, nowMs: number): List {
+  for (const [fp, e] of Object.entries(l)) {
+    if (nowMs - Date.parse(e.revoked_at) > RETENTION_MS) delete l[fp]
+  }
+  return l
+}
+
+/** Add a fingerprint to the revocation list. `now`/`base` injectable for tests. */
+export function revokeFingerprint(
+  fingerprint: string, agentAddress: string, reason: RevocationReason,
+  supersededBy: string | null, now: string, base?: string
+): void {
+  if (!fingerprint) return
+  const l = prune(load(base), Date.parse(now))
+  l[fingerprint] = { fingerprint, agent_address: agentAddress, revoked_at: now, reason, superseded_by: supersededBy }
+  save(l, base)
+}
+
+/** Is this fingerprint revoked? Checked at route + federation-deliver time. */
+export function isRevoked(fingerprint: string | undefined | null, base?: string): boolean {
+  if (!fingerprint) return false
+  return !!load(base)[fingerprint]
+}
+
+/** The current revocation list (for the API / federation propagation). */
+export function getRevocationList(base?: string): RevocationEntry[] {
+  return Object.values(load(base))
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.22",
+  "version": "0.36.23",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -39,6 +39,8 @@ import { authenticateRequest, createApiKey, hashApiKey, extractApiKeyFromHeader,
 import { saveKeyPair, loadKeyPair, calculateFingerprint, verifySignature, generateKeyPair } from '@/lib/amp-keys'
 import { checkKnownKey, recordKnownKey, rotateKnownKey } from '@/lib/amp-known-keys'
 import { deriveDidKey } from '@/lib/amp-did'
+import { revokeFingerprint, isRevoked } from '@/lib/amp-revocation'
+import { checkReplay } from '@/lib/amp-replay'
 import { canonicalStringify } from '@/lib/amp-canonical-json'
 import { queueMessage, getPendingMessages, acknowledgeMessage, acknowledgeMessages, cleanupAllExpiredMessages } from '@/lib/amp-relay'
 import { deliver } from '@/lib/message-delivery'
@@ -953,6 +955,15 @@ export async function routeMessage(
     // caught the fleet-wide shared-key incident.
     if (senderKeyPair?.publicHex && !isMeshForwarded) {
       const senderFp = calculateFingerprint(senderKeyPair.publicHex)
+      // Revoked-key check (AMP 07-security §Key Revocation) — a rotated/compromised
+      // key is dead even if the signature would otherwise verify.
+      if (isRevoked(senderFp)) {
+        console.warn(`[AMP Route] REJECTED — key_revoked for ${senderAddress}: ${senderFp.slice(0, 20)}…`)
+        return {
+          data: { error: 'key_revoked', message: 'Message signed with a revoked key', details: { fingerprint: senderFp } },
+          status: 403
+        }
+      }
       const conflict = checkKnownKey(senderAddress, senderFp)
       if (conflict.status === 'conflict') {
         console.warn(`[AMP Route] REJECTED — key_conflict for ${senderAddress}: known ${conflict.knownFingerprint?.slice(0, 20)}…, presented ${senderFp.slice(0, 20)}…`)
@@ -1456,30 +1467,37 @@ export function getAgentCard(authHeader: string | null): ServiceResult<any> {
   const address = auth.address || `${agent.name}@${getAMPProviderDomain(getOrganization() || undefined)}`
   const signedAt = new Date().toISOString()
 
-  // Build the card
+  // Build the card. `did` is the canonical self-certifying id (derived from the
+  // public key); address/fingerprint remain for compatibility.
   const card: Record<string, unknown> = {
+    did: deriveDidKey(keyPair.publicHex),
     address,
     name: agent.name,
     alias: agent.alias || agent.label || null,
     public_key: keyPair.publicPem,
+    key_algorithm: 'Ed25519',
     fingerprint: keyPair.fingerprint,
     provider: getAMPProviderDomain(getOrganization() || undefined),
     capabilities: ['messaging', 'read_receipts'],
     signed_at: signedAt,
   }
 
-  // Sign: address|public_key_pem|signed_at
-  try {
-    const signable = `${address}|${keyPair.publicPem}|${signedAt}`
-    const privateKey = crypto.createPrivateKey(keyPair.privatePem)
-    const signature = crypto.sign(null, Buffer.from(signable), privateKey)
-    card.signature = signature.toString('base64')
-  } catch (err) {
-    console.error('[AMP] Failed to sign agent card:', err)
-    return {
-      data: { error: 'internal_error', message: 'Failed to sign card' },
-      status: 500
+  // The server holds only the agent's PUBLIC key (private keys never leave the
+  // agent — the core custody rule), so it cannot sign the card. Return it UNSIGNED
+  // and provider-asserted over the authenticated channel; a cryptographically
+  // signed card is generated client-side where the private key lives.
+  if (keyPair.privatePem && keyPair.privatePem.trim()) {
+    try {
+      const signable = `${address}|${keyPair.publicPem}|${signedAt}`
+      const privateKey = crypto.createPrivateKey(keyPair.privatePem)
+      card.signature = crypto.sign(null, Buffer.from(signable), privateKey).toString('base64')
+    } catch (err) {
+      console.warn('[AMP] Agent card returned unsigned (signing failed):', err)
+      card.signature = null
     }
+  } else {
+    card.signature = null
+    card.provider_asserted = true   // authenticity relies on the authenticated channel, not a card signature
   }
 
   return { data: card, status: 200 }
@@ -1786,6 +1804,7 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
 
   // Update agent metadata with new fingerprint
   const existingAmpMeta = (agent.metadata?.amp || {}) as Record<string, unknown>
+  const oldFp = (existingAmpMeta.fingerprint as string) || ''   // capture BEFORE overwrite (for revocation)
   existingAmpMeta.fingerprint = newKeyPair.fingerprint
   updateAgent(auth.agentId!, {
     metadata: {
@@ -1799,8 +1818,14 @@ export async function rotateKeypair(body: AMPKeypairRotationRequest | null, auth
   // flagged as a key-swap. Without this, conflict detection would refuse the
   // rotated agent's next message (the footgun this closes).
   const rotatedAddress = (auth.address as string) || (existingAmpMeta.address as string)
+  const rotNow = new Date().toISOString()
   if (rotatedAddress) {
-    try { rotateKnownKey(rotatedAddress, newKeyPair.fingerprint, new Date().toISOString()) } catch { /* best-effort */ }
+    try { rotateKnownKey(rotatedAddress, newKeyPair.fingerprint, rotNow) } catch { /* best-effort */ }
+  }
+  // Revoke the superseded key (AMP 07-security §Key Revocation): the old fingerprint
+  // is added to the revocation list so messages signed with it are rejected.
+  if (oldFp && oldFp !== newKeyPair.fingerprint) {
+    try { revokeFingerprint(oldFp, rotatedAddress || '', 'key_rotation', newKeyPair.fingerprint, rotNow) } catch { /* best-effort */ }
   }
 
   return {
@@ -1852,11 +1877,12 @@ export async function deliverFederated(
       }
     }
 
-    // ── Replay Protection ───────────────────────────────────────────────
-    if (!trackMessageId(envelope.id)) {
+    // ── Replay Protection (AMP 07-security): dedup by id + timestamp freshness ──
+    const replay = checkReplay(envelope.id, envelope.timestamp, { nowMs: Date.now() })
+    if (!replay.ok) {
       return {
-        data: { error: 'duplicate_message', message: `Message ${envelope.id} has already been delivered` },
-        status: 409
+        data: { error: replay.reason!, message: `Replay rejected: ${replay.reason}` },
+        status: replay.reason === 'duplicate_message' ? 409 : 400
       }
     }
 

--- a/services/service-errors.ts
+++ b/services/service-errors.ts
@@ -41,6 +41,9 @@ export type ServiceErrorCode =
   | 'address_already_registered'
   | 'invalid_signature'
   | 'key_conflict'
+  | 'key_revoked'
+  | 'timestamp_expired'
+  | 'timestamp_future'
   // Generic codes (12)
   | 'already_exists'
   | 'gone'

--- a/tests/amp-replay.test.ts
+++ b/tests/amp-replay.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { checkReplay } from '@/lib/amp-replay'
+
+const NOW = Date.parse('2026-08-03T12:00:00Z')
+
+describe('AMP replay protection (amp-replay)', () => {
+  let base: string
+  beforeEach(() => { base = fs.mkdtempSync(path.join(os.tmpdir(), 'replay-')) })
+  afterEach(() => { fs.rmSync(base, { recursive: true, force: true }) })
+
+  const iso = (ms: number) => new Date(ms).toISOString()
+
+  it('accepts a fresh, unseen message', () => {
+    expect(checkReplay('msg_1', iso(NOW), { nowMs: NOW, base })).toEqual({ ok: true })
+  })
+
+  it('rejects a duplicate message id', () => {
+    checkReplay('msg_1', iso(NOW), { nowMs: NOW, base })
+    expect(checkReplay('msg_1', iso(NOW), { nowMs: NOW, base })).toEqual({ ok: false, reason: 'duplicate_message' })
+  })
+
+  it('rejects a stale timestamp (> 5 min old)', () => {
+    expect(checkReplay('msg_2', iso(NOW - 6 * 60 * 1000), { nowMs: NOW, base }))
+      .toEqual({ ok: false, reason: 'timestamp_expired' })
+  })
+
+  it('rejects a future timestamp (> 60s ahead)', () => {
+    expect(checkReplay('msg_3', iso(NOW + 90 * 1000), { nowMs: NOW, base }))
+      .toEqual({ ok: false, reason: 'timestamp_future' })
+  })
+
+  it('allows a stale timestamp when retrieved from a relay queue', () => {
+    expect(checkReplay('msg_4', iso(NOW - 60 * 60 * 1000), { nowMs: NOW, fromRelay: true, base }))
+      .toEqual({ ok: true })
+  })
+
+  it('tolerates small clock skew (30s future)', () => {
+    expect(checkReplay('msg_5', iso(NOW + 30 * 1000), { nowMs: NOW, base })).toEqual({ ok: true })
+  })
+})

--- a/tests/amp-revocation.test.ts
+++ b/tests/amp-revocation.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { revokeFingerprint, isRevoked, getRevocationList } from '@/lib/amp-revocation'
+
+const FP = 'SHA256:oldkeyfingerprint000'
+const NEW = 'SHA256:newkeyfingerprint000'
+const ADDR = 'alice@acme.aimaestro.local'
+const NOW = '2026-08-03T00:00:00Z'
+
+describe('AMP key revocation list (amp-revocation)', () => {
+  let base: string
+  beforeEach(() => { base = fs.mkdtempSync(path.join(os.tmpdir(), 'revoke-')) })
+  afterEach(() => { fs.rmSync(base, { recursive: true, force: true }) })
+
+  it('a key is not revoked until it is added', () => {
+    expect(isRevoked(FP, base)).toBe(false)
+  })
+
+  it('revoking a fingerprint makes isRevoked true', () => {
+    revokeFingerprint(FP, ADDR, 'key_rotation', NEW, NOW, base)
+    expect(isRevoked(FP, base)).toBe(true)
+    expect(isRevoked(NEW, base)).toBe(false)   // the superseding key is NOT revoked
+  })
+
+  it('records the full revocation record', () => {
+    revokeFingerprint(FP, ADDR, 'key_compromise', null, NOW, base)
+    const [e] = getRevocationList(base)
+    expect(e).toMatchObject({ fingerprint: FP, agent_address: ADDR, reason: 'key_compromise', superseded_by: null, revoked_at: NOW })
+  })
+
+  it('prunes entries older than the 90-day retention window', () => {
+    revokeFingerprint(FP, ADDR, 'key_rotation', NEW, '2026-01-01T00:00:00Z', base)  // >90d before NOW2
+    const NOW2 = '2026-08-03T00:00:00Z'
+    // a fresh revoke triggers prune; the old entry should be gone
+    revokeFingerprint('SHA256:another', ADDR, 'admin_action', null, NOW2, base)
+    expect(isRevoked(FP, base)).toBe(false)          // pruned (older than 90d)
+    expect(isRevoked('SHA256:another', base)).toBe(true)
+  })
+
+  it('empty/undefined fingerprint is never revoked and never stored', () => {
+    expect(isRevoked(undefined, base)).toBe(false)
+    revokeFingerprint('', ADDR, 'admin_action', null, NOW, base)
+    expect(getRevocationList(base).length).toBe(0)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.22",
-  "releaseDate": "2026-08-03",
+  "version": "0.36.23",
+  "releaseDate": "2026-08-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
Closes the remaining AMP spec MUST gaps: **key revocation list** (revoke-on-rotation + reject-at-route, 403 key_revoked), **replay protection** (timestamp freshness + dedup on the federation path), and **Agent Card did:key** (now returns an unsigned provider-asserted card instead of 500, since the server correctly holds only the public key). 11 new tests, 835 total. Message-signing identity only — bearer/JWT auth untouched; ADR-002 now protects 'bring your own JWT provider'.