### PR TITLE
Fix plugin propagation pipeline (v0.36.30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,18 @@ This script updates ALL version references across the codebase:
 □ 1. TESTS PASS: yarn test
 □ 2. BUMP VERSION: ./scripts/bump-version.sh patch
 □ 3. BUILD PASSES: yarn build
-□ 4. COMMIT version bump with your changes
+□ 4. PROPAGATE PLUGIN (if you touched claude-plugin scripts, amp-*.sh, or the hook):
+       cd plugin && ./build-plugin.sh --clean       # rebuild built output from upstream
+       git -C plugin commit -am "build: rebuild plugin" && git -C plugin push
+       git add plugin                                # bump the submodule pointer
+     (Skipping this ships STALE scripts — fresh installs (install-plugin.sh) and host
+      updates (update-aimaestro.sh) read the built submodule, NOT claude-plugin directly.)
+□ 5. COMMIT version bump with your changes
 ```
 
 **This is NON-NEGOTIABLE.** Every PR to main MUST include a version bump. No exceptions.
+
+**Deploy to hosts via `update-aimaestro.sh`** (git pull + submodule update + build + install-hooks.sh + install-plugin.sh + pm2 restart) — NOT a raw `git reset + build + restart`, which skips the hook/statusline install steps and forces manual syncing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.29-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.30-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.29",
+  "version": "0.36.30",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.29",
+  "version": "0.36.30",
   "releaseDate": "2026-08-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
The built plugin submodule had drifted behind upstream `claude-plugin`. Fresh installs (`install-plugin.sh`) and host updates read the **built submodule**, not `claude-plugin` directly — so recent fixes (cost statusline, session_id hook, Priority 3.5 resolver, digest fix, `--body-file`) shipped stale and had to be hand-synced.

- Rebuild + bump the submodule (`build-plugin.sh --clean`).
- Add **PROPAGATE PLUGIN** to the mandatory Pre-PR checklist; require host deploys go through `update-aimaestro.sh` (which runs install-hooks + install-plugin), not raw `git reset + restart`.

866 tests pass (hook drift test green), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)