### PR TITLE
feat(delivery): persist hook status to close the idle-gate blind spot (v0.36.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.42] - 2026-08-27 — Hook status persistence (closes the idle-gate blind spot)
+
+Closes the known gap from 0.36.41: the idle gate only had a signal while a PTY was attached, so it worked for agents someone was watching in the dashboard and was inert for the rest.
+
+### Added
+- **The Claude Code hook's reported state is now persisted, not just broadcast.** The hook already fires on `Stop` / `SessionStart` / `Notification` and knows what the agent is actually doing, but `broadcastActivityUpdate()` only pushed it to WebSocket subscribers and dropped it. It now lands in `shared-state.hookStatus` (sessionName → `{status, notificationType, at}`), and `lib/session-idle.ts` prefers it over PTY recency. **This is the only busy/idle signal that exists for an agent with no attached terminal**, so the idle gate now covers every hooked agent.
+- **`idleSignals` on `GET /api/messages/pending-wakes`** — which agents we have a real signal for, what it says, how old it is, and which source answered (`hook` / `pty` / `none`). `source: "none"` is the remaining blind spot: no hook report and no attached terminal.
+
+### Fixed
+- **`/api/messages/pending-wakes` was returning a build-time snapshot** — the handler reads only in-memory maps and calls no dynamic API, so Next statically prerendered it at build time and served frozen zeros forever. An endpoint whose entire job is reporting live state reported nothing. Now `force-dynamic`; found while verifying this release rather than by a user.
+
+### Notes
+- **Injecting into a permission modal is now impossible by construction.** The two mistakes are not symmetric: deferring a genuinely idle agent delays a wake by one tick, while typing into a `permission_request` **answers the modal**. So only states positively recognised as waiting count as idle — `idle`, and `waiting_for_input` *only* when `notificationType === 'idle_prompt'`. `active`, `permission_request` and anything unrecognised defer.
+- Hook reports expire after 15 minutes. An agent that dies mid-turn would otherwise leave `active` as its last word forever and block its own wakes permanently; after the TTL we fall back to PTY recency.
+
 ## [0.36.37] – [0.36.41] - 2026-08-27 — Provable message delivery
 
 The long-standing "messages arrive but agents never read them" problem. Root cause was not transport — routing, signing and federation all worked. **Every wake route reported success it had not earned, and one of those false positives suppressed the fallback that would have worked.**
@@ -21,7 +36,7 @@ The long-standing "messages arrive but agents never read them" problem. Root cau
 - **End-to-end wake test** [0.36.41] — `./scripts/test-message-wake.sh` sends a real AMP message to a live local agent and asserts whether anything could prove it landed. Verified in production; the trace `stream:unavailable → channel:sent → pane:confirmed` is the original bug being caught and survived live.
 
 ### Notes
-- **Known gap: the idle gate is inert for unwatched agents.** `sessionActivity` is only stamped while a PTY is attached, so an agent nobody is watching in the dashboard always reads as idle. Two alternatives were measured and rejected: tmux `#{session_activity}` was 25 minutes stale on a visibly working agent, and diffing pane captures was backwards in both directions. The real fix is to persist the state the Claude Code hook already reports on `Stop`/`Notification(idle_prompt)`, which today is broadcast but never stored. Follow-on.
+- **Known gap: the idle gate is inert for unwatched agents.** `sessionActivity` is only stamped while a PTY is attached, so an agent nobody is watching in the dashboard always reads as idle. Two alternatives were measured and rejected: tmux `#{session_activity}` was 25 minutes stale on a visibly working agent, and diffing pane captures was backwards in both directions. **Closed in 0.36.42** by persisting the hook's reported state.
 - **Channels cannot carry the fleet.** `--channels` only accepts Anthropic-allowlisted plugins unless an admin sets `allowedChannelPlugins`, which is Team/Enterprise only; it is also Claude Code-only and Anthropic-auth-only. Treat it as an opportunistic fast path. The pane readback is the route that works everywhere.
 
 ## [0.36.35] - 2026-08-19 — Honest agent metrics overview

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.41-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.42-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/messages/pending-wakes/route.ts
+++ b/app/api/messages/pending-wakes/route.ts
@@ -11,17 +11,40 @@
  * `reason` distinguishes the two ways a wake ends up here:
  *   busy        — never attempted; the pane was mid-render when it arrived
  *   unconfirmed — attempted, and nothing could prove it landed
+ *
+ * MUST stay force-dynamic. This handler reads only in-memory maps and calls no
+ * dynamic API, so Next happily evaluates it at BUILD time and serves a frozen
+ * snapshot of empty maps — an endpoint whose entire job is reporting live state
+ * would report zeros forever.
  */
+export const dynamic = 'force-dynamic'
 
 import { NextResponse } from 'next/server'
 import { pendingWakes, totalPendingWakes } from '@/lib/wake-queue'
+import { hookStatus } from '@/services/shared-state'
+import { isSessionIdle, idleSource } from '@/lib/session-idle'
 
 export async function GET() {
   const pending = pendingWakes()
+
+  // Which agents we currently have a real busy/idle signal for. `source: 'none'`
+  // is the blind spot: no hook report and no attached terminal, so the pane
+  // route cannot tell a working agent from a waiting one.
+  const now = Date.now()
+  const idleSignals = Array.from(hookStatus.entries()).map(([sessionName, s]) => ({
+    sessionName,
+    status: s.status,
+    notificationType: s.notificationType,
+    ageMs: now - s.at,
+    idle: isSessionIdle(sessionName),
+    source: idleSource(sessionName),
+  }))
+
   return NextResponse.json({
     total: totalPendingWakes(),
     busy: pending.filter((p) => p.reason === 'busy').length,
     unconfirmed: pending.filter((p) => p.reason === 'unconfirmed').length,
     pending,
+    idleSignals,
   })
 }

--- a/lib/session-idle.ts
+++ b/lib/session-idle.ts
@@ -11,32 +11,54 @@
  * Extracted from sessions-service so the wake path can ask the question
  * without importing the whole session service graph.
  *
- * KNOWN COVERAGE GAP — read before relying on this for a wake decision.
+ * TWO SIGNALS, IN PRIORITY ORDER
  *
- * `sessionActivity` is only stamped while a PTY is attached (someone has the
- * agent's terminal open in the dashboard). For an agent nobody is watching,
- * the map is never written, msSinceActivity() returns null, and this reports
- * IDLE regardless of what the agent is actually doing. So the idle gate in
- * the pane wake route engages for observed agents and is inert for the rest.
+ * 1. The Claude Code hook's reported state (authoritative). It fires on Stop /
+ *    SessionStart / Notification and knows what the agent is actually doing.
+ *    Works for every hooked agent whether or not anyone is watching it.
  *
- * That is a real limitation, not a rounding error, and these alternatives were
- * measured and rejected rather than assumed:
- *   - tmux `#{session_activity}` reported 25 minutes stale on an agent that was
+ * 2. PTY output recency (fallback). Only written while a terminal is attached,
+ *    so it covers observed agents and silently reports "idle" for the rest —
+ *    which is why signal 1 exists.
+ *
+ * Two other candidates were measured and REJECTED, not assumed:
+ *   - tmux `#{session_activity}` was 25 minutes stale on an agent that was
  *     visibly mid-turn.
  *   - Diffing two pane captures 600ms apart was backwards in both directions:
  *     identical on a working agent, different on an idle one.
- *
- * The real fix is to persist the state the Claude Code hook already knows. It
- * fires on Stop / Notification(idle_prompt) and posts a `status` to
- * /api/sessions/activity/update, but that status is only broadcast, never
- * stored anywhere the wake path can read. Persisting it would give a true
- * busy/idle signal for every hooked agent, attached or not.
  */
 
-import { sessionActivity } from '@/services/shared-state'
+import { sessionActivity, hookStatus } from '@/services/shared-state'
 
 /** No output for this long ⇒ treat the session as idle. */
 export const IDLE_THRESHOLD_MS = 30 * 1000
+
+/**
+ * How long a hook-reported state stays authoritative.
+ *
+ * Bounded on purpose. An agent that dies mid-turn leaves its last report as
+ * `active` forever, and without an expiry every future wake would defer against
+ * a state that will never change. After this we fall back to PTY recency.
+ */
+export const HOOK_STATUS_TTL_MS = 15 * 60 * 1000
+
+/**
+ * Does a hook-reported state mean "safe to inject right now"?
+ *
+ * Conservative by design, because the cost of the two mistakes is not
+ * symmetric: deferring a wake on a genuinely idle agent delays it by one tick,
+ * while injecting into a PERMISSION PROMPT types the message into a modal and
+ * answers it. Only states we positively recognise as waiting count as idle.
+ */
+function hookStateIsIdle(state: { status: string; notificationType?: string }): boolean {
+  // Stop fired without blocking: the turn is over.
+  if (state.status === 'idle') return true
+  // A notification that the agent is waiting on the user — but ONLY the
+  // idle-prompt kind. permission_prompt means a modal is up.
+  if (state.status === 'waiting_for_input') return state.notificationType === 'idle_prompt'
+  // 'active', 'permission_request', and anything unrecognised: do not inject.
+  return false
+}
 
 /** Milliseconds since the session last produced output, or null if never seen. */
 export function msSinceActivity(sessionName: string): number | null {
@@ -52,7 +74,24 @@ export function msSinceActivity(sessionName: string): number | null {
  * interrupt.
  */
 export function isSessionIdle(sessionName: string): boolean {
+  // 1. The hook's own report wins while it is fresh — it is the only signal
+  //    that exists for an agent with no attached terminal. Guarded because
+  //    _sharedState is late-initialised across two module graphs; a missing
+  //    map should degrade to the PTY signal, not throw inside a wake.
+  const reported = hookStatus?.get(sessionName)
+  if (reported && Date.now() - reported.at < HOOK_STATUS_TTL_MS) {
+    return hookStateIsIdle(reported)
+  }
+
+  // 2. Fall back to PTY output recency.
   const since = msSinceActivity(sessionName)
   if (since === null) return true
   return since > IDLE_THRESHOLD_MS
+}
+
+/** Which signal answered, for logging and the operator surface. */
+export function idleSource(sessionName: string): 'hook' | 'pty' | 'none' {
+  const reported = hookStatus?.get(sessionName)
+  if (reported && Date.now() - reported.at < HOOK_STATUS_TTL_MS) return 'hook'
+  return msSinceActivity(sessionName) === null ? 'none' : 'pty'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.41",
+  "version": "0.36.42",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -33,7 +33,7 @@ import { getHosts, getSelfHost, isSelf, getHostById } from '@/lib/hosts-config'
 import { persistSession, loadPersistedSessions, unpersistSession } from '@/lib/session-persistence'
 import { parseNameForDisplay, isCallSession } from '@/types/agent'
 import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
-import { sessionActivity, agentActivity, terminalSessions, broadcastStatusUpdate, broadcastChatEvent } from '@/services/shared-state'
+import { sessionActivity, agentActivity, terminalSessions, hookStatus as hookStatusMap, broadcastStatusUpdate, broadcastChatEvent } from '@/services/shared-state'
 import { isSessionIdle, IDLE_THRESHOLD_MS } from '@/lib/session-idle'
 import { getRuntime } from '@/lib/agent-runtime'
 import crypto from 'crypto'
@@ -558,6 +558,19 @@ export function broadcastActivityUpdate(
 ): ServiceResult<{ success: boolean }> {
   if (!sessionName && !agentId) {
     return missingField('sessionName')
+  }
+
+  // Persist the hook's view of the agent's state, not just broadcast it. This
+  // is the only busy/idle signal that exists for an agent nobody is watching:
+  // sessionActivity is written by the PTY layer, which only runs while a
+  // terminal is attached. The wake path reads this via lib/session-idle.
+  const reported = hookStatus || status
+  if (sessionName && reported) {
+    hookStatusMap.set(sessionName, {
+      status: reported,
+      notificationType,
+      at: Date.now(),
+    })
   }
 
   broadcastStatusUpdate(sessionName, status, hookStatus, notificationType, agentId)

--- a/services/shared-state-bridge.mjs
+++ b/services/shared-state-bridge.mjs
@@ -18,11 +18,16 @@ if (!globalThis._sharedState) {
     statusSubscribers: new Set(),    // Set<WebSocket> for /status subscribers
     companionClients: new Map(),     // agentId -> Set<WebSocket> for /companion-ws
     callSessions: new Map(),         // agentId -> CallSessionState for companion call forks
+    hookStatus: new Map(),           // sessionName -> { status, notificationType, at } from the Claude Code hook
   }
 }
-// Ensure callSessions exists for hot-reload / late initialization
+// Ensure late-added maps exist for hot-reload / late initialization, and for
+// whichever module graph initialised _sharedState first.
 if (!globalThis._sharedState.callSessions) {
   globalThis._sharedState.callSessions = new Map()
+}
+if (!globalThis._sharedState.hookStatus) {
+  globalThis._sharedState.hookStatus = new Map()
 }
 
 const state = globalThis._sharedState
@@ -33,6 +38,7 @@ export const terminalSessions = state.terminalSessions
 export const statusSubscribers = state.statusSubscribers
 export const companionClients = state.companionClients
 export const callSessions = state.callSessions
+export const hookStatus = state.hookStatus
 
 /**
  * Broadcast a chat event to all chat-subscribed WebSocket clients for a session.

--- a/services/shared-state.ts
+++ b/services/shared-state.ts
@@ -34,6 +34,25 @@ export interface StatusUpdate {
   timestamp: string
 }
 
+/**
+ * Agent state as reported by the Claude Code hook.
+ *
+ * The hook fires on Stop / SessionStart / Notification and knows the agent's
+ * real state, which nothing else on the server does: PTY activity only exists
+ * while someone has the terminal open, and tmux's own activity timestamps were
+ * measured stale by 25 minutes on a visibly working agent.
+ *
+ *   idle              — Stop fired and did not block: turn over, safe to inject
+ *   active            — SessionStart, or a Stop that blocked to force an AMP read
+ *   waiting_for_input — a Notification; check notificationType before injecting
+ *   permission_request— a modal is up; typing would ANSWER IT. Never inject.
+ */
+export interface HookStatusState {
+  status: string
+  notificationType?: string
+  at: number
+}
+
 export interface CallSessionState {
   agentId: string
   agentName: string
@@ -56,6 +75,7 @@ declare global {
     statusSubscribers: Set<WebSocket>
     companionClients: Map<string, Set<WebSocket>>
     callSessions: Map<string, CallSessionState>
+    hookStatus: Map<string, HookStatusState>
   } | undefined
 }
 
@@ -67,11 +87,17 @@ if (!globalThis._sharedState) {
     statusSubscribers: new Set<WebSocket>(),
     companionClients: new Map<string, Set<WebSocket>>(),
     callSessions: new Map<string, CallSessionState>(),
+    hookStatus: new Map<string, HookStatusState>(),
   }
 }
-// Ensure callSessions exists for hot-reload / late initialization
+// Ensure late-added maps exist for hot-reload, and for whichever module graph
+// initialised _sharedState first (server.mjs via the bridge, or Next via this
+// file). A missing map here is an undefined deref at call time, not a warning.
 if (!globalThis._sharedState.callSessions) {
   globalThis._sharedState.callSessions = new Map()
+}
+if (!globalThis._sharedState.hookStatus) {
+  globalThis._sharedState.hookStatus = new Map()
 }
 
 const state = globalThis._sharedState!
@@ -97,6 +123,9 @@ export const companionClients: Map<string, Set<WebSocket>> = state.companionClie
 
 /** agentId -> active call session state. Populated by companion-ws handler in server.mjs. */
 export const callSessions: Map<string, CallSessionState> = state.callSessions
+
+/** sessionName -> last state reported by the Claude Code hook. See HookStatusState. */
+export const hookStatus: Map<string, HookStatusState> = state.hookStatus
 
 // ---------------------------------------------------------------------------
 // Broadcast a chat event to chat-subscribed WebSocket clients for a session

--- a/tests/services/sessions-service.test.ts
+++ b/tests/services/sessions-service.test.ts
@@ -63,6 +63,10 @@ const {
     mockSharedState: {
       sessionActivity: new Map<string, number>(),
       agentActivity: new Map<string, number>(),
+      // Read by lib/session-idle, which sessions-service delegates its
+      // busy/idle question to. Omitting it makes isSessionIdle() deref
+      // undefined rather than fail a clear assertion.
+      hookStatus: new Map<string, { status: string; notificationType?: string; at: number }>(),
       broadcastStatusUpdate: vi.fn(),
     },
     mockFs: {
@@ -122,6 +126,7 @@ beforeEach(() => {
   resetFixtureCounter()
   mockSharedState.sessionActivity.clear()
   mockSharedState.agentActivity.clear()
+  mockSharedState.hookStatus.clear()
   // Reset runtime mock defaults
   mockRuntime.listSessions.mockResolvedValue([])
   mockRuntime.sessionExists.mockResolvedValue(false)

--- a/tests/session-idle.test.ts
+++ b/tests/session-idle.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for lib/session-idle.ts.
+ *
+ * The wake path asks one question here — "safe to type into this pane right
+ * now?" — and two mistakes are possible with very different costs:
+ *
+ *   deferring a genuinely idle agent  → the wake waits one tick
+ *   injecting into a permission modal → the text ANSWERS the modal
+ *
+ * So the hook's reported state is trusted only where we positively recognise
+ * it as waiting, and everything else defers.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { sessionActivity, hookStatus } from '@/services/shared-state'
+import {
+  isSessionIdle,
+  msSinceActivity,
+  idleSource,
+  IDLE_THRESHOLD_MS,
+  HOOK_STATUS_TTL_MS,
+} from '@/lib/session-idle'
+
+const S = 'agent-session'
+
+function reportHook(status: string, notificationType?: string, ageMs = 0) {
+  hookStatus.set(S, { status, notificationType, at: Date.now() - ageMs })
+}
+
+beforeEach(() => {
+  sessionActivity.clear()
+  hookStatus.clear()
+})
+
+describe('hook status (authoritative signal)', () => {
+  it('treats a completed turn as idle', () => {
+    reportHook('idle')
+    expect(isSessionIdle(S)).toBe(true)
+    expect(idleSource(S)).toBe('hook')
+  })
+
+  it('treats an active agent as busy', () => {
+    reportHook('active')
+    expect(isSessionIdle(S)).toBe(false)
+  })
+
+  it('NEVER reports idle during a permission request', () => {
+    // Typing here would answer the modal.
+    reportHook('permission_request')
+    expect(isSessionIdle(S)).toBe(false)
+  })
+
+  it('treats an idle prompt as idle', () => {
+    reportHook('waiting_for_input', 'idle_prompt')
+    expect(isSessionIdle(S)).toBe(true)
+  })
+
+  it('does NOT treat a permission prompt notification as idle', () => {
+    reportHook('waiting_for_input', 'permission_prompt')
+    expect(isSessionIdle(S)).toBe(false)
+  })
+
+  it('defers on an unrecognised state rather than guessing', () => {
+    reportHook('something-new-from-a-future-hook')
+    expect(isSessionIdle(S)).toBe(false)
+  })
+
+  it('overrides PTY recency while fresh', () => {
+    // PTY says busy (output 1s ago) but the hook says the turn ended.
+    sessionActivity.set(S, Date.now() - 1000)
+    reportHook('idle')
+    expect(isSessionIdle(S)).toBe(true)
+  })
+})
+
+describe('hook status expiry', () => {
+  it('stops trusting a stale report so a dead agent cannot block wakes forever', () => {
+    // An agent that died mid-turn would otherwise stay "active" permanently.
+    reportHook('active', undefined, HOOK_STATUS_TTL_MS + 1000)
+    expect(idleSource(S)).not.toBe('hook')
+    expect(isSessionIdle(S)).toBe(true) // falls back; no PTY data ⇒ idle
+  })
+
+  it('falls back to PTY recency once the hook report expires', () => {
+    reportHook('idle', undefined, HOOK_STATUS_TTL_MS + 1000)
+    sessionActivity.set(S, Date.now()) // output right now ⇒ busy
+    expect(isSessionIdle(S)).toBe(false)
+    expect(idleSource(S)).toBe('pty')
+  })
+})
+
+describe('PTY fallback', () => {
+  it('reports busy while output is recent', () => {
+    sessionActivity.set(S, Date.now())
+    expect(isSessionIdle(S)).toBe(false)
+    expect(idleSource(S)).toBe('pty')
+  })
+
+  it('reports idle once output goes quiet past the threshold', () => {
+    sessionActivity.set(S, Date.now() - (IDLE_THRESHOLD_MS + 1000))
+    expect(isSessionIdle(S)).toBe(true)
+  })
+
+  it('reports idle — and says so — when there is no signal at all', () => {
+    expect(msSinceActivity(S)).toBeNull()
+    expect(isSessionIdle(S)).toBe(true)
+    // This is the coverage hole the hook signal closes: an unwatched agent
+    // with no hook report is indistinguishable from an idle one.
+    expect(idleSource(S)).toBe('none')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.41",
+  "version": "0.36.42",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Summary

Closes the known gap shipped with v0.36.41: the idle gate only had a signal while a PTY was attached, so it worked for agents someone was watching in the dashboard and was **inert for every other agent in the fleet**.

## The signal was already there

The Claude Code hook fires on `Stop` / `SessionStart` / `Notification` and reports the agent's real state — but `broadcastActivityUpdate()` pushed it to WebSocket subscribers and dropped it. It now lands in `shared-state.hookStatus`, and `lib/session-idle.ts` prefers it over PTY recency.

**This is the only busy/idle signal that exists for an agent with no attached terminal.**

Two other candidates were measured and rejected before landing here, and are recorded in `session-idle.ts` so nobody re-tries them:
- tmux `#{session_activity}` — **25 minutes stale** on an agent that was visibly mid-turn
- diffing two pane captures 600ms apart — **backwards in both directions** (identical while working, different while idle)

## Safety: the two mistakes are not symmetric

Deferring a genuinely idle agent delays a wake by one tick. Typing into a `permission_request` **answers the modal**.

So the mapping is deliberately conservative — only states positively recognised as waiting count as idle:

| hook state | idle? |
|---|---|
| `idle` | ✅ |
| `waiting_for_input` + `notificationType: idle_prompt` | ✅ |
| `waiting_for_input` + `permission_prompt` | ❌ |
| `active` | ❌ |
| `permission_request` | ❌ |
| anything unrecognised | ❌ |

A future hook state we don't know about defers rather than typing into it.

Reports expire after 15 minutes: an agent that dies mid-turn would otherwise leave `active` as its last word forever and permanently block its own wakes.

## Also fixed — found while verifying, not by a user

**`/api/messages/pending-wakes` was returning a build-time snapshot.** The handler reads only in-memory maps and calls no dynamic API, so Next statically prerendered it and served frozen zeros. An endpoint whose entire job is reporting live state has been reporting nothing since it shipped in v0.36.41. Now `force-dynamic`, with a comment saying why it must stay that way.

## Verification

- Synthetic POSTs matching the hook's exact payload → `idle:true, source:"hook"` for `idle`; `idle:false` for `permission_request`
- The real hook binary writes the correct state for the right cwd (`~/.aimaestro/chat-state/`)
- Hook wired for all three events in `~/.claude/settings.json`
- Build output confirms `ƒ /api/messages/pending-wakes` (dynamic) rather than `○` (static)

## Testing

`951 passing (+12)`, `yarn build` clean. New `tests/session-idle.test.ts` covers the permission-modal guard, deferring on unrecognised states, hook-over-PTY precedence, and TTL fallback.

Also added `hookStatus` to the sessions-service test's shared-state mock — the extraction in v0.36.40 meant `isSessionIdle()` would deref undefined there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)