### PR TITLE
Detached sessions self-identify for AMP + statusline (v0.36.25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.24-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.25-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -222,6 +222,49 @@ export function saveAgents(agents: Agent[]): boolean {
 }
 
 /**
+ * Write a per-project identity hint so DETACHED Claude Code sessions (started
+ * manually in a directory, not via tmux/AI Maestro) can self-identify.
+ *
+ * Claude Code injects `env` from `<dir>/.claude/settings.local.json` into the
+ * shell, and the AMP CLI + statusline resolve identity from CLAUDE_AGENT_NAME.
+ * Without this hint, a detached session in a dir claimed by many agents cannot
+ * tell which agent it is, so AMP refuses to run ("Multiple AMP agents found").
+ *
+ * Merges into any existing settings.local.json (never clobbers permissions or
+ * other keys). Best-effort: failures are logged, never thrown — provisioning an
+ * agent must not fail because a project dir is read-only or missing.
+ */
+export function writeAgentDirHint(agentName: string, workingDirectory?: string | null): void {
+  try {
+    if (!agentName || !workingDirectory) return
+    // Only real, absolute local dirs — skip root and ephemeral scratch dirs.
+    if (!path.isAbsolute(workingDirectory)) return
+    if (workingDirectory === '/' || workingDirectory === os.homedir()) return
+    if (workingDirectory.includes('/claude-501/') || workingDirectory.startsWith('/private/tmp/') || workingDirectory.startsWith('/tmp/')) return
+    if (!fs.existsSync(workingDirectory)) return
+
+    const claudeDir = path.join(workingDirectory, '.claude')
+    const settingsFile = path.join(claudeDir, 'settings.local.json')
+    let settings: any = {}
+    if (fs.existsSync(settingsFile)) {
+      try {
+        settings = JSON.parse(fs.readFileSync(settingsFile, 'utf-8')) || {}
+      } catch {
+        // Corrupt/unreadable settings — don't overwrite a file we can't parse.
+        console.warn(`[Agent Registry] Skipping dir hint; unparseable ${settingsFile}`)
+        return
+      }
+    }
+    if (settings.env && settings.env.CLAUDE_AGENT_NAME === agentName) return // already correct
+    settings.env = { ...(settings.env || {}), CLAUDE_AGENT_NAME: agentName }
+    fs.mkdirSync(claudeDir, { recursive: true })
+    fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + '\n', 'utf-8')
+  } catch (error) {
+    console.warn('[Agent Registry] writeAgentDirHint failed (non-fatal):', error)
+  }
+}
+
+/**
  * Get agent by ID.
  * By default excludes soft-deleted agents. Pass includeDeleted=true to include them.
  */
@@ -494,6 +537,9 @@ export function createAgent(request: CreateAgentRequest): Agent {
   agents.push(agent)
   saveAgents(agents)
   invalidateAgentCache()
+
+  // Let detached sessions in this dir self-identify (statusline + AMP).
+  writeAgentDirHint(agent.name, agent.workingDirectory)
 
   return agent
 }
@@ -929,6 +975,8 @@ export function linkSession(agentId: string, sessionName: string, workingDirecto
 
   const saved = saveAgents(agents)
   if (saved) invalidateAgentCache()
+  // Let detached sessions in this dir self-identify (statusline + AMP).
+  writeAgentDirHint(agents[index].name, agents[index].workingDirectory)
   return saved
 }
 
@@ -971,7 +1019,10 @@ export function updateAgentWorkingDirectory(agentId: string, workingDirectory: s
     agents[index].preferences.defaultWorkingDirectory = workingDirectory
   }
 
-  return saveAgents(agents)
+  const ok = saveAgents(agents)
+  // Keep the detached-session identity hint in sync with the new dir.
+  writeAgentDirHint(agents[index].name, workingDirectory)
+  return ok
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.24",
+  "version": "0.36.25",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/tests/agent-dir-hint.test.ts
+++ b/tests/agent-dir-hint.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { writeAgentDirHint } from '@/lib/agent-registry'
+
+// Use a dir under the repo (not /tmp — the helper intentionally skips scratch dirs).
+const tmpRoot = path.join(process.cwd(), '.vitest-hint-tmp')
+
+function freshDir(name: string): string {
+  const d = path.join(tmpRoot, name)
+  fs.mkdirSync(d, { recursive: true })
+  return d
+}
+function readSettings(dir: string): any {
+  const f = path.join(dir, '.claude', 'settings.local.json')
+  return fs.existsSync(f) ? JSON.parse(fs.readFileSync(f, 'utf-8')) : null
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+describe('writeAgentDirHint', () => {
+  it('creates settings.local.json with the env hint when none exists', () => {
+    const d = freshDir('new')
+    writeAgentDirHint('my-agent', d)
+    expect(readSettings(d)?.env?.CLAUDE_AGENT_NAME).toBe('my-agent')
+  })
+
+  it('merges into existing settings without clobbering other keys', () => {
+    const d = freshDir('merge')
+    fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+    fs.writeFileSync(
+      path.join(d, '.claude', 'settings.local.json'),
+      JSON.stringify({ permissions: { allow: ['Bash(ls:*)'] }, env: { FOO: 'bar' } })
+    )
+    writeAgentDirHint('agent-x', d)
+    const s = readSettings(d)
+    expect(s.env.CLAUDE_AGENT_NAME).toBe('agent-x')
+    expect(s.env.FOO).toBe('bar')                    // other env preserved
+    expect(s.permissions.allow).toContain('Bash(ls:*)') // other keys preserved
+  })
+
+  it('overwrites a stale hint with the current agent name', () => {
+    const d = freshDir('stale')
+    fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+    fs.writeFileSync(
+      path.join(d, '.claude', 'settings.local.json'),
+      JSON.stringify({ env: { CLAUDE_AGENT_NAME: 'old-name' } })
+    )
+    writeAgentDirHint('new-name', d)
+    expect(readSettings(d).env.CLAUDE_AGENT_NAME).toBe('new-name')
+  })
+
+  it('does not clobber an unparseable settings file', () => {
+    const d = freshDir('corrupt')
+    fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+    const f = path.join(d, '.claude', 'settings.local.json')
+    fs.writeFileSync(f, '{ not valid json')
+    writeAgentDirHint('agent-x', d)
+    expect(fs.readFileSync(f, 'utf-8')).toBe('{ not valid json') // untouched
+  })
+
+  it('is a no-op for root, scratch, empty-name, and missing dirs', () => {
+    // root — never write
+    writeAgentDirHint('x', '/')
+    expect(fs.existsSync('/.claude/settings.local.json')).toBe(false)
+    // scratch under /private/tmp — skipped
+    const scratch = fs.mkdtempSync('/private/tmp/hint-')
+    writeAgentDirHint('x', scratch)
+    expect(readSettings(scratch)).toBeNull()
+    fs.rmSync(scratch, { recursive: true, force: true })
+    // empty agent name — skipped
+    const d = freshDir('emptyname')
+    writeAgentDirHint('', d)
+    expect(readSettings(d)).toBeNull()
+    // non-existent dir — not created
+    const missing = path.join(tmpRoot, 'does-not-exist')
+    writeAgentDirHint('x', missing)
+    expect(fs.existsSync(missing)).toBe(false)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.24",
-  "releaseDate": "2026-08-04",
+  "version": "0.36.25",
+  "releaseDate": "2026-08-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Problem

Detached Claude Code sessions (started manually in a directory, **not** via tmux/AI Maestro) had no way to know which agent they were. Two consequences:

1. **Wrong status-bar identity** — the statusline scraped `CLAUDE_AGENT_NAME=` out of *permission allow-rules* in `settings.local.json` (e.g. `"Bash(CLAUDE_AGENT_NAME=foo amp-send.sh:*)"`) and painted a bogus name; or matched a broad/shared working directory and picked a random agent (the "piano-instructor" class of bug).
2. **AMP unusable** — with many agents, `amp-inbox.sh`/`amp-send.sh` without `--id` aborted with `"Multiple AMP agents found. Use --id"`. **This meant you could not send or receive AMP messages with detached agents at all** — the critical issue.

## Fix (3 layers)

1. **`writeAgentDirHint()`** (`lib/agent-registry.ts`) — AI Maestro writes a per-project `.claude/settings.local.json` `env.CLAUDE_AGENT_NAME` whenever it provisions an agent with a working directory (`createAgent`, `linkSession`, `updateAgentWorkingDirectory`). Claude Code injects that `env` into the shell (confirmed against the docs), so the statusline **and** the AMP CLI resolve the correct identity. Merge-safe (never clobbers permissions/other keys); best-effort (never fails provisioning).
2. **AMP scripts** (plugin submodule): `amp-helper.sh` gains cwd-based identity resolution (Priority 3.5: settings hint → registry unique-owner) so detached sessions resolve **without `--id`**, independent of env injection; `amp-statusline.sh` reads the real `.env` field instead of grep-ing the raw file.
3. **Tests** — `tests/agent-dir-hint.test.ts` covers merge safety, skip rules (root/scratch/empty/missing), and the corrupt-file guard.

## Verification

- Live: `amp-inbox.sh` with **no `--id`** from a detached session now resolves the correct mailbox (previously hard-errored).
- Backfilled hints across 50 uniquely-owned project dirs; verified statusline + AMP resolve end-to-end for real agents.
- 849 unit tests pass (`yarn test`), `yarn build` passes, version bumped to 0.36.25.
- AMP script fixes deployed to all local copies + mac-mini + mini-lola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)