### PR TITLE
Total API Calls tile via OTLP logs (v0.36.33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.33] - 2026-08-19 — Total API Calls tile (OTLP logs)
+
+### Added
+- **Total API Calls telemetry** — completes the metrics tiles. With `AIMAESTRO_TELEMETRY`, agents now also export OTLP *logs* (`OTEL_LOGS_EXPORTER=otlp`); a receiver at `POST /api/telemetry/v1/logs` counts `claude_code.api_request` events per `session.id` and increments the matching agent's `totalApiCalls` (`services/telemetry-service.ts` `parseApiRequestCounts`/`ingestClaudeLogs`). Log batches are deltas, so this increments rather than sets. Verified live end-to-end.
+
 ## [0.36.25] – [0.36.32] - 2026-08-19 — Detached-session identity, native Claude Code integration & telemetry
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.32-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.33-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/claude-telemetry.ts
+++ b/lib/claude-telemetry.ts
@@ -44,6 +44,9 @@ export function claudeTelemetryEnvPrefix(program: string): string {
   const pairs: Record<string, string> = {
     CLAUDE_CODE_ENABLE_TELEMETRY: '1',
     OTEL_METRICS_EXPORTER: 'otlp',
+    // Logs carry the per-request `claude_code.api_request` events (each with a
+    // session.id) — the source for the agent's Total API Calls tile.
+    OTEL_LOGS_EXPORTER: 'otlp',
     OTEL_EXPORTER_OTLP_PROTOCOL: 'http/json',
     OTEL_EXPORTER_OTLP_ENDPOINT: telemetryEndpoint(),
     // session.id is included by default; keep metric cardinality per-session so

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.32",
+  "version": "0.36.33",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/telemetry-service.ts
+++ b/services/telemetry-service.ts
@@ -12,7 +12,7 @@
  * Both are cumulative counters, so the latest export's per-session sum IS the
  * running total — we SET (not accumulate) on the agent.
  */
-import { getAgentByClaudeSessionId, updateAgentMetrics } from '@/lib/agent-registry'
+import { getAgentByClaudeSessionId, updateAgentMetrics, incrementAgentMetric } from '@/lib/agent-registry'
 
 interface OtlpAttr {
   key: string
@@ -86,4 +86,54 @@ export function ingestClaudeMetrics(body: any): { sessions: number; updated: num
     }
   }
   return { sessions: sessionIds.length, updated, unmatched }
+}
+
+// ── Logs: claude_code.api_request events → Total API Calls ──────────────────
+// Unlike metrics (cumulative counters), each OTLP logs export is a BATCH of new
+// events since the last export, so we INCREMENT the agent's call count rather
+// than set it. Each record carries event.name + session.id (standard attribute).
+
+const API_REQUEST_EVENTS = new Set(['api_request', 'claude_code.api_request'])
+
+/**
+ * Pure parse: OTLP logs JSON → per-session count of api_request events in this
+ * export (a delta, not a cumulative total).
+ */
+export function parseApiRequestCounts(body: any): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const rl of (body?.resourceLogs || [])) {
+    for (const sl of (rl?.scopeLogs || [])) {
+      for (const rec of (sl?.logRecords || [])) {
+        const attrs = rec?.attributes as OtlpAttr[] | undefined
+        const evt = attrString(attrs, 'event.name')
+        // Some exporters put the event name in the record body instead.
+        const bodyVal = rec?.body?.stringValue
+        if (!API_REQUEST_EVENTS.has(evt || '') && !API_REQUEST_EVENTS.has(bodyVal || '')) continue
+        const sid = attrString(attrs, 'session.id')
+        if (!sid) continue
+        counts[sid] = (counts[sid] || 0) + 1
+      }
+    }
+  }
+  return counts
+}
+
+/**
+ * Increment each matching agent's totalApiCalls by the number of api_request
+ * events in this export.
+ */
+export function ingestClaudeLogs(body: any): { sessions: number; updated: number; unmatched: number; apiCalls: number } {
+  const counts = parseApiRequestCounts(body)
+  const sessionIds = Object.keys(counts)
+  let updated = 0
+  let unmatched = 0
+  let apiCalls = 0
+  for (const sid of sessionIds) {
+    apiCalls += counts[sid]
+    const agent = getAgentByClaudeSessionId(sid)
+    if (!agent) { unmatched++; continue }
+    incrementAgentMetric(agent.id, 'totalApiCalls', counts[sid])
+    updated++
+  }
+  return { sessions: sessionIds.length, updated, unmatched, apiCalls }
 }

--- a/tests/claude-telemetry.test.ts
+++ b/tests/claude-telemetry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { isTelemetryEnabled, telemetryEndpoint, claudeTelemetryEnvPrefix } from '@/lib/claude-telemetry'
-import { parseClaudeMetrics } from '@/services/telemetry-service'
+import { parseClaudeMetrics, parseApiRequestCounts } from '@/services/telemetry-service'
 
 const ORIG = { ...process.env }
 afterEach(() => {
@@ -17,6 +17,7 @@ describe('claudeTelemetryEnvPrefix', () => {
     const p = claudeTelemetryEnvPrefix('claude')
     expect(p).toContain("CLAUDE_CODE_ENABLE_TELEMETRY='1'")
     expect(p).toContain("OTEL_METRICS_EXPORTER='otlp'")
+    expect(p).toContain("OTEL_LOGS_EXPORTER='otlp'")
     expect(p).toContain("OTEL_EXPORTER_OTLP_PROTOCOL='http/json'")
     expect(p).toContain("OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:23000/api/telemetry'")
     expect(p.endsWith(' ')).toBe(true) // trailing space so it prefixes the command
@@ -79,5 +80,37 @@ describe('parseClaudeMetrics (OTLP JSON)', () => {
     expect(parseClaudeMetrics({})).toEqual({})
     expect(parseClaudeMetrics(null)).toEqual({})
     expect(parseClaudeMetrics({ resourceMetrics: [{}] })).toEqual({})
+  })
+})
+
+describe('parseApiRequestCounts (OTLP logs)', () => {
+  const body = {
+    resourceLogs: [{
+      scopeLogs: [{
+        logRecords: [
+          // two api_request events for s1
+          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }, { key: 'session.id', value: { stringValue: 's1' } }] },
+          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }, { key: 'session.id', value: { stringValue: 's1' } }] },
+          // one for s2, with the full event name form
+          { attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.api_request' } }, { key: 'session.id', value: { stringValue: 's2' } }] },
+          // a different event → ignored
+          { attributes: [{ key: 'event.name', value: { stringValue: 'user_prompt' } }, { key: 'session.id', value: { stringValue: 's1' } }] },
+          // api_request without session.id → ignored
+          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }] },
+        ],
+      }],
+    }],
+  }
+
+  it('counts api_request events per session (this export = a delta)', () => {
+    expect(parseApiRequestCounts(body)).toEqual({ s1: 2, s2: 1 })
+  })
+  it('ignores non-api_request events and records without session.id', () => {
+    const r = parseApiRequestCounts(body)
+    expect(r.s1).toBe(2) // the user_prompt + session-less api_request did not count
+  })
+  it('handles empty / malformed bodies', () => {
+    expect(parseApiRequestCounts({})).toEqual({})
+    expect(parseApiRequestCounts(null)).toEqual({})
   })
 })

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.32",
-  "releaseDate": "2026-08-19",
+  "version": "0.36.33",
+  "releaseDate": "2026-08-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
Completes the telemetry tiles. Agents with `AIMAESTRO_TELEMETRY` now also export OTLP logs; a receiver at `POST /api/telemetry/v1/logs` counts `claude_code.api_request` events per `session.id` (a standard attribute on every log record) and increments the agent's `totalApiCalls`. Log batches are deltas → increment, not set. 877 tests pass, verified live (+3). Off by default.