### PR TITLE
fix: permission menu drops option 1 ("Yes") on tall prompts (v0.36.24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.23-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.24-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/pane-permission.mjs
+++ b/lib/pane-permission.mjs
@@ -1,0 +1,86 @@
+/**
+ * Parse a Claude Code permission / choice menu out of captured tmux pane text.
+ *
+ * Pure (no tmux, no IO) so it is unit-testable. Returns the permission-card shape
+ * that chat clients render, or null when there is no complete, active menu.
+ *
+ * Fixes for the bug where TALL prompts silently drop option 1 (usually "Yes"):
+ *  1. Anchor on the menu STRUCTURE. Find the live "1." and walk the key sequence
+ *     1,2,3,… instead of trusting a fixed line window (a long tool preview pushes
+ *     the menu's top line far above any slice, and option 1 is the first casualty).
+ *  2. Reject a TRUNCATED parse. A real menu is 1..N with no gaps; anything else
+ *     means lines were lost, so return null and let the caller retry rather than
+ *     render a menu that is quietly missing "Yes".
+ *  3. TRUNCATE long labels instead of dropping them. Dropping a >90-char label
+ *     punched a hole in the middle of the menu that the completeness check would
+ *     then reject; long AskUserQuestion choices now survive.
+ */
+export function parsePermissionMenu(paneText) {
+  if (!paneText) return null
+
+  // Strip the box-drawing borders Claude Code wraps the menu in, and trailing ws.
+  const lines = paneText.split('\n').map((l) =>
+    l.replace(/[│┃╎╏┆┇]/g, ' ').replace(/\s+$/, ''))
+
+  // Every numbered option line, with its position in the capture.
+  const optRe = /^[\s❯>▶*]*(\d+)\.\s+(.+?)\s*$/
+  const optLines = []
+  lines.forEach((l, idx) => {
+    const m = l.match(optRe)
+    if (m) optLines.push({ idx, key: m[1], label: m[2].replace(/\s+/g, ' ').trim() })
+  })
+  if (optLines.length < 2) return null
+
+  // The live menu starts at the LAST "1." in view (older menus and prose lists sit
+  // above it). Walk the key sequence downward, matching by KEY, so wrapped label
+  // lines between options do not break the run.
+  let startI = -1
+  for (let i = optLines.length - 1; i >= 0; i--) {
+    if (optLines[i].key === '1') { startI = i; break }
+  }
+  if (startI === -1) return null // no option 1 in view means the parse is truncated
+
+  const block = [optLines[startI]]
+  let expected = 2
+  for (let i = startI + 1; i < optLines.length; i++) {
+    const n = Number(optLines[i].key)
+    if (n === 1) break // a newer menu began
+    if (n === expected) { block.push(optLines[i]); expected++ }
+  }
+
+  // Guard against a gapped menu (e.g. a mangled middle option): if a numbered line
+  // that is not the start of a new menu sits just below the block, the run broke.
+  const lastIdx = block[block.length - 1].idx
+  const trailing = optLines.find((o) => o.idx > lastIdx && o.idx - lastIdx <= 4)
+  if (trailing && trailing.key !== '1') return null
+
+  // Confirm an ACTIVE prompt near the menu (footer, phrasing, or the ❯ selector),
+  // not a stale numbered list somewhere in scrollback.
+  const near = lines.slice(Math.max(0, block[0].idx - 8)).join('\n')
+  const activeMarker =
+    /tab to amend|ctrl\+e to explain|esc to cancel|do you want to proceed|would you like to proceed|yes, and don'?t ask/i
+  const hasSelector = /[❯▶]\s*\d+\.\s/.test(near)
+  if (!activeMarker.test(near) && !hasSelector) return null
+
+  const byKey = new Map()
+  for (const o of block) {
+    if (!o.label) continue
+    const label = o.label.length > 200 ? o.label.slice(0, 197) + '…' : o.label
+    byKey.set(o.key, {
+      key: o.key,
+      label,
+      value: /^no\b|decline|cancel|don'?t/i.test(label) ? 'no' : 'yes',
+    })
+  }
+  const options = Array.from(byKey.values()).sort((a, b) => Number(a.key) - Number(b.key))
+
+  // Completeness: keys must be exactly 1..N. Reject a truncated/corrupt scrape.
+  if (options.length < 2) return null
+  for (let i = 0; i < options.length; i++) {
+    if (Number(options[i].key) !== i + 1) return null
+  }
+
+  const qMatch = near.match(/((?:Do you want|Would you like)[^\n?]*\??)/i)
+  const question = qMatch ? qMatch[1].trim() : 'The agent is asking to run a tool'
+  return { status: 'permission_request', message: question, description: question, options, source: 'pane' }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.23",
+  "version": "0.36.24",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/server.mjs
+++ b/server.mjs
@@ -10,6 +10,7 @@ import path from 'path'
 import { getHostById, isSelf } from './lib/hosts-config-server.mjs'
 import { hostHints } from './lib/host-hints-server.mjs'
 import { getOrCreateBuffer, removeBuffer } from './lib/cerebellum/session-bridge.mjs'
+import { parsePermissionMenu } from './lib/pane-permission.mjs'
 import {
   resolveJsonlPath,
   getAgentWorkingDir,
@@ -336,44 +337,13 @@ function startJsonlWatcher(sessionName, sessionState, agentId) {
  */
 function detectPermissionFromPane(sessionName) {
   try {
-    const raw = execSync(`tmux capture-pane -p -t "${sessionName}" -S -60`,
+    // Capture a generous history (-200) and let parsePermissionMenu anchor on the
+    // menu STRUCTURE. A fixed line window used to drop option 1 ("Yes") on tall
+    // prompts; the parser now finds the live menu wherever it is and rejects a
+    // truncated scrape rather than rendering a menu missing choices.
+    const raw = execSync(`tmux capture-pane -p -t "${sessionName}" -S -200`,
       { timeout: 2000, encoding: 'utf-8' })
-    // Strip box-drawing borders Claude Code wraps the menu in, and trailing ws.
-    const lines = raw.split('\n').map(l => l.replace(/[│┃╎╏┆┇]/g, ' ').replace(/\s+$/, ''))
-    // Scan a generous lower region (the live prompt sits near the bottom, but a
-    // long message + the task list can push it up ~30+ lines). Anchor on
-    // STRUCTURE, not a fixed line count.
-    const region = lines.slice(-45)
-    const text = region.join('\n')
-
-    // An ACTIVE permission/choice prompt is identified by permission-SPECIFIC
-    // signals — its footer, the exact "do you want to proceed" phrasing, or the
-    // ❯ selector on a numbered option. Generic "would you like…?" is NOT used
-    // (it appears in ordinary prose and caused false positives). "esc to
-    // interrupt" is excluded — that means Claude is just working.
-    const activeMarker =
-      /tab to amend|ctrl\+e to explain|esc to cancel|do you want to proceed|would you like to proceed|yes, and don'?t ask/i
-    const hasSelector = /[❯▶]\s*\d+\.\s/.test(text)
-    if (!activeMarker.test(text) && !hasSelector) return null
-
-    // Collect SHORT numbered options (a real menu, not prose "1. Long sentence…").
-    const optRe = /^[\s❯>▶*]*(\d+)\.\s+(.+?)\s*$/
-    const byKey = new Map()
-    for (const l of region) {
-      const m = l.match(optRe)
-      if (!m) continue
-      const key = m[1]
-      const label = m[2].replace(/\s+/g, ' ').trim()
-      if (!label || label.length > 90) continue  // skip prose
-      // Keep the LAST occurrence (the live menu, not an old one in history)
-      byKey.set(key, { key, label, value: /^no\b|decline|cancel|don'?t/i.test(label) ? 'no' : 'yes' })
-    }
-    const options = Array.from(byKey.values()).sort((a, b) => Number(a.key) - Number(b.key))
-    if (options.length < 2) return null  // a genuine menu has ≥2 choices
-
-    const qMatch = text.match(/((?:Do you want|Would you like)[^\n?]*\??)/i)
-    const question = qMatch ? qMatch[1].trim() : 'The agent is asking to run a tool'
-    return { status: 'permission_request', message: question, description: question, options, source: 'pane' }
+    return parsePermissionMenu(raw)
   } catch { return null }
 }
 

--- a/tests/pane-permission.test.ts
+++ b/tests/pane-permission.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { parsePermissionMenu } from '@/lib/pane-permission.mjs'
+
+// Build a realistic captured pane: a long tool preview, the question, a 6-option
+// menu, the footer, then trailing pane rows (a tall window). Option 1 sits far
+// above the bottom of the capture — the exact condition the old fixed 45-line
+// window dropped it.
+function tallPrompt() {
+  const preview = Array.from({ length: 40 }, (_, i) => `  src/very/long/path/segment/file-${i}.ts`)
+  const trailing = Array.from({ length: 15 }, () => '')
+  return [
+    ...preview,
+    'Do you want to proceed with this command?',
+    '❯ 1. Yes',
+    "  2. Yes, and don't ask again this session",
+    '  3. Yes, allow all edits this session',
+    '  4. No, and tell Claude what to do differently',
+    '  5. No, cancel',
+    '  6. Explain this command first',
+    '  esc to cancel · tab to amend',
+    ...trailing,
+  ].join('\n')
+}
+
+describe('parsePermissionMenu (pane scraper)', () => {
+  it('keeps option 1 on a tall prompt (the bug)', () => {
+    const r = parsePermissionMenu(tallPrompt())
+    expect(r).not.toBeNull()
+    expect(r!.options.map((o: any) => o.key)).toEqual(['1', '2', '3', '4', '5', '6'])
+    expect(r!.options[0]).toMatchObject({ key: '1', label: 'Yes', value: 'yes' })
+    expect(r!.options[3].value).toBe('no') // "No, and tell Claude…"
+  })
+
+  it('still parses a small 2-option menu', () => {
+    const t = ['Do you want to proceed?', '❯ 1. Yes', '  2. No, tell Claude what to do differently'].join('\n')
+    const r = parsePermissionMenu(t)
+    expect(r!.options.map((o: any) => o.key)).toEqual(['1', '2'])
+    expect(r!.options[0].label).toBe('Yes')
+  })
+
+  it('rejects a truncated menu that lost option 1', () => {
+    const t = [
+      'Do you want to proceed?',
+      '  2. Yes, and don\'t ask again',
+      '  3. Yes',
+      '  4. No',
+      '  esc to cancel',
+    ].join('\n')
+    expect(parsePermissionMenu(t)).toBeNull()
+  })
+
+  it('rejects a gapped menu (mangled middle option)', () => {
+    const t = ['Do you want to proceed?', '❯ 1. Yes', '  2. Maybe', '  4. No', '  esc to cancel'].join('\n')
+    expect(parsePermissionMenu(t)).toBeNull()
+  })
+
+  it('truncates a long label instead of dropping it (no hole)', () => {
+    const long = 'Use the payments service '.repeat(12) // > 200 chars
+    const t = ['Do you want to proceed?', '❯ 1. Yes', `  2. ${long}`, '  3. No', '  esc to cancel'].join('\n')
+    const r = parsePermissionMenu(t)
+    expect(r!.options.map((o: any) => o.key)).toEqual(['1', '2', '3'])
+    expect(r!.options[1].label.length).toBeLessThanOrEqual(200)
+    expect(r!.options[1].label.endsWith('…')).toBe(true)
+  })
+
+  it('ignores a prose numbered list with no active prompt', () => {
+    const t = ['Here are the steps:', '1. First do this', '2. Then that', '3. Finally this', 'and that is all.'].join('\n')
+    expect(parsePermissionMenu(t)).toBeNull()
+  })
+
+  it('ignores an older menu in scrollback, picks the live one', () => {
+    const t = [
+      'Do you want to proceed?', '  1. Yes (old)', '  2. No (old)', '', 'lots of later output', '',
+      'Do you want to proceed?', '❯ 1. Yes', '  2. No, tell Claude', '  esc to cancel',
+    ].join('\n')
+    const r = parsePermissionMenu(t)
+    expect(r!.options.map((o: any) => o.key)).toEqual(['1', '2'])
+    expect(r!.options[1].label).toContain('No, tell Claude')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.23",
+  "version": "0.36.24",
   "releaseDate": "2026-08-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
**Bug:** `detectPermissionFromPane()` scanned a fixed 45-line window and shipped whatever it found. On a tall prompt the menu's top line fell outside the window, so **option 1 ("Yes") was silently omitted** and the card rendered options 2-6. Affects every chat client (scraper path, not the hook).

**Fix** (extracted to `lib/pane-permission.mjs`, unit-tested):
- Anchor on menu **structure** (find the live `1.`, walk the key sequence); capture widened to -200.
- **Reject** a truncated/gapped parse (must be 1..N) so a partial scrape retries instead of rendering a menu missing "Yes".
- **Truncate** long labels instead of dropping them (dropping punched a hole the completeness check then rejected) — fixes long AskUserQuestion choices too.

7 new tests (tall prompt, truncation reject, gap reject, long-label truncate, prose-ignore, live-vs-scrollback). 842 total pass. Verified on v0.36.24.