### PR TITLE
OTLP telemetry receiver — fill token/cost tiles (v0.36.32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.31-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.32-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/telemetry/v1/metrics/route.ts
+++ b/app/api/telemetry/v1/metrics/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ingestClaudeMetrics } from '@/services/telemetry-service'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * OTLP/HTTP metrics receiver — agents launched with AIMAESTRO_TELEMETRY export
+ * `claude_code.*` metrics here (OTEL_EXPORTER_OTLP_ENDPOINT=.../api/telemetry,
+ * the SDK appends /v1/metrics). We attribute token/cost usage to agents via the
+ * session.id on each data point. Always answers 200 with an empty
+ * ExportMetricsServiceResponse so the exporter never retry-storms.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const summary = ingestClaudeMetrics(body)
+    if (process.env.DEBUG) console.log('[Telemetry] ingest', summary)
+  } catch (error) {
+    console.error('[Telemetry] ingest error:', error)
+  }
+  return NextResponse.json({}, { status: 200 })
+}

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -401,6 +401,17 @@ export function getAgentBySession(sessionName: string, hostId?: string): Agent |
 }
 
 /**
+ * Find the agent whose current Claude Code session matches this session id.
+ * Used to correlate OTLP telemetry (each metric carries a `session.id`) back to
+ * an agent. Returns null when no agent owns the session.
+ */
+export function getAgentByClaudeSessionId(sessionId: string): Agent | null {
+  if (!sessionId) return null
+  const agents = loadAgents()
+  return agents.find(a => !a.deletedAt && a.claudeSessionId === sessionId) || null
+}
+
+/**
  * Create a new agent
  */
 export function createAgent(request: CreateAgentRequest): Agent {

--- a/lib/claude-telemetry.ts
+++ b/lib/claude-telemetry.ts
@@ -1,0 +1,56 @@
+/**
+ * Claude Code OTLP telemetry → AI Maestro (`claude_code.*` metrics).
+ *
+ * When enabled, agent launches export OpenTelemetry metrics to AI Maestro's
+ * receiver. Each metric carries a `session.id` attribute (on by default), which
+ * we map to an agent via `Agent.claudeSessionId` to populate real token/cost
+ * usage on the agent's metrics tiles.
+ *
+ * Off by default (opt-in via AIMAESTRO_TELEMETRY): telemetry adds an exporter to
+ * every agent process, so the fleet is unaffected until an operator opts in.
+ * Mirrors AIMAESTRO_SESSION_NAME / AIMAESTRO_CHANNEL_FLAG rollout.
+ *
+ * Exact env surface + metric names verified against
+ * https://code.claude.com/docs/en/monitoring-usage.md
+ */
+
+const CLAUDE_PROGRAMS = new Set(['claude', 'claude-code'])
+
+/** True when AIMAESTRO_TELEMETRY opts this host into exporting OTLP telemetry. */
+export function isTelemetryEnabled(): boolean {
+  const v = (process.env.AIMAESTRO_TELEMETRY || '').trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on'
+}
+
+/**
+ * Base URL of the receiver AI Maestro exposes for OTLP/HTTP. The exporter posts
+ * metrics to `<endpoint>/v1/metrics`. Overridable so remote hosts can point at a
+ * central collector; defaults to the local AI Maestro server.
+ */
+export function telemetryEndpoint(): string {
+  return (process.env.AIMAESTRO_TELEMETRY_ENDPOINT || 'http://localhost:23000/api/telemetry').replace(/\/+$/, '')
+}
+
+/**
+ * `KEY='value' ...` env-export prefix to prepend to a claude launch command so
+ * the process exports OTLP metrics to AI Maestro. Empty string when disabled or
+ * not a claude program. http/json protocol so the receiver parses plain JSON
+ * (no protobuf dependency). Values are fixed/sanitized, so the prefix is
+ * shell-safe.
+ */
+export function claudeTelemetryEnvPrefix(program: string): string {
+  if (!isTelemetryEnabled()) return ''
+  if (!CLAUDE_PROGRAMS.has((program || '').toLowerCase())) return ''
+  const pairs: Record<string, string> = {
+    CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+    OTEL_METRICS_EXPORTER: 'otlp',
+    OTEL_EXPORTER_OTLP_PROTOCOL: 'http/json',
+    OTEL_EXPORTER_OTLP_ENDPOINT: telemetryEndpoint(),
+    // session.id is included by default; keep metric cardinality per-session so
+    // the receiver can attribute usage to an agent.
+    OTEL_METRICS_INCLUDE_SESSION_ID: 'true',
+    // Export a bit more often than the 60s default for fresher dashboard tiles.
+    OTEL_METRIC_EXPORT_INTERVAL: '30000',
+  }
+  return Object.entries(pairs).map(([k, v]) => `${k}='${v}'`).join(' ') + ' '
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.31",
+  "version": "0.36.32",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -60,6 +60,7 @@ import {
 import { resolveAgentIdentifier } from '@/lib/messageQueue'
 import { getHosts, getSelfHost, getSelfHostId, isSelf, updateHostRaw } from '@/lib/hosts-config'
 import { claudeSessionNameFlag } from '@/lib/claude-session-name'
+import { claudeTelemetryEnvPrefix } from '@/lib/claude-telemetry'
 import { persistSession, unpersistSession } from '@/lib/session-persistence'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { initializeAllAgents, getStartupStatus } from '@/lib/agent-startup'
@@ -1872,6 +1873,10 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
           if (process.env.AIMAESTRO_KEEP_ALT_SCREEN !== 'true') {
             fullCommand = `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 ${fullCommand}`
           }
+
+          // Opt-in OTLP telemetry: export claude_code.* metrics to AI Maestro's
+          // receiver, correlated to this agent via session.id (off by default).
+          fullCommand = `${claudeTelemetryEnvPrefix(startCommand)}${fullCommand}`
         }
 
         // Small delay to let the session initialize

--- a/services/agents-docker-service.ts
+++ b/services/agents-docker-service.ts
@@ -21,6 +21,7 @@ import { PERMISSION_MODE_TO_CLI } from '@/types/agent'
 import type { AgentPermissionMode } from '@/types/agent'
 import { CONTAINER_CWD_GEMINI_PROJECT } from '@/lib/container-utils'
 import { claudeSessionNameFlag } from '@/lib/claude-session-name'
+import { claudeTelemetryEnvPrefix } from '@/lib/claude-telemetry'
 
 const execAsync = promisify(exec)
 
@@ -105,7 +106,8 @@ export function buildAiToolCommand(body: Pick<DockerCreateRequest, 'program' | '
     const escapedPrompt = body.prompt.replace(/'/g, "'\\''")
     aiTool += ` -p '${escapedPrompt}'`
   }
-  return aiTool
+  // Opt-in OTLP telemetry env prefix (off by default; no-op for non-claude).
+  return claudeTelemetryEnvPrefix(program) + aiTool
 }
 
 export function validateMounts(mounts: SandboxMount[] | undefined): string | null {

--- a/services/telemetry-service.ts
+++ b/services/telemetry-service.ts
@@ -1,0 +1,89 @@
+/**
+ * OTLP telemetry receiver for Claude Code `claude_code.*` metrics.
+ *
+ * Agents launched with AIMAESTRO_TELEMETRY export OTLP/HTTP+JSON metrics here.
+ * Each metric data point carries a `session.id` attribute; we sum token/cost
+ * usage per session and map it to an agent via Agent.claudeSessionId, filling
+ * the Tokens Used / API Cost tiles with real data.
+ *
+ * Metric names + attributes per https://code.claude.com/docs/en/monitoring-usage.md
+ *   - claude_code.token.usage  (counter, tokens; attr: session.id, type, model)
+ *   - claude_code.cost.usage   (counter, USD;    attr: session.id, model, ...)
+ * Both are cumulative counters, so the latest export's per-session sum IS the
+ * running total — we SET (not accumulate) on the agent.
+ */
+import { getAgentByClaudeSessionId, updateAgentMetrics } from '@/lib/agent-registry'
+
+interface OtlpAttr {
+  key: string
+  value?: { stringValue?: string; intValue?: string | number; doubleValue?: number; boolValue?: boolean }
+}
+interface OtlpDataPoint { attributes?: OtlpAttr[]; asInt?: string | number; asDouble?: number }
+interface OtlpMetric {
+  name?: string
+  sum?: { dataPoints?: OtlpDataPoint[] }
+  gauge?: { dataPoints?: OtlpDataPoint[] }
+}
+
+const TOKEN_METRIC = 'claude_code.token.usage'
+const COST_METRIC = 'claude_code.cost.usage'
+
+function attrString(attrs: OtlpAttr[] | undefined, key: string): string | undefined {
+  return (attrs || []).find(a => a.key === key)?.value?.stringValue
+}
+function pointValue(dp: OtlpDataPoint): number {
+  if (dp.asDouble !== undefined && dp.asDouble !== null) return Number(dp.asDouble) || 0
+  if (dp.asInt !== undefined && dp.asInt !== null) return Number(dp.asInt) || 0
+  return 0
+}
+
+/**
+ * Pure parse: OTLP metrics JSON → per-session cumulative { tokens, cost }.
+ * Sums across type/model series so each session gets a single total.
+ */
+export function parseClaudeMetrics(body: any): Record<string, { tokens: number; cost: number }> {
+  const bySession: Record<string, { tokens: number; cost: number }> = {}
+  for (const rm of (body?.resourceMetrics || [])) {
+    for (const sm of (rm?.scopeMetrics || [])) {
+      for (const m of (sm?.metrics || []) as OtlpMetric[]) {
+        const isToken = m?.name === TOKEN_METRIC
+        const isCost = m?.name === COST_METRIC
+        if (!isToken && !isCost) continue
+        const dps = m?.sum?.dataPoints || m?.gauge?.dataPoints || []
+        for (const dp of dps) {
+          const sid = attrString(dp.attributes, 'session.id')
+          if (!sid) continue
+          if (!bySession[sid]) bySession[sid] = { tokens: 0, cost: 0 }
+          const v = pointValue(dp)
+          if (isToken) bySession[sid].tokens += v
+          else bySession[sid].cost += v
+        }
+      }
+    }
+  }
+  return bySession
+}
+
+/**
+ * Parse an OTLP metrics export and write per-session totals onto the matching
+ * agents. Returns a small summary for the response/logs.
+ */
+export function ingestClaudeMetrics(body: any): { sessions: number; updated: number; unmatched: number } {
+  const bySession = parseClaudeMetrics(body)
+  const sessionIds = Object.keys(bySession)
+  let updated = 0
+  let unmatched = 0
+  for (const sid of sessionIds) {
+    const agent = getAgentByClaudeSessionId(sid)
+    if (!agent) { unmatched++; continue }
+    const { tokens, cost } = bySession[sid]
+    const metrics: Record<string, number> = {}
+    if (tokens > 0) metrics.totalTokensUsed = Math.round(tokens)
+    if (cost > 0) metrics.estimatedCost = cost
+    if (Object.keys(metrics).length > 0) {
+      updateAgentMetrics(agent.id, metrics as any)
+      updated++
+    }
+  }
+  return { sessions: sessionIds.length, updated, unmatched }
+}

--- a/tests/claude-telemetry.test.ts
+++ b/tests/claude-telemetry.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { isTelemetryEnabled, telemetryEndpoint, claudeTelemetryEnvPrefix } from '@/lib/claude-telemetry'
+import { parseClaudeMetrics } from '@/services/telemetry-service'
+
+const ORIG = { ...process.env }
+afterEach(() => {
+  process.env = { ...ORIG }
+})
+
+describe('claudeTelemetryEnvPrefix', () => {
+  it('is empty by default (opt-in)', () => {
+    delete process.env.AIMAESTRO_TELEMETRY
+    expect(claudeTelemetryEnvPrefix('claude')).toBe('')
+  })
+  it('emits the OTLP env prefix for claude when enabled', () => {
+    process.env.AIMAESTRO_TELEMETRY = '1'
+    const p = claudeTelemetryEnvPrefix('claude')
+    expect(p).toContain("CLAUDE_CODE_ENABLE_TELEMETRY='1'")
+    expect(p).toContain("OTEL_METRICS_EXPORTER='otlp'")
+    expect(p).toContain("OTEL_EXPORTER_OTLP_PROTOCOL='http/json'")
+    expect(p).toContain("OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:23000/api/telemetry'")
+    expect(p.endsWith(' ')).toBe(true) // trailing space so it prefixes the command
+  })
+  it('is empty for non-claude programs even when enabled', () => {
+    process.env.AIMAESTRO_TELEMETRY = 'on'
+    expect(claudeTelemetryEnvPrefix('codex')).toBe('')
+  })
+  it('honors a custom endpoint override', () => {
+    process.env.AIMAESTRO_TELEMETRY = 'true'
+    process.env.AIMAESTRO_TELEMETRY_ENDPOINT = 'http://collector.internal:4318/'
+    expect(telemetryEndpoint()).toBe('http://collector.internal:4318')
+    expect(claudeTelemetryEnvPrefix('claude')).toContain("OTEL_EXPORTER_OTLP_ENDPOINT='http://collector.internal:4318'")
+  })
+  it('isTelemetryEnabled reads truthy/falsey values', () => {
+    for (const v of ['1', 'true', 'yes', 'on']) { process.env.AIMAESTRO_TELEMETRY = v; expect(isTelemetryEnabled()).toBe(true) }
+    for (const v of ['0', 'false', 'off', '']) { process.env.AIMAESTRO_TELEMETRY = v; expect(isTelemetryEnabled()).toBe(false) }
+  })
+})
+
+describe('parseClaudeMetrics (OTLP JSON)', () => {
+  // One export: session s1 has input+output tokens (summed) and a cost;
+  // session s2 has only cost; a data point with no session.id is ignored.
+  const body = {
+    resourceMetrics: [{
+      scopeMetrics: [{
+        metrics: [
+          {
+            name: 'claude_code.token.usage',
+            sum: { dataPoints: [
+              { attributes: [{ key: 'session.id', value: { stringValue: 's1' } }, { key: 'type', value: { stringValue: 'input' } }], asInt: '1000' },
+              { attributes: [{ key: 'session.id', value: { stringValue: 's1' } }, { key: 'type', value: { stringValue: 'output' } }], asInt: '250' },
+              { attributes: [{ key: 'type', value: { stringValue: 'input' } }], asInt: '999' }, // no session.id → ignored
+            ] },
+          },
+          {
+            name: 'claude_code.cost.usage',
+            sum: { dataPoints: [
+              { attributes: [{ key: 'session.id', value: { stringValue: 's1' } }], asDouble: 0.42 },
+              { attributes: [{ key: 'session.id', value: { stringValue: 's2' } }], asDouble: 1.5 },
+            ] },
+          },
+          { name: 'claude_code.session.count', sum: { dataPoints: [{ attributes: [{ key: 'session.id', value: { stringValue: 's1' } }], asInt: '1' }] } }, // ignored metric
+        ],
+      }],
+    }],
+  }
+
+  it('sums tokens across type series per session and reads cost', () => {
+    const r = parseClaudeMetrics(body)
+    expect(r.s1).toEqual({ tokens: 1250, cost: 0.42 })
+    expect(r.s2).toEqual({ tokens: 0, cost: 1.5 })
+  })
+  it('ignores data points without a session.id', () => {
+    const r = parseClaudeMetrics(body)
+    // the 999-token point had no session.id, so s1 tokens stay 1250 (not 2249)
+    expect(r.s1.tokens).toBe(1250)
+  })
+  it('handles empty / malformed bodies without throwing', () => {
+    expect(parseClaudeMetrics({})).toEqual({})
+    expect(parseClaudeMetrics(null)).toEqual({})
+    expect(parseClaudeMetrics({ resourceMetrics: [{}] })).toEqual({})
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.31",
+  "version": "0.36.32",
   "releaseDate": "2026-08-19",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Completes the agent metrics tiles. Agents launched with `AIMAESTRO_TELEMETRY` export `claude_code.*` OTLP metrics to a new receiver that attributes token/cost usage to an agent via `session.id` → `Agent.claudeSessionId` (shipped v0.36.29).

- **lib/claude-telemetry.ts**: gated OTEL env prefix (off by default; http/json → no protobuf dep), injected into both launch builders.
- **POST /api/telemetry/v1/metrics**: OTLP/HTTP receiver (always 200).
- **services/telemetry-service.ts**: parse `claude_code.token.usage` (summed across type series) + `claude_code.cost.usage`, set on the agent.
- Tests + verified **live end-to-end** (POST OTLP → tiles show tokens=15400, cost=0.876).

`totalApiCalls` needs the logs exporter (follow-on). 874 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)