### PR TITLE
Native Claude Code session names for agents (v0.36.28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.27-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.28-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/claude-session-name.ts
+++ b/lib/claude-session-name.ts
@@ -1,0 +1,50 @@
+/**
+ * Claude Code native session naming (`claude --name <name>` / `-n`).
+ *
+ * When enabled, agent launches pass `--name <agent>` so Claude Code natively
+ * knows the agent's name. The name surfaces in:
+ *   - the statusline JSON as `session_name` (amp-statusline.sh reads it),
+ *   - the terminal title,
+ *   - `claude --resume <name>` (interactive resume-by-name).
+ *
+ * It does NOT reach hook payloads — Claude Code does not expose session_name to
+ * hooks — so this does not change ai-maestro-hook.cjs identity resolution.
+ *
+ * Off by default (opt-in via AIMAESTRO_SESSION_NAME): an unknown flag would break
+ * launches on a Claude Code too old to know `--name`, so the fleet is unaffected
+ * until an operator flips the env var. Mirrors AIMAESTRO_CHANNEL_FLAG rollout.
+ */
+
+const CLAUDE_PROGRAMS = new Set(['claude', 'claude-code'])
+
+/** True when AIMAESTRO_SESSION_NAME opts this host into passing `--name`. */
+export function isSessionNamingEnabled(): boolean {
+  const v = (process.env.AIMAESTRO_SESSION_NAME || '').trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on'
+}
+
+/**
+ * Coerce an agent name to the Claude Code / tmux session charset
+ * (`^[A-Za-z0-9_-]+$`): map any other run of characters to a single '-', trim
+ * leading/trailing '-', and cap length. Real agent names are already in this
+ * charset, so this is a no-op for them and a safety net for anything unusual —
+ * and it guarantees the value needs no shell quoting.
+ */
+export function sanitizeClaudeSessionName(name: string): string {
+  return (name || '')
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+/**
+ * The ` --name <sanitized>` fragment to append to a claude launch command, or ''
+ * when: session naming is disabled, the program is not claude, or the name is
+ * empty. The returned fragment is shell-safe (sanitized charset, no quoting).
+ */
+export function claudeSessionNameFlag(agentName: string | undefined, program: string): string {
+  if (!isSessionNamingEnabled()) return ''
+  if (!CLAUDE_PROGRAMS.has((program || '').toLowerCase())) return ''
+  const safe = sanitizeClaudeSessionName(agentName || '')
+  return safe ? ` --name ${safe}` : ''
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.27",
+  "version": "0.36.28",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -59,6 +59,7 @@ import {
 } from '@/lib/agent-registry'
 import { resolveAgentIdentifier } from '@/lib/messageQueue'
 import { getHosts, getSelfHost, getSelfHostId, isSelf, updateHostRaw } from '@/lib/hosts-config'
+import { claudeSessionNameFlag } from '@/lib/claude-session-name'
 import { persistSession, unpersistSession } from '@/lib/session-persistence'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { initializeAllAgents, getStartupStatus } from '@/lib/agent-startup'
@@ -1840,6 +1841,11 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
             const cliMode = PERMISSION_MODE_TO_CLI[effectiveMode]
             fullCommand = `${fullCommand} --permission-mode ${cliMode}`
           }
+
+          // Give Claude Code the agent's native session name (opt-in via
+          // AIMAESTRO_SESSION_NAME). Surfaces in the statusline session_name
+          // field, terminal title, and `claude --resume <name>`.
+          fullCommand = `${fullCommand}${claudeSessionNameFlag(agentName, startCommand)}`
 
           // Channels: reliable idle-agent wake via MCP turn-injection. When
           // AIMAESTRO_CHANNEL_FLAG is set, the agent boots with the amp channel so

--- a/services/agents-docker-service.ts
+++ b/services/agents-docker-service.ts
@@ -20,6 +20,7 @@ import type { Agent, SandboxMount } from '@/types/agent'
 import { PERMISSION_MODE_TO_CLI } from '@/types/agent'
 import type { AgentPermissionMode } from '@/types/agent'
 import { CONTAINER_CWD_GEMINI_PROJECT } from '@/lib/container-utils'
+import { claudeSessionNameFlag } from '@/lib/claude-session-name'
 
 const execAsync = promisify(exec)
 
@@ -83,13 +84,16 @@ const CONTAINER_HOME = '/home/claude'
  *   2. body.yolo (legacy backward compat, maps to fullAutonomy)
  *   3. 'supervised' (default, no flag injected)
  */
-export function buildAiToolCommand(body: Pick<DockerCreateRequest, 'program' | 'permissionMode' | 'yolo' | 'programArgs' | 'model' | 'prompt'>): string {
+export function buildAiToolCommand(body: Pick<DockerCreateRequest, 'program' | 'permissionMode' | 'yolo' | 'programArgs' | 'model' | 'prompt'> & { name?: string }): string {
   const program = body.program || 'claude'
   let aiTool = program
   const effectivePermMode: AgentPermissionMode = body.permissionMode || (body.yolo ? 'fullAutonomy' : 'supervised')
   if (effectivePermMode !== 'supervised' && (program === 'claude' || program === 'claude-code')) {
     aiTool += ` --permission-mode ${PERMISSION_MODE_TO_CLI[effectivePermMode]}`
   }
+  // Give Claude Code the agent's native session name (opt-in). Surfaces in the
+  // statusline session_name field, terminal title, and `claude --resume <name>`.
+  aiTool += claudeSessionNameFlag(body.name, program)
   if (body.programArgs) {
     const sanitizedArgs = body.programArgs.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
     if (sanitizedArgs) aiTool += ` ${sanitizedArgs}`

--- a/tests/claude-session-name.test.ts
+++ b/tests/claude-session-name.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  isSessionNamingEnabled,
+  sanitizeClaudeSessionName,
+  claudeSessionNameFlag,
+} from '@/lib/claude-session-name'
+
+const ORIG = process.env.AIMAESTRO_SESSION_NAME
+afterEach(() => {
+  if (ORIG === undefined) delete process.env.AIMAESTRO_SESSION_NAME
+  else process.env.AIMAESTRO_SESSION_NAME = ORIG
+})
+function setFlag(v: string | undefined) {
+  if (v === undefined) delete process.env.AIMAESTRO_SESSION_NAME
+  else process.env.AIMAESTRO_SESSION_NAME = v
+}
+
+describe('isSessionNamingEnabled', () => {
+  it('is off by default / for falsey values', () => {
+    for (const v of [undefined, '', '0', 'false', 'off', 'no', 'nope']) {
+      setFlag(v)
+      expect(isSessionNamingEnabled()).toBe(false)
+    }
+  })
+  it('is on for truthy values (case/space-insensitive)', () => {
+    for (const v of ['1', 'true', 'yes', 'on', 'TRUE', ' On ']) {
+      setFlag(v)
+      expect(isSessionNamingEnabled()).toBe(true)
+    }
+  })
+})
+
+describe('sanitizeClaudeSessionName', () => {
+  it('leaves a valid tmux-charset name untouched', () => {
+    expect(sanitizeClaudeSessionName('23blocks-api-authentication')).toBe('23blocks-api-authentication')
+    expect(sanitizeClaudeSessionName('agent_0')).toBe('agent_0')
+  })
+  it('maps runs of illegal chars to a single dash and trims', () => {
+    expect(sanitizeClaudeSessionName('fluidmind/agents/backend architect')).toBe('fluidmind-agents-backend-architect')
+    expect(sanitizeClaudeSessionName('  weird!!name  ')).toBe('weird-name')
+    expect(sanitizeClaudeSessionName('/leading/and/trailing/')).toBe('leading-and-trailing')
+  })
+  it('caps length at 64', () => {
+    expect(sanitizeClaudeSessionName('a'.repeat(200)).length).toBe(64)
+  })
+  it('handles empty input', () => {
+    expect(sanitizeClaudeSessionName('')).toBe('')
+  })
+})
+
+describe('claudeSessionNameFlag', () => {
+  it('returns empty when the flag is disabled (default)', () => {
+    setFlag(undefined)
+    expect(claudeSessionNameFlag('my-agent', 'claude')).toBe('')
+  })
+  it('returns the --name fragment for claude programs when enabled', () => {
+    setFlag('1')
+    expect(claudeSessionNameFlag('my-agent', 'claude')).toBe(' --name my-agent')
+    expect(claudeSessionNameFlag('my-agent', 'claude-code')).toBe(' --name my-agent')
+    expect(claudeSessionNameFlag('my-agent', 'CLAUDE')).toBe(' --name my-agent') // case-insensitive
+  })
+  it('returns empty for non-claude programs even when enabled', () => {
+    setFlag('1')
+    expect(claudeSessionNameFlag('my-agent', 'codex')).toBe('')
+    expect(claudeSessionNameFlag('my-agent', 'gemini')).toBe('')
+  })
+  it('sanitizes the name in the fragment (shell-safe, no quoting needed)', () => {
+    setFlag('1')
+    expect(claudeSessionNameFlag('a/b c', 'claude')).toBe(' --name a-b-c')
+  })
+  it('returns empty when the name is empty/whitespace', () => {
+    setFlag('1')
+    expect(claudeSessionNameFlag('', 'claude')).toBe('')
+    expect(claudeSessionNameFlag('   ', 'claude')).toBe('')
+  })
+})

--- a/tests/services/agents-docker-service.test.ts
+++ b/tests/services/agents-docker-service.test.ts
@@ -1632,6 +1632,34 @@ describe('buildAiToolCommand', () => {
     expect(result).toBe('claude')
   })
 
+  describe('native session name (AIMAESTRO_SESSION_NAME)', () => {
+    const ORIG = process.env.AIMAESTRO_SESSION_NAME
+    afterEach(() => {
+      if (ORIG === undefined) delete process.env.AIMAESTRO_SESSION_NAME
+      else process.env.AIMAESTRO_SESSION_NAME = ORIG
+    })
+
+    it('does NOT add --name when the flag is off (default)', () => {
+      delete process.env.AIMAESTRO_SESSION_NAME
+      const result = buildAiToolCommand({ name: 'my-agent', program: 'claude' })
+      expect(result).toBe('claude')
+      expect(result).not.toContain('--name')
+    })
+
+    it('adds --name <name> for claude when the flag is on', () => {
+      process.env.AIMAESTRO_SESSION_NAME = '1'
+      const result = buildAiToolCommand({ name: 'my-agent', program: 'claude', model: 'opus' })
+      expect(result).toBe('claude --name my-agent --model opus')
+    })
+
+    it('does NOT add --name for non-claude programs', () => {
+      process.env.AIMAESTRO_SESSION_NAME = '1'
+      const result = buildAiToolCommand({ name: 'my-agent', program: 'codex' })
+      expect(result).toBe('codex')
+      expect(result).not.toContain('--name')
+    })
+  })
+
   it('appends programArgs after permission-mode flag', () => {
     const result = buildAiToolCommand({ program: 'claude', permissionMode: 'smartAuto', programArgs: '--continue' })
     expect(result).toBe('claude --permission-mode auto --continue')

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.27",
-  "releaseDate": "2026-08-07",
+  "version": "0.36.28",
+  "releaseDate": "2026-08-17",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## What
When `AIMAESTRO_SESSION_NAME` is enabled, agent launches pass `claude --name <agent>` so Claude Code natively knows the agent's name.

It surfaces in:
- the statusline JSON `session_name` field (paired PR in claude-plugin lets `amp-statusline.sh` resolve identity from it),
- the terminal title,
- `claude --resume <name>` (interactive resume-by-name).

## How
- **`lib/claude-session-name.ts`** — `isSessionNamingEnabled` / `sanitizeClaudeSessionName` / `claudeSessionNameFlag`. Sanitizes to the tmux/Claude charset (shell-safe, no quoting).
- Injected into **both** launch builders: tmux wake (`agents-core-service.ts`) and docker/cloud (`agents-docker-service.ts buildAiToolCommand`), guarded to claude programs.
- **Off by default** — an unknown flag would break launches on a Claude Code too old to know `--name`, so it's opt-in per host (mirrors `AIMAESTRO_CHANNEL_FLAG`). Nothing in the fleet changes until an operator sets the env var.

## Caveat (documented)
Claude Code does **not** expose `session_name` to hooks, so this does not change `ai-maestro-hook.cjs` identity resolution — the win is the statusline + native UX.

## Tests
Helper (enable/charset/flag-gating) + docker builder cases. 866 tests pass, build clean, v0.36.28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)