### PR TITLE
Single source of truth for ai-maestro-hook.cjs (v0.36.27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## ⚠️ The Claude Code hook has ONE source of truth
+
+`ai-maestro-hook.cjs` ships from three byte-identical locations. **Edit only the canonical one, then run the sync script:**
+
+```bash
+# 1. Edit the canonical hook:
+scripts/claude-hooks/ai-maestro-hook.cjs        # used by install.sh + docker cloud agents
+# 2. Propagate to the plugin copies:
+bash scripts/sync-plugin-hook.sh                # -> plugin/src + plugin/plugins/.../scripts
+```
+
+`tests/plugin-hook-sync.test.ts` fails in CI if the three copies drift. They previously diverged into two implementations and every fix had to be applied twice — do not hand-edit the plugin copies. (The AMP shell scripts — `amp-*.sh`, `amp-statusline.sh`, `amp-helper.sh` — have their own upstream source at `agentmessaging/claude-plugin`, pulled by the plugin builder at `ref: main`; never hand-edit those downstream either.)
+
 ## Project Overview
 
 **Claude Code Dashboard** - A browser-based terminal dashboard for managing multiple Claude Code agents running in tmux on macOS. The application auto-discovers agents from tmux sessions and provides a unified web interface with real-time terminal streaming.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.26-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.27-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.26",
+  "version": "0.36.27",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/sync-plugin-hook.sh
+++ b/scripts/sync-plugin-hook.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Single source of truth for the AI Maestro Claude Code hook.
+#
+# The hook exists in three places that MUST stay byte-identical:
+#   1. scripts/claude-hooks/ai-maestro-hook.cjs   <- CANONICAL (edit here)
+#        used by install.sh / update-aimaestro.sh (global install) and by
+#        services/agents-docker-service.ts (per cloud-agent copy).
+#   2. plugin/src/scripts/ai-maestro-hook.cjs     <- plugin builder source
+#   3. plugin/plugins/ai-maestro/scripts/ai-maestro-hook.cjs <- plugin build output
+#        (2)+(3) ship in the marketplace plugin, which must build standalone so it
+#        carries its own copy.
+#
+# Historically these drifted into two independent implementations and every fix
+# had to be applied twice. Edit ONLY #1, then run this script. A unit test
+# (tests/plugin-hook-sync.test.ts) fails if they ever diverge, so CI catches drift.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT/scripts/claude-hooks/ai-maestro-hook.cjs"
+DESTS=(
+  "$ROOT/plugin/src/scripts/ai-maestro-hook.cjs"
+  "$ROOT/plugin/plugins/ai-maestro/scripts/ai-maestro-hook.cjs"
+)
+[ -f "$SRC" ] || { echo "canonical hook missing: $SRC" >&2; exit 1; }
+node --check "$SRC" || { echo "canonical hook has a syntax error; aborting" >&2; exit 1; }
+for d in "${DESTS[@]}"; do
+  mkdir -p "$(dirname "$d")"
+  cp "$SRC" "$d"
+  echo "synced -> ${d#$ROOT/}"
+done
+echo "done. canonical: scripts/claude-hooks/ai-maestro-hook.cjs"

--- a/tests/plugin-hook-sync.test.ts
+++ b/tests/plugin-hook-sync.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+
+// The AI Maestro Claude Code hook must stay byte-identical across the three
+// places it ships from. They historically drifted into two implementations and
+// every fix had to be applied twice. Canonical is scripts/claude-hooks/…; the
+// two plugin copies are produced by scripts/sync-plugin-hook.sh. If this fails,
+// someone edited one copy without syncing — run: bash scripts/sync-plugin-hook.sh
+const ROOT = process.cwd()
+const CANONICAL = 'scripts/claude-hooks/ai-maestro-hook.cjs'
+const COPIES = [
+  'plugin/src/scripts/ai-maestro-hook.cjs',
+  'plugin/plugins/ai-maestro/scripts/ai-maestro-hook.cjs',
+]
+
+const sha = (rel: string) =>
+  crypto.createHash('sha256').update(fs.readFileSync(path.join(ROOT, rel))).digest('hex')
+
+describe('ai-maestro-hook.cjs single source of truth', () => {
+  it('canonical hook exists', () => {
+    expect(fs.existsSync(path.join(ROOT, CANONICAL))).toBe(true)
+  })
+
+  for (const copy of COPIES) {
+    it(`${copy} is in sync with the canonical hook`, () => {
+      expect(fs.existsSync(path.join(ROOT, copy))).toBe(true)
+      expect(sha(copy)).toBe(sha(CANONICAL)) // out of sync → run scripts/sync-plugin-hook.sh
+    })
+  }
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.26",
+  "version": "0.36.27",
   "releaseDate": "2026-08-07",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Problem
The Claude Code hook `ai-maestro-hook.cjs` shipped from **two independently-maintained copies** that had drifted into different feature sets:
- `scripts/claude-hooks/ai-maestro-hook.cjs` (709 lines) — used by `install.sh`/`update-aimaestro.sh` and copied per cloud agent by `agents-docker-service.ts`. Superset: meeting-inject queue, `UserPromptSubmit` context, richer Stop-hook delivery + `resolveAgent`.
- `plugin/.../scripts/ai-maestro-hook.cjs` (609 lines) — shipped in the marketplace plugin. An older subset.

Same features were implemented twice in parallel (Stop-hook delivery, detached-session cwd resolution), so every fix had to be applied twice — the root of the "diverged copies" mess.

## Fix
One canonical hook + sync + drift guard (no behavior change: both hook configs register the same 3 events — `SessionStart`/`Stop`/`Notification` — so the superset's extra `UserPromptSubmit` handler is dormant in both; the plugin simply stops being stale):
- **Canonical**: `scripts/claude-hooks/ai-maestro-hook.cjs` (edit here only).
- **`scripts/sync-plugin-hook.sh`**: propagates it to `plugin/src` + `plugin/plugins/.../scripts` (syntax-checked).
- **`tests/plugin-hook-sync.test.ts`**: CI fails if the three copies drift.
- **CLAUDE.md**: documents the edit-canonical-then-sync workflow.
- Plugin submodule bumped to the synced superset hook (ai-maestro-plugins).

## Verification
- All three copies byte-identical (sha256).
- 852 tests pass, `yarn build` passes, version 0.36.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)