### PR TITLE
Skip registry writes when telemetry metrics unchanged (v0.36.36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.35-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.36-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.35",
+  "version": "0.36.36",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/telemetry-service.ts
+++ b/services/telemetry-service.ts
@@ -80,10 +80,18 @@ export function ingestClaudeMetrics(body: any): { sessions: number; updated: num
     const agent = getAgentByClaudeSessionId(sid)
     if (!agent) { unmatched++; continue }
     const { tokens, cost, activeSeconds } = bySession[sid]
+    // Only write metrics that actually changed. These are cumulative counters,
+    // so an idle agent re-exports identical totals — skipping unchanged values
+    // means idle agents cause ZERO registry writes (no perf cost at fleet scale).
+    const cur = agent.metrics || {}
     const metrics: Record<string, number> = {}
-    if (tokens > 0) metrics.totalTokensUsed = Math.round(tokens)
-    if (cost > 0) metrics.estimatedCost = cost
-    if (activeSeconds > 0) metrics.uptimeHours = activeSeconds / 3600
+    const newTokens = Math.round(tokens)
+    if (tokens > 0 && newTokens !== (cur.totalTokensUsed || 0)) metrics.totalTokensUsed = newTokens
+    if (cost > 0 && cost !== (cur.estimatedCost || 0)) metrics.estimatedCost = cost
+    if (activeSeconds > 0) {
+      const hours = activeSeconds / 3600
+      if (hours !== (cur.uptimeHours || 0)) metrics.uptimeHours = hours
+    }
     if (Object.keys(metrics).length > 0) {
       updateAgentMetrics(agent.id, metrics as any)
       updated++

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.35",
+  "version": "0.36.36",
   "releaseDate": "2026-08-20",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Each OTLP export rewrote the whole registry.json. token/cost/active_time are cumulative counters, so idle agents re-export identical totals — now we only write changed values, so idle agents cause zero writes. Makes always-on telemetry safe at fleet scale.