### PR TITLE
update-aimaestro.sh: checkout submodule after pull (v0.36.31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.30-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.31-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.30",
+  "version": "0.36.31",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/update-aimaestro.sh
+++ b/update-aimaestro.sh
@@ -188,6 +188,15 @@ else
     git pull origin main
     print_success "Code updated"
 
+    # Check out the submodule content the new pointer references. `git pull` moves
+    # the gitlink but does NOT update the submodule working tree — without this,
+    # install-plugin.sh below reinstalls STALE scripts (old statusline/hook/amp-*)
+    # from the previous submodule commit. --force to override any local drift.
+    print_step "$DOWNLOAD" "Updating plugin submodule..."
+    git submodule update --init --recursive --force \
+        && print_success "Plugin submodule updated" \
+        || print_warning "Submodule update had issues (plugin scripts may be stale)"
+
     # Detect ecosystem.config.js changes that require PM2 config reload
     if ! git diff --quiet "$BEFORE_SHA" HEAD -- ecosystem.config.js ecosystem.config.cjs 2>/dev/null; then
         ECOSYSTEM_CHANGED=true

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.30",
+  "version": "0.36.31",
   "releaseDate": "2026-08-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
`update-aimaestro.sh` did `git pull` → `install-plugin.sh` but never `git submodule update` in between. `git pull` moves the submodule pointer but doesn't check out its content, so install-plugin reinstalled **stale** plugin scripts. Add `git submodule update --init --recursive --force` after the pull — the missing link behind host updates shipping stale statusline/hook/amp-* scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)