### PR TITLE
Scope dir-hint writes to stable provisioning points (v0.36.26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.25-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.26-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -1019,10 +1019,11 @@ export function updateAgentWorkingDirectory(agentId: string, workingDirectory: s
     agents[index].preferences.defaultWorkingDirectory = workingDirectory
   }
 
-  const ok = saveAgents(agents)
-  // Keep the detached-session identity hint in sync with the new dir.
-  writeAgentDirHint(agents[index].name, workingDirectory)
-  return ok
+  // NOTE: intentionally do NOT write the detached-session identity hint here.
+  // This runs on transient tmux pwd sync (index-delta), so an agent that cd's
+  // around would scatter/churn settings.local.json hints across subdirs. The
+  // hint is written only at stable provisioning points: createAgent + linkSession.
+  return saveAgents(agents)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.25",
+  "version": "0.36.26",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.25",
+  "version": "0.36.26",
   "releaseDate": "2026-08-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Follow-up to #398. `updateAgentWorkingDirectory` fires on transient tmux pwd sync (index-delta), so writing the identity hint there scatters/churns `settings.local.json` across subdirs an agent cd's into. Restrict hint writes to `createAgent` + `linkSession` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)