### PR TITLE
Honest agent metrics overview (v0.36.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.35] - 2026-08-19 — Honest agent metrics overview
+
+### Changed
+- **Agent profile "Metrics Overview" now shows only real data.** Five of the eight tiles (Messages, Tasks, Uptime, Sessions, Avg Response) had no writer anywhere and were permanently `0`/`N/A` across every agent. Fixed:
+  - **Sessions** ← `launchCount` (tracked on every wake; falls back live so existing agents populate immediately).
+  - **Active Time** (was "Uptime") ← telemetry `claude_code.active_time.total` — real active time, not calendar age.
+  - **Avg Response** ← telemetry `api_request.duration_ms` (running average in the OTLP logs receiver).
+  - **Removed Messages and Tasks** — a message counter belongs in a dedicated AMP view (per-agent disk I/O on render or under-counting history), and Tasks is team-meeting-scoped. Both applied to `AgentProfileTab` and `AgentProfile`.
+- Result: 6 honest tiles — Sessions, Active Time, Avg Response, API Cost, Tokens Used, API Calls (the last four fill when telemetry is enabled). Verified live end-to-end.
+
 ## [0.36.33] - 2026-08-19 — Total API Calls tile (OTLP logs)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.34-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.35-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/components/AgentProfile.tsx
+++ b/components/AgentProfile.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import {
   X, User, Building2, Briefcase, Code2, Cpu, Tag,
-  Activity, MessageSquare, CheckCircle, Clock, Zap,
+  Activity, CheckCircle, Clock, Zap,
   DollarSign, Database, BookOpen, Link2, Edit2, Save,
   ChevronDown, ChevronRight, Plus, Trash2, TrendingUp, TrendingDown,
   Cloud, Monitor, Server, Play, Wifi, WifiOff, Folder, Download, Send,
@@ -889,24 +889,14 @@ export default function AgentProfile({ isOpen, onClose, agentId, sessionStatus, 
                 {expandedSections.metrics && agent.metrics && (
                   <div className="grid grid-cols-2 gap-4">
                     <MetricCard
-                      icon={<MessageSquare className="w-5 h-5 text-blue-400" />}
-                      value={agent.metrics.totalMessages || 0}
-                      label="Messages"
-                    />
-                    <MetricCard
-                      icon={<CheckCircle className="w-5 h-5 text-green-400" />}
-                      value={agent.metrics.totalTasksCompleted || 0}
-                      label="Tasks"
+                      icon={<Activity className="w-5 h-5 text-orange-400" />}
+                      value={agent.metrics.totalSessions || agent.launchCount || 0}
+                      label="Sessions"
                     />
                     <MetricCard
                       icon={<Clock className="w-5 h-5 text-purple-400" />}
                       value={`${(agent.metrics.uptimeHours || 0).toFixed(1)}h`}
-                      label="Uptime"
-                    />
-                    <MetricCard
-                      icon={<Activity className="w-5 h-5 text-orange-400" />}
-                      value={agent.metrics.totalSessions || 0}
-                      label="Sessions"
+                      label="Active Time"
                     />
                     <MetricCard
                       icon={<Zap className="w-5 h-5 text-yellow-400" />}

--- a/components/zoom/AgentProfileTab.tsx
+++ b/components/zoom/AgentProfileTab.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react'
 import {
   User, Building2, Briefcase, Code2, Cpu, Tag,
-  Activity, MessageSquare, CheckCircle, Clock, Zap,
+  Activity, CheckCircle, Clock, Zap,
   DollarSign, Database, BookOpen, Link2, Edit2, Save,
   ChevronDown, ChevronRight, Trash2,
   Cloud, Monitor, Wifi, WifiOff, Folder, Download, Send,
@@ -660,24 +660,14 @@ export default function AgentProfileTab({ agent: initialAgent, hostUrl, onClose 
           {expandedSections.metrics && agent.metrics && (
             <div className="grid grid-cols-2 gap-4">
               <MetricCard
-                icon={<MessageSquare className="w-5 h-5 text-blue-400" />}
-                value={agent.metrics.totalMessages || 0}
-                label="Messages"
-              />
-              <MetricCard
-                icon={<CheckCircle className="w-5 h-5 text-green-400" />}
-                value={agent.metrics.totalTasksCompleted || 0}
-                label="Tasks"
+                icon={<Activity className="w-5 h-5 text-orange-400" />}
+                value={agent.metrics.totalSessions || agent.launchCount || 0}
+                label="Sessions"
               />
               <MetricCard
                 icon={<Clock className="w-5 h-5 text-purple-400" />}
                 value={`${(agent.metrics.uptimeHours || 0).toFixed(1)}h`}
-                label="Uptime"
-              />
-              <MetricCard
-                icon={<Activity className="w-5 h-5 text-orange-400" />}
-                value={agent.metrics.totalSessions || 0}
-                label="Sessions"
+                label="Active Time"
               />
               <MetricCard
                 icon={<Zap className="w-5 h-5 text-yellow-400" />}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.34",
+  "version": "0.36.35",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -714,6 +714,9 @@ function updateAgentSessionInRegistry(
 
   if (incrementLaunch) {
     agents[index].launchCount = (agents[index].launchCount || 0) + 1
+    // Mirror launch count into metrics so the profile's "Sessions" tile is fed.
+    if (!agents[index].metrics) agents[index].metrics = {}
+    agents[index].metrics!.totalSessions = agents[index].launchCount
   }
 
   saveAgents(agents)

--- a/services/telemetry-service.ts
+++ b/services/telemetry-service.ts
@@ -12,7 +12,7 @@
  * Both are cumulative counters, so the latest export's per-session sum IS the
  * running total — we SET (not accumulate) on the agent.
  */
-import { getAgentByClaudeSessionId, updateAgentMetrics, incrementAgentMetric } from '@/lib/agent-registry'
+import { getAgentByClaudeSessionId, updateAgentMetrics } from '@/lib/agent-registry'
 
 interface OtlpAttr {
   key: string
@@ -27,6 +27,7 @@ interface OtlpMetric {
 
 const TOKEN_METRIC = 'claude_code.token.usage'
 const COST_METRIC = 'claude_code.cost.usage'
+const ACTIVE_TIME_METRIC = 'claude_code.active_time.total' // seconds (counter)
 
 function attrString(attrs: OtlpAttr[] | undefined, key: string): string | undefined {
   return (attrs || []).find(a => a.key === key)?.value?.stringValue
@@ -38,25 +39,27 @@ function pointValue(dp: OtlpDataPoint): number {
 }
 
 /**
- * Pure parse: OTLP metrics JSON → per-session cumulative { tokens, cost }.
- * Sums across type/model series so each session gets a single total.
+ * Pure parse: OTLP metrics JSON → per-session cumulative { tokens, cost,
+ * activeSeconds }. All three are cumulative counters, summed across series.
  */
-export function parseClaudeMetrics(body: any): Record<string, { tokens: number; cost: number }> {
-  const bySession: Record<string, { tokens: number; cost: number }> = {}
+export function parseClaudeMetrics(body: any): Record<string, { tokens: number; cost: number; activeSeconds: number }> {
+  const bySession: Record<string, { tokens: number; cost: number; activeSeconds: number }> = {}
   for (const rm of (body?.resourceMetrics || [])) {
     for (const sm of (rm?.scopeMetrics || [])) {
       for (const m of (sm?.metrics || []) as OtlpMetric[]) {
         const isToken = m?.name === TOKEN_METRIC
         const isCost = m?.name === COST_METRIC
-        if (!isToken && !isCost) continue
+        const isActive = m?.name === ACTIVE_TIME_METRIC
+        if (!isToken && !isCost && !isActive) continue
         const dps = m?.sum?.dataPoints || m?.gauge?.dataPoints || []
         for (const dp of dps) {
           const sid = attrString(dp.attributes, 'session.id')
           if (!sid) continue
-          if (!bySession[sid]) bySession[sid] = { tokens: 0, cost: 0 }
+          if (!bySession[sid]) bySession[sid] = { tokens: 0, cost: 0, activeSeconds: 0 }
           const v = pointValue(dp)
           if (isToken) bySession[sid].tokens += v
-          else bySession[sid].cost += v
+          else if (isCost) bySession[sid].cost += v
+          else bySession[sid].activeSeconds += v
         }
       }
     }
@@ -76,10 +79,11 @@ export function ingestClaudeMetrics(body: any): { sessions: number; updated: num
   for (const sid of sessionIds) {
     const agent = getAgentByClaudeSessionId(sid)
     if (!agent) { unmatched++; continue }
-    const { tokens, cost } = bySession[sid]
+    const { tokens, cost, activeSeconds } = bySession[sid]
     const metrics: Record<string, number> = {}
     if (tokens > 0) metrics.totalTokensUsed = Math.round(tokens)
     if (cost > 0) metrics.estimatedCost = cost
+    if (activeSeconds > 0) metrics.uptimeHours = activeSeconds / 3600
     if (Object.keys(metrics).length > 0) {
       updateAgentMetrics(agent.id, metrics as any)
       updated++
@@ -95,12 +99,21 @@ export function ingestClaudeMetrics(body: any): { sessions: number; updated: num
 
 const API_REQUEST_EVENTS = new Set(['api_request', 'claude_code.api_request'])
 
+function attrNumber(attrs: OtlpAttr[] | undefined, key: string): number | undefined {
+  const v = (attrs || []).find(a => a.key === key)?.value
+  if (!v) return undefined
+  if (v.doubleValue !== undefined && v.doubleValue !== null) return Number(v.doubleValue)
+  if (v.intValue !== undefined && v.intValue !== null) return Number(v.intValue)
+  if (v.stringValue) { const n = Number(v.stringValue); return Number.isFinite(n) ? n : undefined }
+  return undefined
+}
+
 /**
- * Pure parse: OTLP logs JSON → per-session count of api_request events in this
- * export (a delta, not a cumulative total).
+ * Pure parse: OTLP logs JSON → per-session { count, durationSumMs } of
+ * api_request events in this export (a delta, not a cumulative total).
  */
-export function parseApiRequestCounts(body: any): Record<string, number> {
-  const counts: Record<string, number> = {}
+export function parseApiRequests(body: any): Record<string, { count: number; durationSumMs: number }> {
+  const out: Record<string, { count: number; durationSumMs: number }> = {}
   for (const rl of (body?.resourceLogs || [])) {
     for (const sl of (rl?.scopeLogs || [])) {
       for (const rec of (sl?.logRecords || [])) {
@@ -111,28 +124,40 @@ export function parseApiRequestCounts(body: any): Record<string, number> {
         if (!API_REQUEST_EVENTS.has(evt || '') && !API_REQUEST_EVENTS.has(bodyVal || '')) continue
         const sid = attrString(attrs, 'session.id')
         if (!sid) continue
-        counts[sid] = (counts[sid] || 0) + 1
+        if (!out[sid]) out[sid] = { count: 0, durationSumMs: 0 }
+        out[sid].count += 1
+        const d = attrNumber(attrs, 'duration_ms')
+        if (d && d > 0) out[sid].durationSumMs += d
       }
     }
   }
-  return counts
+  return out
 }
 
 /**
- * Increment each matching agent's totalApiCalls by the number of api_request
- * events in this export.
+ * For each matching agent: increment totalApiCalls by the number of api_request
+ * events, and update averageResponseTime as a running average using duration_ms.
  */
 export function ingestClaudeLogs(body: any): { sessions: number; updated: number; unmatched: number; apiCalls: number } {
-  const counts = parseApiRequestCounts(body)
-  const sessionIds = Object.keys(counts)
+  const byS = parseApiRequests(body)
+  const sessionIds = Object.keys(byS)
   let updated = 0
   let unmatched = 0
   let apiCalls = 0
   for (const sid of sessionIds) {
-    apiCalls += counts[sid]
+    const { count, durationSumMs } = byS[sid]
+    apiCalls += count
     const agent = getAgentByClaudeSessionId(sid)
     if (!agent) { unmatched++; continue }
-    incrementAgentMetric(agent.id, 'totalApiCalls', counts[sid])
+    const oldCalls = agent.metrics?.totalApiCalls || 0
+    const oldAvg = agent.metrics?.averageResponseTime || 0
+    const newCalls = oldCalls + count
+    const metrics: Record<string, number> = { totalApiCalls: newCalls }
+    if (durationSumMs > 0 && newCalls > 0) {
+      // Running mean over all calls seen so far.
+      metrics.averageResponseTime = Math.round((oldAvg * oldCalls + durationSumMs) / newCalls)
+    }
+    updateAgentMetrics(agent.id, metrics as any)
     updated++
   }
   return { sessions: sessionIds.length, updated, unmatched, apiCalls }

--- a/tests/claude-telemetry.test.ts
+++ b/tests/claude-telemetry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { isTelemetryEnabled, telemetryEndpoint, claudeTelemetryEnvPrefix } from '@/lib/claude-telemetry'
-import { parseClaudeMetrics, parseApiRequestCounts } from '@/services/telemetry-service'
+import { parseClaudeMetrics, parseApiRequests } from '@/services/telemetry-service'
 
 const ORIG = { ...process.env }
 afterEach(() => {
@@ -68,8 +68,8 @@ describe('parseClaudeMetrics (OTLP JSON)', () => {
 
   it('sums tokens across type series per session and reads cost', () => {
     const r = parseClaudeMetrics(body)
-    expect(r.s1).toEqual({ tokens: 1250, cost: 0.42 })
-    expect(r.s2).toEqual({ tokens: 0, cost: 1.5 })
+    expect(r.s1).toEqual({ tokens: 1250, cost: 0.42, activeSeconds: 0 })
+    expect(r.s2).toEqual({ tokens: 0, cost: 1.5, activeSeconds: 0 })
   })
   it('ignores data points without a session.id', () => {
     const r = parseClaudeMetrics(body)
@@ -83,15 +83,15 @@ describe('parseClaudeMetrics (OTLP JSON)', () => {
   })
 })
 
-describe('parseApiRequestCounts (OTLP logs)', () => {
+describe('parseApiRequests (OTLP logs)', () => {
   const body = {
     resourceLogs: [{
       scopeLogs: [{
         logRecords: [
-          // two api_request events for s1
-          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }, { key: 'session.id', value: { stringValue: 's1' } }] },
-          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }, { key: 'session.id', value: { stringValue: 's1' } }] },
-          // one for s2, with the full event name form
+          // two api_request events for s1, with duration_ms (int + double forms)
+          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }, { key: 'session.id', value: { stringValue: 's1' } }, { key: 'duration_ms', value: { intValue: '100' } }] },
+          { attributes: [{ key: 'event.name', value: { stringValue: 'api_request' } }, { key: 'session.id', value: { stringValue: 's1' } }, { key: 'duration_ms', value: { doubleValue: 200 } }] },
+          // one for s2, with the full event name form, no duration
           { attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.api_request' } }, { key: 'session.id', value: { stringValue: 's2' } }] },
           // a different event → ignored
           { attributes: [{ key: 'event.name', value: { stringValue: 'user_prompt' } }, { key: 'session.id', value: { stringValue: 's1' } }] },
@@ -102,15 +102,17 @@ describe('parseApiRequestCounts (OTLP logs)', () => {
     }],
   }
 
-  it('counts api_request events per session (this export = a delta)', () => {
-    expect(parseApiRequestCounts(body)).toEqual({ s1: 2, s2: 1 })
+  it('counts api_request events + sums duration_ms per session', () => {
+    expect(parseApiRequests(body)).toEqual({
+      s1: { count: 2, durationSumMs: 300 },
+      s2: { count: 1, durationSumMs: 0 },
+    })
   })
   it('ignores non-api_request events and records without session.id', () => {
-    const r = parseApiRequestCounts(body)
-    expect(r.s1).toBe(2) // the user_prompt + session-less api_request did not count
+    expect(parseApiRequests(body).s1.count).toBe(2)
   })
   it('handles empty / malformed bodies', () => {
-    expect(parseApiRequestCounts({})).toEqual({})
-    expect(parseApiRequestCounts(null)).toEqual({})
+    expect(parseApiRequests({})).toEqual({})
+    expect(parseApiRequests(null)).toEqual({})
   })
 })

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.34",
+  "version": "0.36.35",
   "releaseDate": "2026-08-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
5 of 8 profile tiles had no writer (permanently 0/N/A). Wire the feasible ones from real sources — **Sessions** (launchCount), **Active Time** (telemetry active_time), **Avg Response** (telemetry duration_ms) — and remove **Messages** (needs a dedicated AMP view) + **Tasks** (team-scoped). 6 honest tiles remain; verified live end-to-end. 877 tests pass.