### PR TITLE
fix(delivery): never report a message wake we cannot prove (v0.36.37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.36-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.37-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/channels/amp-plugin/server.mjs
+++ b/channels/amp-plugin/server.mjs
@@ -15488,10 +15488,46 @@ var REG_FILE = AGENT_ID ? path.join(CHANNELS_DIR, `${AGENT_ID}.json`) : null;
 var mcp = new Server(
   { name: "amp", version: "0.1.0" },
   {
-    capabilities: { experimental: { "claude/channel": {} } },
-    instructions: 'Events from the "amp" channel arrive as <channel source="amp" ...>. They mean new AMP messages landed in your inbox while you were idle. Read and address them using the agent-messaging skill (amp-inbox.sh, amp-read.sh <id>, amp-reply.sh <id> "..."), then continue. One-way channel: no reply is expected back through it.'
+    capabilities: {
+      experimental: { "claude/channel": {} },
+      tools: {}
+      // enables discovery of amp_channel_ack (the delivery handshake)
+    },
+    instructions: 'Events from the "amp" channel arrive as <channel source="amp" ...>. They mean new AMP messages landed in your inbox. The event body already contains the message, so act on it directly; use the agent-messaging skill (amp-inbox.sh, amp-read.sh <id>, amp-reply.sh <id> "...") to read the full copy or reply, then continue. The FIRST time you see an <channel source="amp"> event in this session, also call the amp_channel_ack tool once. That confirms this session can actually receive channel events; until it is confirmed AI Maestro must keep sending a duplicate tmux notification as a safety net. One acknowledgement per session is enough \u2014 do not call it again.'
   }
 );
+var verified = false;
+function markVerified() {
+  if (verified || !REG_FILE) return;
+  verified = true;
+  try {
+    const info = JSON.parse(fs.readFileSync(REG_FILE, "utf8"));
+    info.verified = true;
+    info.verifiedAt = (/* @__PURE__ */ new Date()).toISOString();
+    fs.writeFileSync(REG_FILE, JSON.stringify(info));
+    process.stderr.write(`[amp-channel] verified \u2014 session receives channel events
+`);
+  } catch (e) {
+    process.stderr.write(`[amp-channel] verify write failed: ${e}
+`);
+  }
+}
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "amp_channel_ack",
+      description: 'Confirm once per session that you received an <channel source="amp"> event. Call this the first time you see one and never again. It lets AI Maestro stop sending duplicate tmux notifications to this session.',
+      inputSchema: { type: "object", properties: {}, additionalProperties: false }
+    }
+  ]
+}));
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name !== "amp_channel_ack") {
+    return { isError: true, content: [{ type: "text", text: `unknown tool: ${req.params.name}` }] };
+  }
+  markVerified();
+  return { content: [{ type: "text", text: "Channel delivery confirmed. Do not call this again." }] };
+});
 await mcp.connect(new StdioServerTransport());
 function cleanup() {
   try {

--- a/lib/amp-channel-server.mjs
+++ b/lib/amp-channel-server.mjs
@@ -19,6 +19,7 @@
  */
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import http from 'node:http'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -31,15 +32,74 @@ const REG_FILE = AGENT_ID ? path.join(CHANNELS_DIR, `${AGENT_ID}.json`) : null
 const mcp = new Server(
   { name: 'amp', version: '0.1.0' },
   {
-    capabilities: { experimental: { 'claude/channel': {} } },
+    capabilities: {
+      experimental: { 'claude/channel': {} },
+      tools: {}, // enables discovery of amp_channel_ack (the delivery handshake)
+    },
     instructions:
       'Events from the "amp" channel arrive as <channel source="amp" ...>. ' +
-      'They mean new AMP messages landed in your inbox while you were idle. ' +
-      'Read and address them using the agent-messaging skill (amp-inbox.sh, ' +
-      'amp-read.sh <id>, amp-reply.sh <id> "..."), then continue. ' +
-      'One-way channel: no reply is expected back through it.',
+      'They mean new AMP messages landed in your inbox. ' +
+      'The event body already contains the message, so act on it directly; use ' +
+      'the agent-messaging skill (amp-inbox.sh, amp-read.sh <id>, ' +
+      'amp-reply.sh <id> "...") to read the full copy or reply, then continue. ' +
+      'The FIRST time you see an <channel source="amp"> event in this session, ' +
+      'also call the amp_channel_ack tool once. That confirms this session can ' +
+      'actually receive channel events; until it is confirmed AI Maestro must ' +
+      'keep sending a duplicate tmux notification as a safety net. ' +
+      'One acknowledgement per session is enough — do not call it again.',
   },
 )
+
+// --- Delivery handshake -----------------------------------------------------
+// Claude Code does NOT acknowledge channel notifications: mcp.notification()
+// resolves when the event is written to the transport, not when the model has
+// seen it. If the session never registered us as a channel (org policy off,
+// plugin not on the allowlist, --channels not passed), events are dropped
+// SILENTLY. So a successful push proves nothing on its own, and deliver() must
+// not suppress the tmux fallback on that basis alone.
+//
+// The failure is static per session — a channel that is registered stays
+// registered — so one confirmation is enough for the session's lifetime. The
+// model calls amp_channel_ack once; we persist verified:true into the registry
+// file, and deliver() reads it to decide whether it may skip the fallback.
+// If the model never calls it, we simply never suppress the fallback: the
+// degraded state is exactly today's behaviour, not a dropped message.
+let verified = false
+
+function markVerified() {
+  if (verified || !REG_FILE) return
+  verified = true
+  try {
+    const info = JSON.parse(fs.readFileSync(REG_FILE, 'utf8'))
+    info.verified = true
+    info.verifiedAt = new Date().toISOString()
+    fs.writeFileSync(REG_FILE, JSON.stringify(info))
+    process.stderr.write(`[amp-channel] verified — session receives channel events\n`)
+  } catch (e) {
+    process.stderr.write(`[amp-channel] verify write failed: ${e}\n`)
+  }
+}
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'amp_channel_ack',
+      description:
+        'Confirm once per session that you received an <channel source="amp"> ' +
+        'event. Call this the first time you see one and never again. It lets ' +
+        'AI Maestro stop sending duplicate tmux notifications to this session.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    },
+  ],
+}))
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name !== 'amp_channel_ack') {
+    return { isError: true, content: [{ type: 'text', text: `unknown tool: ${req.params.name}` }] }
+  }
+  markVerified()
+  return { content: [{ type: 'text', text: 'Channel delivery confirmed. Do not call this again.' }] }
+})
 
 await mcp.connect(new StdioServerTransport())
 

--- a/lib/channel-bridge.mjs
+++ b/lib/channel-bridge.mjs
@@ -33,6 +33,23 @@ export function hasChannel(agentId) {
 }
 
 /**
+ * True once the agent's session has PROVEN it receives channel events, by
+ * calling the channel server's amp_channel_ack tool at least once.
+ *
+ * A successful pushToChannel() only means our own local HTTP server accepted
+ * the POST and wrote the MCP notification to the stdio transport. Claude Code
+ * never acknowledges notifications, and silently drops them when the session
+ * did not register the server as a channel (no --channels flag, plugin off the
+ * allowlist, or channelsEnabled unset for the org). Treating the POST result as
+ * delivery confirmation is how a message gets lost with no fallback at all.
+ *
+ * Only this flag is safe to suppress the tmux fallback on.
+ */
+export function isChannelVerified(agentId) {
+  return getChannelInfo(agentId)?.verified === true
+}
+
+/**
  * Push text into the agent's Channel MCP server → injects a turn. Returns true
  * only if the channel accepted it (HTTP 200). A stale registry (server gone)
  * fails the POST and returns false, so deliver() falls back to tmux — self-healing.

--- a/lib/message-delivery.ts
+++ b/lib/message-delivery.ts
@@ -2,9 +2,13 @@
  * Message Delivery - Single local delivery function
  *
  * Both the AMP route (/api/v1/route) and the web UI (/api/messages)
- * call deliver() for local delivery. It does exactly 2 things:
- *   1. Write to the recipient's AMP inbox
- *   2. Send a tmux notification
+ * call deliver() for local delivery:
+ *   1. Write to the recipient's AMP inbox (persistence, source of truth)
+ *   2. Wake the agent over the best available route — channel, streaming
+ *      session, WebSocket, or the tmux pane — and CONFIRM it landed
+ *
+ * No route may report a delivery it cannot prove. See `verified` on
+ * DeliveryResult: a push that merely left our process is not an arrival.
  *
  * No routing. No resolution. No sent write. No remote. No relay.
  */
@@ -12,11 +16,11 @@
 import { createHmac } from 'crypto'
 import { canonicalStringify } from '@/lib/amp-canonical-json'
 import { writeToAMPInbox } from '@/lib/amp-inbox-writer'
-import { notifyAgent } from '@/lib/notification-service'
+import { notifyAgent, messageRef } from '@/lib/notification-service'
 import { applyContentSecurity } from '@/lib/content-security'
 import { deliverViaWebSocket, isAgentConnectedViaWS } from '@/lib/amp-websocket'
 import { pushToStreamSession } from '@/lib/streaming-bridge.mjs'
-import { pushToChannel } from '@/lib/channel-bridge.mjs'
+import { pushToChannel, isChannelVerified } from '@/lib/channel-bridge.mjs'
 import { getAgent } from '@/lib/agent-registry'
 import type { AMPEnvelope, AMPPayload } from '@/lib/types/amp'
 
@@ -37,6 +41,12 @@ export interface DeliveryInput {
 export interface DeliveryResult {
   delivered: boolean
   notified: boolean
+  /**
+   * True only when the wake was PROVEN to reach the agent: an acknowledged
+   * channel, or the notification read back off the pane. `notified` without
+   * `verified` means "sent, unconfirmed" — never treat it as proof.
+   */
+  verified?: boolean
   error?: string
 }
 
@@ -84,11 +94,14 @@ export async function deliver(input: DeliveryInput): Promise<DeliveryResult> {
     }
   }
 
-  // The wake text used by both the streaming and channel injection paths.
+  // The wake text used by the streaming and channel injection paths. The tmux
+  // path below carries the same sender/subject/body (via notifyAgent's `body`),
+  // so every delivery route hands the agent the actual message instead of a
+  // pointer to an inbox it has to choose to open.
   const sender = senderHost && senderHost !== 'local' ? `${senderName}@${senderHost}` : senderName
   const injectBody = (securedEnvelopePayload.message || '').toString().slice(0, 2000)
   const injectText =
-    `[AMP] New message from ${sender}${subject ? ` — "${subject}"` : ''}:\n` +
+    `[AMP #${messageRef(envelope.id)}] New message from ${sender}${subject ? ` — "${subject}"` : ''}:\n` +
     `${injectBody}\n\n` +
     `(Reply using the agent-messaging skill, then continue.)`
 
@@ -120,10 +133,24 @@ export async function deliver(input: DeliveryInput): Promise<DeliveryResult> {
     console.warn('[Delivery] Channel push failed (non-fatal):', err)
   }
 
-  // 2. Send tmux notification — FALLBACK only. Skipped when the Channel already
-  // injected the turn (no redundant, fragile keystroke wake).
-  let notified = channelDelivered
-  if (!channelDelivered) {
+  // A successful push is NOT proof of delivery: Claude Code never acknowledges
+  // channel notifications and silently drops them when the session did not
+  // register us as a channel. Only suppress the fallback once the session has
+  // proven it receives events (isChannelVerified — see channel-bridge.mjs).
+  // Until then both fire; a duplicate nudge is cheap, a lost message is not.
+  const channelConfirmed =
+    channelDelivered && !!recipientAgentId && isChannelVerified(recipientAgentId)
+  if (channelDelivered && !channelConfirmed) {
+    console.log(
+      `[Delivery] Channel for ${recipientAgentName} is unverified — keeping tmux fallback for ${envelope.id}`
+    )
+  }
+
+  // 2. Send tmux notification — FALLBACK only. Skipped once the Channel is
+  // CONFIRMED to reach the model (no redundant, fragile keystroke wake).
+  let notified = channelConfirmed
+  let verified = channelConfirmed
+  if (!channelConfirmed) {
     try {
       const result = await notifyAgent({
         agentId: recipientAgentId,
@@ -134,8 +161,10 @@ export async function deliver(input: DeliveryInput): Promise<DeliveryResult> {
         messageId: envelope.id,
         priority,
         messageType,
+        body: injectBody,
       })
       notified = result.notified
+      verified = result.verified === true
     } catch (err) {
       console.warn('[Delivery] Notification failed (non-fatal):', err)
     }
@@ -152,7 +181,7 @@ export async function deliver(input: DeliveryInput): Promise<DeliveryResult> {
     }
   }
 
-  return { delivered: true, notified }
+  return { delivered: true, notified, verified }
 }
 
 // ============================================================================

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -30,11 +30,15 @@ export interface NotificationOptions {
   messageId: string       // Message ID (for reference)
   priority?: string       // Message priority (urgent, high, normal, low)
   messageType?: string    // Content type (request, response, notification, etc.)
+  body?: string           // Message body, so the pane carries the same content
+                          // as the channel/stream injection paths (not just a
+                          // "check your inbox" pointer the agent may ignore)
 }
 
 export interface NotificationResult {
   success: boolean
-  notified: boolean       // True if notification was actually sent
+  notified: boolean       // True if the notification reached the pane
+  verified?: boolean      // True if we READ IT BACK off the pane (real proof)
   reason?: string         // Why notification was skipped (if notified=false)
   error?: string          // Error message (if success=false)
 }
@@ -48,30 +52,103 @@ export interface NotificationResult {
 // every agent's terminal for notifications to take effect.
 const NOTIFICATION_SUBMIT_DELAY_MS = 150
 
+// Readback verification. send-keys returning without throwing only proves we
+// handed bytes to tmux — not that the agent's TUI accepted them. So after
+// submitting we capture the pane and look for the message back. Poll first
+// (render lag is common), and only re-send if it never appears, so a slow
+// render doesn't produce a duplicate notification.
+const NOTIFICATION_VERIFY_POLLS = 4          // x delay below = ~1s per send
+const NOTIFICATION_VERIFY_DELAY_MS = 250
+const NOTIFICATION_MAX_SENDS = 2             // initial + one resend
+const NOTIFICATION_CAPTURE_LINES = 120
+
+// Body appended to the pane notification. Kept short and single-lined: a raw
+// newline inside send-keys would submit the TUI early (and open an unterminated
+// quote at a shell prompt), truncating the message at the first line break.
+const NOTIFICATION_BODY_MAX = 400
+
+interface PaneDeliveryResult {
+  /** The bytes were handed to the runtime without error. */
+  sent: boolean
+  /** We read the message back off the pane — actual proof of arrival. */
+  verified: boolean
+  /** The runtime can't be captured, so absence of proof isn't proof of absence. */
+  unverifiable: boolean
+}
+
+/** Short, stable per-message token used as the readback needle. */
+export function messageRef(messageId: string): string {
+  return (messageId || '').replace(/[^a-zA-Z0-9]/g, '').slice(0, 8) || 'nomsgid'
+}
+
+/** Collapse to one line so send-keys can't submit early on an embedded newline. */
+export function toSingleLine(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
 /**
- * Send a notification to a tmux session.
+ * Whitespace-insensitive containment check. The pane hard-wraps at its width,
+ * so the needle can be split across lines mid-token; normalising both sides
+ * makes the match survive wrapping.
+ */
+function paneContains(pane: string, needle: string): boolean {
+  const strip = (s: string) => s.replace(/\s+/g, '')
+  return strip(pane).includes(strip(needle))
+}
+
+/**
+ * Send a notification to a tmux session and confirm it landed.
  *
  * The notification is delivered in two separate send-keys calls with a short
  * shell-level delay between them (text first, then Enter). See the comment on
  * NOTIFICATION_SUBMIT_DELAY_MS for why this matters.
+ *
+ * Then we read the pane back. This is the runtime-agnostic equivalent of the
+ * channel's amp_channel_ack: it needs no cooperation from whatever agent is
+ * running in the pane, so it works for Claude Code, Codex, Gemini CLI, Aider,
+ * or a bare shell alike.
  */
-async function sendTmuxNotification(sessionName: string, message: string): Promise<void> {
+async function sendTmuxNotification(
+  sessionName: string,
+  message: string,
+  needle: string
+): Promise<PaneDeliveryResult> {
   const runtime = getRuntime()
   // Target the first pane of the first window
   const target = `${sessionName}:0.0`
 
   // Wrap in echo so shells still render the notification at an idle prompt.
   const escapedMessage = message.replace(/'/g, "'\\''")
-  await runtime.sendKeys(target, `echo '${escapedMessage}'`, { literal: true })
-  await new Promise(resolve => setTimeout(resolve, NOTIFICATION_SUBMIT_DELAY_MS))
-  await runtime.sendKeys(target, 'Enter')
+  let sawPane = false
+
+  for (let send = 1; send <= NOTIFICATION_MAX_SENDS; send++) {
+    await runtime.sendKeys(target, `echo '${escapedMessage}'`, { literal: true })
+    await new Promise(resolve => setTimeout(resolve, NOTIFICATION_SUBMIT_DELAY_MS))
+    await runtime.sendKeys(target, 'Enter')
+
+    for (let poll = 0; poll < NOTIFICATION_VERIFY_POLLS; poll++) {
+      await new Promise(resolve => setTimeout(resolve, NOTIFICATION_VERIFY_DELAY_MS))
+      const pane = await runtime.capturePane(target, NOTIFICATION_CAPTURE_LINES).catch(() => '')
+      if (pane) sawPane = true
+      if (pane && paneContains(pane, needle)) {
+        return { sent: true, verified: true, unverifiable: false }
+      }
+    }
+
+    // Never captured anything at all: this runtime doesn't support readback, so
+    // resending would just double-deliver against a check that can't succeed.
+    if (!sawPane) return { sent: true, verified: false, unverifiable: true }
+  }
+
+  return { sent: true, verified: false, unverifiable: false }
 }
 
 /**
  * Format a notification message using the configured template
  */
 function formatNotification(options: NotificationOptions): string {
-  const { fromName, fromHost, subject, priority } = options
+  const { fromName, fromHost, subject, priority, body, messageId } = options
 
   // Build sender info with optional host
   const senderWithHost = fromHost && fromHost !== 'local'
@@ -88,7 +165,17 @@ function formatNotification(options: NotificationOptions): string {
     .replace('{from}', senderWithHost)
     .replace('{subject}', subject)
 
-  return priorityPrefix + message
+  // Per-message ref: doubles as the readback needle and lets an agent (or a
+  // human reading the pane) tie the nudge to the inbox entry.
+  const ref = `[#${messageRef(messageId)}]`
+
+  // Carry the body, so the pane gets the same content the channel and stream
+  // paths inject rather than a pointer the agent has to choose to follow.
+  // NOTIFICATION_FORMAT still owns the header line, so custom templates keep
+  // working — the body is appended, not substituted.
+  const tail = body ? ` — ${toSingleLine(body, NOTIFICATION_BODY_MAX)}` : ''
+
+  return `${priorityPrefix}${ref} ${message}${tail}`
 }
 
 /**
@@ -150,12 +237,28 @@ export async function notifyAgent(options: NotificationOptions): Promise<Notific
       return { success: true, notified: false, reason: 'Session not active' }
     }
 
-    // Format and send the notification
+    // Format, send, and confirm the notification actually landed in the pane.
     const notification = formatNotification(options)
-    await sendTmuxNotification(sessionName, notification)
+    const ref = `[#${messageRef(options.messageId)}]`
+    const result = await sendTmuxNotification(sessionName, notification, ref)
 
-    console.log(`[Notify] ✓ Notified ${agentName} about message from ${options.fromName}`)
-    return { success: true, notified: true }
+    if (result.verified) {
+      console.log(`[Notify] ✓ Notified ${agentName} about message from ${options.fromName} (verified in pane)`)
+      return { success: true, notified: true, verified: true }
+    }
+
+    if (result.unverifiable) {
+      // Runtime offers no readback (docker/api/direct). Report it as sent, but
+      // never as verified — callers must not mistake this for proof.
+      console.log(`[Notify] ~ Sent to ${agentName}, runtime cannot verify pane content`)
+      return { success: true, notified: true, verified: false, reason: 'Runtime cannot verify' }
+    }
+
+    // We could read the pane and the message never showed up after a resend.
+    // Report honestly so the caller can retry or surface it, rather than
+    // recording a delivery that never happened.
+    console.warn(`[Notify] ✗ Notification to ${agentName} not seen in pane after ${NOTIFICATION_MAX_SENDS} sends`)
+    return { success: true, notified: false, verified: false, reason: 'Not seen in pane after retries' }
 
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.36",
+  "version": "0.36.37",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/tests/agent-dir-hint.test.ts
+++ b/tests/agent-dir-hint.test.ts
@@ -65,8 +65,9 @@ describe('writeAgentDirHint', () => {
     // root — never write
     writeAgentDirHint('x', '/')
     expect(fs.existsSync('/.claude/settings.local.json')).toBe(false)
-    // scratch under /private/tmp — skipped
-    const scratch = fs.mkdtempSync('/private/tmp/hint-')
+    // scratch under /tmp — skipped (/tmp exists on macOS and Linux; on macOS it
+    // resolves under /private/tmp. Both prefixes are guarded in agent-registry.)
+    const scratch = fs.mkdtempSync('/tmp/hint-')
     writeAgentDirHint('x', scratch)
     expect(readSettings(scratch)).toBeNull()
     fs.rmSync(scratch, { recursive: true, force: true })

--- a/tests/channel-bridge.test.ts
+++ b/tests/channel-bridge.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for lib/channel-bridge.mjs + the amp-channel-server delivery handshake.
+ *
+ * The bug these guard: pushToChannel() returning true only means our own local
+ * HTTP server accepted the POST and wrote an MCP notification to the stdio
+ * transport. Claude Code never acknowledges channel notifications and drops
+ * them silently when the session did not register the server as a channel. So
+ * deliver() must NOT suppress the tmux fallback on a successful push — only on
+ * isChannelVerified(), which flips to true after the model calls the server's
+ * amp_channel_ack tool once.
+ *
+ * The registry file at ~/.aimaestro/channels/<agentId>.json is the IPC between
+ * the channel server (inside the agent's CLI process) and AI Maestro's server,
+ * so these tests drive that file directly.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getChannelInfo, hasChannel, isChannelVerified, pushToChannel } from '@/lib/channel-bridge.mjs'
+
+const CHANNELS_DIR = path.join(os.homedir(), '.aimaestro', 'channels')
+const AGENT_ID = 'test-channel-bridge-0000-1111-2222'
+const REG_FILE = path.join(CHANNELS_DIR, `${AGENT_ID}.json`)
+
+function writeReg(info: Record<string, unknown>) {
+  fs.mkdirSync(CHANNELS_DIR, { recursive: true })
+  fs.writeFileSync(REG_FILE, JSON.stringify({ agentId: AGENT_ID, ...info }))
+}
+
+function clearReg() {
+  try { fs.unlinkSync(REG_FILE) } catch { /* not there */ }
+}
+
+describe('channel-bridge', () => {
+  beforeEach(clearReg)
+  afterAll(clearReg)
+
+  it('reports no channel when the agent has no registry file', () => {
+    expect(getChannelInfo(AGENT_ID)).toBeNull()
+    expect(hasChannel(AGENT_ID)).toBe(false)
+    expect(isChannelVerified(AGENT_ID)).toBe(false)
+  })
+
+  it('reports a channel once registered, but NOT verified', () => {
+    writeReg({ port: 51234, pid: 1 })
+    expect(hasChannel(AGENT_ID)).toBe(true)
+    // The core guarantee: a registered channel is not a confirmed one.
+    expect(isChannelVerified(AGENT_ID)).toBe(false)
+  })
+
+  it('reports verified only when the registry says verified:true', () => {
+    writeReg({ port: 51234, pid: 1, verified: true, verifiedAt: '2026-08-26T00:00:00.000Z' })
+    expect(isChannelVerified(AGENT_ID)).toBe(true)
+  })
+
+  it('does not treat a truthy non-true verified value as confirmation', () => {
+    writeReg({ port: 51234, pid: 1, verified: 'yes' })
+    expect(isChannelVerified(AGENT_ID)).toBe(false)
+  })
+
+  it('handles a corrupt registry file without throwing', () => {
+    fs.mkdirSync(CHANNELS_DIR, { recursive: true })
+    fs.writeFileSync(REG_FILE, 'not json{')
+    expect(getChannelInfo(AGENT_ID)).toBeNull()
+    expect(isChannelVerified(AGENT_ID)).toBe(false)
+  })
+
+  it('fails the push (rather than throwing) when the registry is stale', async () => {
+    // Port nothing is listening on — a dead channel server that left its file.
+    writeReg({ port: 1, pid: 999999 })
+    await expect(pushToChannel(AGENT_ID, 'hello')).resolves.toBe(false)
+  })
+
+  it('returns false for a missing agent id', async () => {
+    await expect(pushToChannel('', 'hello')).resolves.toBe(false)
+    expect(isChannelVerified('')).toBe(false)
+  })
+})
+
+/**
+ * End-to-end handshake: boot the real channel server, confirm it registers
+ * unverified, POST a message in, then call amp_channel_ack over MCP stdio and
+ * confirm the registry flips to verified.
+ */
+describe('amp-channel-server handshake', () => {
+  const SERVER = fileURLToPath(new URL('../lib/amp-channel-server.mjs', import.meta.url))
+  const HS_AGENT = 'test-channel-handshake-0000-1111'
+  const HS_FILE = path.join(CHANNELS_DIR, `${HS_AGENT}.json`)
+
+  afterAll(() => { try { fs.unlinkSync(HS_FILE) } catch { /* gone */ } })
+
+  it('registers unverified, then verifies after amp_channel_ack', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js')
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js')
+
+    try { fs.unlinkSync(HS_FILE) } catch { /* gone */ }
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER],
+      env: { ...process.env, AIMAESTRO_AGENT_ID: HS_AGENT } as Record<string, string>,
+    })
+    const client = new Client({ name: 'test', version: '1.0.0' }, { capabilities: {} })
+    await client.connect(transport)
+
+    // The server binds its port and self-registers asynchronously after connect.
+    for (let i = 0; i < 50 && !fs.existsSync(HS_FILE); i++) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+
+    const initial = JSON.parse(fs.readFileSync(HS_FILE, 'utf8'))
+    expect(typeof initial.port).toBe('number')
+    // Registered but unproven — deliver() must still send the tmux fallback.
+    expect(initial.verified).toBeUndefined()
+    expect(isChannelVerified(HS_AGENT)).toBe(false)
+
+    // A push succeeds even though nothing has confirmed receipt. This is
+    // exactly the false positive that must not suppress the fallback.
+    await expect(pushToChannel(HS_AGENT, 'hello over the channel')).resolves.toBe(true)
+    expect(isChannelVerified(HS_AGENT)).toBe(false)
+
+    const tools = await client.listTools()
+    expect(tools.tools.map((t) => t.name)).toContain('amp_channel_ack')
+
+    await client.callTool({ name: 'amp_channel_ack', arguments: {} })
+
+    for (let i = 0; i < 50 && !isChannelVerified(HS_AGENT); i++) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    expect(isChannelVerified(HS_AGENT)).toBe(true)
+
+    await client.close()
+  }, 30_000)
+})

--- a/tests/notification-service.test.ts
+++ b/tests/notification-service.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for lib/notification-service.ts — pane readback verification.
+ *
+ * send-keys returning without throwing only proves bytes reached tmux, not
+ * that the agent's TUI accepted them. notifyAgent() therefore reads the pane
+ * back and looks for a per-message ref. This is the runtime-agnostic twin of
+ * the channel's amp_channel_ack: it needs no cooperation from whatever agent
+ * occupies the pane, so it covers Claude Code, Codex, Gemini CLI, Aider, or a
+ * bare shell equally.
+ *
+ * The contract these lock down:
+ *   verified: true   — read back off the pane (proof)
+ *   verified: false + notified: true  — sent, runtime can't be captured
+ *   notified: false  — pane readable and the message never appeared
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockRuntime = {
+  sendKeys: vi.fn().mockResolvedValue(undefined),
+  capturePane: vi.fn().mockResolvedValue(''),
+  sessionExists: vi.fn().mockResolvedValue(true),
+}
+
+vi.mock('@/lib/agent-runtime', () => ({
+  getRuntime: vi.fn(() => mockRuntime),
+}))
+
+const AGENT = {
+  id: 'agent-uuid-1',
+  name: 'receiver',
+  sessions: [{ index: 0, status: 'online' }],
+}
+
+vi.mock('@/lib/agent-registry', () => ({
+  getAgent: vi.fn(() => AGENT),
+  getAgentByName: vi.fn(() => AGENT),
+}))
+
+vi.mock('@/lib/hosts-config-server.mjs', () => ({
+  getSelfHostId: vi.fn(() => 'local'),
+  isSelf: vi.fn(() => true),
+}))
+
+vi.mock('@/types/agent', () => ({
+  computeSessionName: vi.fn((name: string) => name),
+}))
+
+import { notifyAgent, messageRef, toSingleLine } from '@/lib/notification-service'
+
+const BASE = {
+  agentId: 'agent-uuid-1',
+  agentName: 'receiver',
+  fromName: 'sender',
+  fromHost: 'local',
+  subject: 'deploy failed',
+  messageId: 'abc12345-dead-beef-0000-111122223333',
+}
+
+/** What the pane would show once the notification rendered. */
+function paneWith(messageId: string) {
+  return `$ echo '...'\n[#${messageRef(messageId)}] [MESSAGE] From: sender - deploy failed\n$ `
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRuntime.sendKeys.mockResolvedValue(undefined)
+  mockRuntime.sessionExists.mockResolvedValue(true)
+})
+
+describe('messageRef', () => {
+  it('derives a short alphanumeric token from the message id', () => {
+    expect(messageRef('abc12345-dead-beef')).toBe('abc12345')
+  })
+
+  it('is stable for the same id', () => {
+    expect(messageRef(BASE.messageId)).toBe(messageRef(BASE.messageId))
+  })
+
+  it('never returns empty, even for a missing id', () => {
+    expect(messageRef('')).toBe('nomsgid')
+    expect(messageRef('---')).toBe('nomsgid')
+  })
+})
+
+describe('toSingleLine', () => {
+  it('collapses newlines so send-keys cannot submit early', () => {
+    expect(toSingleLine('line one\nline two\n\nline three', 100)).toBe('line one line two line three')
+  })
+
+  it('truncates with an ellipsis past the limit', () => {
+    const out = toSingleLine('x'.repeat(50), 10)
+    expect(out).toHaveLength(10)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})
+
+describe('notifyAgent — pane readback', () => {
+  it('reports verified when the ref is read back off the pane', async () => {
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+
+    const res = await notifyAgent(BASE)
+
+    expect(res).toMatchObject({ success: true, notified: true, verified: true })
+    // One send only — no wasteful resend once it is confirmed.
+    expect(mockRuntime.sendKeys).toHaveBeenCalledTimes(2) // text + Enter
+  })
+
+  it('matches the ref even when the pane hard-wraps it mid-token', async () => {
+    const ref = messageRef(BASE.messageId)
+    // tmux wrapped the line in the middle of the ref.
+    mockRuntime.capturePane.mockResolvedValue(`[#${ref.slice(0, 4)}\n${ref.slice(4)}] [MESSAGE] From: sender`)
+
+    const res = await notifyAgent(BASE)
+
+    expect(res.verified).toBe(true)
+  })
+
+  it('reports notified-but-unverified when the runtime cannot be captured', async () => {
+    mockRuntime.capturePane.mockResolvedValue('')
+
+    const res = await notifyAgent(BASE)
+
+    expect(res).toMatchObject({ success: true, notified: true, verified: false })
+    expect(res.reason).toMatch(/cannot verify/i)
+    // No resend: the check can never succeed here, so retrying would only
+    // double-deliver.
+    expect(mockRuntime.sendKeys).toHaveBeenCalledTimes(2)
+  })
+
+  it('resends, then reports NOT notified when the pane never shows the message', async () => {
+    // Pane is readable but our message never lands (TUI dropped the input).
+    mockRuntime.capturePane.mockResolvedValue('$ some unrelated pane content\n$ ')
+
+    const res = await notifyAgent(BASE)
+
+    expect(res).toMatchObject({ success: true, notified: false, verified: false })
+    expect(res.reason).toMatch(/not seen/i)
+    // Initial send + one resend, each text + Enter.
+    expect(mockRuntime.sendKeys).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not mistake a DIFFERENT message on the pane for this one', async () => {
+    mockRuntime.capturePane.mockResolvedValue(paneWith('99999999-other-message'))
+
+    const res = await notifyAgent(BASE)
+
+    expect(res.notified).toBe(false)
+  })
+
+  it('recovers when the message renders late, without resending', async () => {
+    mockRuntime.capturePane
+      .mockResolvedValueOnce('$ ')
+      .mockResolvedValueOnce('$ ')
+      .mockResolvedValue(paneWith(BASE.messageId))
+
+    const res = await notifyAgent(BASE)
+
+    expect(res.verified).toBe(true)
+    expect(mockRuntime.sendKeys).toHaveBeenCalledTimes(2)
+  })
+
+  it('carries the message body into the pane, single-lined', async () => {
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+
+    await notifyAgent({ ...BASE, body: 'the build broke\non step 3' })
+
+    const sent = mockRuntime.sendKeys.mock.calls[0][1] as string
+    expect(sent).toContain('the build broke on step 3')
+    expect(sent).not.toContain('\n')
+  })
+
+  it('includes the ref so the agent can tie the nudge to the inbox entry', async () => {
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+
+    await notifyAgent(BASE)
+
+    const sent = mockRuntime.sendKeys.mock.calls[0][1] as string
+    expect(sent).toContain(`[#${messageRef(BASE.messageId)}]`)
+  })
+
+  it('skips cleanly when the session is gone', async () => {
+    mockRuntime.sessionExists.mockResolvedValue(false)
+
+    const res = await notifyAgent(BASE)
+
+    expect(res).toMatchObject({ notified: false, reason: 'Session not active' })
+    expect(mockRuntime.sendKeys).not.toHaveBeenCalled()
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.36.36",
-  "releaseDate": "2026-08-20",
+  "version": "0.36.37",
+  "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
## Summary

Both AMP wake paths reported deliveries that had not happened, and the channel path used that false positive to **suppress its own fallback** — so in exactly the configuration a fleet rollout starts from, messages vanished with no delivery at all.

This makes every wake path report only what it can prove, and makes the universal (pane) path prove itself.

## The bug

`pushToChannel()` returning `true` only means our local HTTP server accepted the POST and `mcp.notification()` wrote to the stdio transport. Per the [channels reference](https://code.claude.com/docs/en/channels-reference):

> Claude Code doesn't acknowledge notifications. The `await` on `mcp.notification()` resolves when the message is written to the transport, not when Claude has processed it. If the session hasn't loaded your server as a channel, or the organization policy blocks it, **Claude Code drops the events silently and returns no error to your server.**

`deliver()` treated that boolean as confirmation and skipped the tmux fallback. Channel server running + events dropped = silent total loss, strictly worse than the flaky keystroke it replaced.

The same class of bug existed one layer down: `sendTmuxNotification()` returned `void`, so `notified: true` meant only "two `send-keys` calls did not throw."

## Changes

**Channel ack.** The failure is static per session, so one confirmation covers its lifetime. The channel server exposes an `amp_channel_ack` tool and persists `verified: true` into `~/.aimaestro/channels/<agentId>.json`. Only `isChannelVerified()` suppresses the fallback. Until a session confirms, both paths fire — a duplicate nudge is cheap, a lost message is not. If the model never calls the tool, we degrade to today's behaviour rather than to silence.

**Pane readback.** `sendTmuxNotification()` now reads the pane back looking for a per-message ref, polling for render lag before resending, and reports honestly:

| Result | Meaning |
|---|---|
| `verified: true` | read back off the pane — proof |
| `notified: true, verified: false` | sent; runtime offers no capture |
| `notified: false` | pane readable, message never arrived |

Readback needs no cooperation from whatever occupies the pane, so it is the runtime-agnostic equivalent of the channel ack: Claude Code, Codex, Gemini CLI, Aider and a bare shell all work. **This matters because channels cannot carry the fleet** — `--channels` only accepts Anthropic-allowlisted plugins unless an admin sets `allowedChannelPlugins`, which is Team/Enterprise only.

**Body in the pane.** The notification now carries the message body, single-lined and truncated, instead of a "check your inbox" pointer the agent could ignore. Single-lining is required, not cosmetic: a raw newline in `send-keys` submits a TUI early and opens an unterminated quote at a shell prompt. `NOTIFICATION_FORMAT` still owns the header line, so custom templates keep working.

**`DeliveryResult.verified`** exposes the distinction to callers: `notified` without `verified` means sent-unconfirmed and must not be read as proof.

## Deliberate scope calls

- **Kept the `echo '...'` wrapper.** Removing it breaks the idle-shell case (the text would execute as a command and error). Fixing it properly needs `pane_current_command` detection, i.e. a new method on `AgentRuntime` and all four implementations. Single-lining removes the actual danger.
- **`NOTIFICATION_FORMAT` preserved.** The body is appended, not substituted, so the documented env var keeps working. The paths now carry the same *information*, not byte-identical text.

## Cost

Fallback path: ~400ms when confirmed, bounded at ~2.3s when the message never lands. Only applies when the channel is unconfirmed.

## Testing

- `899 passing (+14)`, `yarn build` clean
- `tests/channel-bridge.test.ts` drives the **real channel server over MCP stdio** and asserts the bug directly: a push returns `true` while `isChannelVerified()` is still `false`, flipping only after the ack
- `tests/notification-service.test.ts` covers verified / unverifiable / never-arrived, wrap-split refs, late render without resend, and not mistaking a different message on the pane for this one

## Follow-ups (not in this PR)

Idle-gated queueing, an explicit capability-driven adapter chain, and an undelivered-message surface with backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)