### PR TITLE
Commit the OTLP logs receiver route (v0.36.34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ temp
 # Session logs
 logs/
 *.log
+# ...but NOT the Next.js OTLP-logs API route (the `logs/` dir above is a URL segment)
+!app/api/telemetry/v1/logs/
+!app/api/telemetry/v1/logs/**
 
 # Configuration
 .aimaestro/hosts.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.33-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.34-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/telemetry/v1/logs/route.ts
+++ b/app/api/telemetry/v1/logs/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ingestClaudeLogs } from '@/services/telemetry-service'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * OTLP/HTTP logs receiver — agents launched with AIMAESTRO_TELEMETRY export
+ * `claude_code.*` event logs here (the SDK appends /v1/logs to the endpoint).
+ * We count `claude_code.api_request` events per session.id and increment the
+ * matching agent's totalApiCalls. Always answers 200 (empty
+ * ExportLogsServiceResponse) so the exporter never retry-storms.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const summary = ingestClaudeLogs(body)
+    if (process.env.DEBUG) console.log('[Telemetry/logs] ingest', summary)
+  } catch (error) {
+    console.error('[Telemetry/logs] ingest error:', error)
+  }
+  return NextResponse.json({}, { status: 200 })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.33",
+  "version": "0.36.34",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.33",
+  "version": "0.36.34",
   "releaseDate": "2026-08-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
The `logs/` .gitignore rule silently excluded `app/api/telemetry/v1/logs/route.ts`, so #407 merged without the receiver (POSTs to /v1/logs would 404). Un-ignore the path and commit the route.