### PR TITLE
Capture Claude Code session_id per agent (v0.36.29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.28-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.29-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/agents/[id]/heartbeat/route.ts
+++ b/app/api/agents/[id]/heartbeat/route.ts
@@ -16,7 +16,7 @@ export async function POST(
   try {
     const { id } = await params
     const body = await request.json().catch(() => ({}))
-    const result = heartbeat(id, body.status)
+    const result = heartbeat(id, body.status, body.claudeSessionId)
     return toResponse(result)
   } catch (error) {
     console.error('[Heartbeat API] Error:', error)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.28",
+  "version": "0.36.29",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -19,6 +19,10 @@ const path = require('path');
 const crypto = require('crypto');
 const os = require('os');
 
+// Claude Code's native session id for this invocation (from the hook payload).
+// Single-shot process, so a module-level value set once in main() is sufficient.
+let currentSessionId = null;
+
 // Read stdin as JSON
 async function readStdin() {
     return new Promise((resolve, reject) => {
@@ -124,12 +128,14 @@ async function broadcastStatusUpdate(cwd, state) {
             })
         });
 
-        // Also send heartbeat so standalone agents appear in dashboard
+        // Also send heartbeat so standalone agents appear in dashboard. Include
+        // Claude Code's native session id (present in the hook payload) so the
+        // registry can link the agent to its transcript / support native resume.
         if (agent.id) {
             await fetch(`http://localhost:23000/api/agents/${encodeURIComponent(agent.id)}/heartbeat`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ status: state.status })
+                body: JSON.stringify({ status: state.status, claudeSessionId: currentSessionId })
             }).catch(() => {});
         }
 
@@ -415,6 +421,7 @@ function decideStopDelivery({ agent, stopHookActive, messages, alreadyIds }) {
 // Main
 async function main() {
     const input = await readStdin();
+    currentSessionId = input.session_id || null;
 
     // Log all input for debugging
     debugLog({ event: 'hook_received', input });

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -27,7 +27,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import type { Session } from '@/types/session'
-import { getAgent, getAgentBySession, getAgentByName, createAgent, deleteAgentBySession, renameAgentSession } from '@/lib/agent-registry'
+import { getAgent, getAgentBySession, getAgentByName, createAgent, deleteAgentBySession, renameAgentSession, updateAgent } from '@/lib/agent-registry'
 import { loadAgents } from '@/lib/agent-registry'
 import { getHosts, getSelfHost, isSelf, getHostById } from '@/lib/hosts-config'
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
@@ -599,12 +599,17 @@ export function broadcastActivityUpdate(
  * Record a heartbeat for a standalone agent (no tmux session).
  * Makes the agent appear in the dashboard session list.
  */
-export function heartbeat(agentId: string, status?: string): ServiceResult<{ success: boolean }> {
+export function heartbeat(agentId: string, status?: string, claudeSessionId?: string): ServiceResult<{ success: boolean }> {
   if (!agentId) return missingField('agentId')
   // Resolve: agentId could be a UUID or a name. Store heartbeat under the UUID.
   const agent = getAgent(agentId) || getAgentByName(agentId)
   const resolvedId = agent?.id || agentId
   agentActivity.set(resolvedId, Date.now())
+  // Capture Claude Code's native session id (sent by the hook on SessionStart)
+  // when it changes — enables transcript lookup, native resume, telemetry.
+  if (agent && claudeSessionId && agent.claudeSessionId !== claudeSessionId) {
+    updateAgent(agent.id, { claudeSessionId } as any)
+  }
   broadcastStatusUpdate('', status || 'active', undefined, undefined, resolvedId)
   return { data: { success: true }, status: 200 }
 }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -222,6 +222,11 @@ export interface Agent {
   // Working Directory (agent-level default)
   workingDirectory?: string     // Default working directory for sessions
 
+  // Claude Code native session id (from the hook payload on SessionStart).
+  // Enables transcript lookup (~/.claude/projects/<proj>/<id>.jsonl), native
+  // `claude --resume <id>`, and OTLP/session telemetry correlation.
+  claudeSessionId?: string
+
   // Sessions (zero or more, Phase 1: max 1)
   sessions: AgentSession[]      // Active/historical sessions for this agent
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.28",
-  "releaseDate": "2026-08-17",
+  "version": "0.36.29",
+  "releaseDate": "2026-08-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
The hook already receives Claude Code's native `session_id`; now it forwards it on the heartbeat and the registry stores it as `agent.claudeSessionId`. Links an agent to its Claude Code session/transcript; correlation key for native `claude --resume <id>` and session telemetry (OTLP). 866 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)