### PR TITLE
fix(notify): unique message refs and notifications that don't look like commands (v0.36.43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.43] - 2026-08-27 — Legible, uniquely-identified notifications
+
+Field report: an agent appeared to receive the same message over and over. It was eleven different messages — made to look identical by two defects introduced in 0.36.37.
+
+### Fixed
+- **`messageRef` was not per-message.** It sliced the FIRST 8 characters of `msg-<timestamp>-<random>`, but all the entropy is at the end, so every message sent within roughly 27 hours produced the identical ref (`msg17878`). Two consequences: the pane readback needle was not unique, so `confirmed` could be satisfied by a **stale ref left on screen from an earlier message** — a false positive in the exact mechanism built to eliminate false positives — and every notification looked like the same message repeating. Now takes the tail of the id.
+- **Notifications no longer render as shell commands in an agent's transcript.** Every wake was wrapped in `echo '...'` so a bare shell would not execute it. With a TUI agent in the pane that wrapper is not just cosmetic — it puts `echo '[MESSAGE] ...'` into the agent's transcript on every message. 0.36.42's persisted hook status finally makes the two cases distinguishable: a live hook report means an agent TUI, so the text is sent plainly; no report still means `echo`, since an unnecessary `echo` is ugly but an unquoted message at a shell prompt is a command.
+- **Default notification format leads with the subject** (`[MESSAGE] {subject} — from {from}`). Stacked in a transcript, sender-first lines were visually identical with the differentiator truncated off the right edge. `NOTIFICATION_FORMAT` still overrides.
+
 ## [0.36.42] - 2026-08-27 — Hook status persistence (closes the idle-gate blind spot)
 
 Closes the known gap from 0.36.41: the idle gate only had a signal while a PTY was attached, so it worked for agents someone was watching in the dashboard and was inert for the rest.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.42-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.43-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -11,10 +11,14 @@ import { getAgent, getAgentByName } from '@/lib/agent-registry'
 import { computeSessionName } from '@/types/agent'
 import { getSelfHostId, isSelf } from '@/lib/hosts-config-server.mjs'
 import { getRuntime } from '@/lib/agent-runtime'
+import { hasHookReport } from '@/lib/session-idle'
 
 // Configuration (can be overridden via environment variables)
 const NOTIFICATIONS_ENABLED = process.env.NOTIFICATIONS_ENABLED !== 'false'
-const NOTIFICATION_FORMAT = process.env.NOTIFICATION_FORMAT || '[MESSAGE] From: {from} - {subject} - check your inbox'
+// Subject FIRST: these lines stack up in an agent's transcript, and with the
+// sender leading, consecutive notifications were visually indistinguishable —
+// the differentiator sat far right and got truncated.
+const NOTIFICATION_FORMAT = process.env.NOTIFICATION_FORMAT || '[MESSAGE] {subject} — from {from}'
 const NOTIFICATION_SKIP_TYPES = (process.env.NOTIFICATION_SKIP_TYPES || 'system,heartbeat').split(',')
 
 export interface NotificationOptions {
@@ -76,9 +80,20 @@ interface PaneDeliveryResult {
   unverifiable: boolean
 }
 
-/** Short, stable per-message token used as the readback needle. */
+/**
+ * Short, stable, PER-MESSAGE token used as the readback needle.
+ *
+ * Takes the TAIL of the id, not the head. Ids look like
+ * `msg-<timestamp>-<random>`, so the leading characters are near-constant:
+ * slicing the front gave every message sent within ~27 hours the identical ref
+ * (`msg17878`). That broke two things at once — the pane readback could be
+ * satisfied by a STALE ref left on screen from an earlier message, making
+ * `confirmed` a false positive, and every notification looked like the same
+ * message repeating to anyone reading the pane.
+ */
 export function messageRef(messageId: string): string {
-  return (messageId || '').replace(/[^a-zA-Z0-9]/g, '').slice(0, 8) || 'nomsgid'
+  const alnum = (messageId || '').replace(/[^a-zA-Z0-9]/g, '')
+  return alnum.slice(-8) || 'nomsgid'
 }
 
 /** Collapse to one line so send-keys can't submit early on an embedded newline. */
@@ -118,12 +133,23 @@ async function sendTmuxNotification(
   // Target the first pane of the first window
   const target = `${sessionName}:0.0`
 
-  // Wrap in echo so shells still render the notification at an idle prompt.
-  const escapedMessage = message.replace(/'/g, "'\\''")
+  // A TUI agent takes the text as a prompt, so send it plainly. A bare shell
+  // would try to EXECUTE it, so there the text is wrapped in `echo`.
+  //
+  // We can tell them apart now: a hook report for this session means a Claude
+  // Code (or Codex/Gemini) agent is live in the pane. Before v0.36.42 there was
+  // no such signal, so everything got the echo wrapper and every notification
+  // landed in the agent's transcript looking like a shell command.
+  //
+  // No report ⇒ assume shell and keep the wrapper. That is the safe default:
+  // an unnecessary `echo` is ugly, an unquoted message at a shell prompt is a
+  // command.
+  const isTui = hasHookReport(sessionName)
+  const payload = isTui ? message : `echo '${message.replace(/'/g, "'\\''")}'`
   let sawPane = false
 
   for (let send = 1; send <= NOTIFICATION_MAX_SENDS; send++) {
-    await runtime.sendKeys(target, `echo '${escapedMessage}'`, { literal: true })
+    await runtime.sendKeys(target, payload, { literal: true })
     await new Promise(resolve => setTimeout(resolve, NOTIFICATION_SUBMIT_DELAY_MS))
     await runtime.sendKeys(target, 'Enter')
 

--- a/lib/session-idle.ts
+++ b/lib/session-idle.ts
@@ -89,6 +89,17 @@ export function isSessionIdle(sessionName: string): boolean {
   return since > IDLE_THRESHOLD_MS
 }
 
+/**
+ * True if the Claude Code hook has reported for this session recently — i.e. an
+ * agent TUI is live in the pane rather than a bare shell. Used to decide
+ * whether a notification can be sent as plain text or must be wrapped in
+ * `echo` so a shell does not try to execute it.
+ */
+export function hasHookReport(sessionName: string): boolean {
+  const reported = hookStatus?.get(sessionName)
+  return !!reported && Date.now() - reported.at < HOOK_STATUS_TTL_MS
+}
+
 /** Which signal answered, for logging and the operator surface. */
 export function idleSource(sessionName: string): 'hook' | 'pty' | 'none' {
   const reported = hookStatus?.get(sessionName)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.42",
+  "version": "0.36.43",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/tests/notification-service.test.ts
+++ b/tests/notification-service.test.ts
@@ -46,6 +46,9 @@ vi.mock('@/types/agent', () => ({
   computeSessionName: vi.fn((name: string) => name),
 }))
 
+const mockIdle = vi.hoisted(() => ({ hasHookReport: vi.fn(() => false) }))
+vi.mock('@/lib/session-idle', () => mockIdle)
+
 import { notifyAgent, messageRef, toSingleLine } from '@/lib/notification-service'
 
 const BASE = {
@@ -66,11 +69,21 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockRuntime.sendKeys.mockResolvedValue(undefined)
   mockRuntime.sessionExists.mockResolvedValue(true)
+  mockIdle.hasHookReport.mockReturnValue(false)
 })
 
 describe('messageRef', () => {
-  it('derives a short alphanumeric token from the message id', () => {
-    expect(messageRef('abc12345-dead-beef')).toBe('abc12345')
+  it('derives the token from the TAIL of the id, where the entropy is', () => {
+    // Ids are `msg-<timestamp>-<random>`; slicing the head gave every message
+    // in a ~27h window the same ref, which both broke readback confirmation
+    // and made every notification look like the same message repeating.
+    expect(messageRef('msg-1787802846153-bk2096t')).toBe('3bk2096t')
+  })
+
+  it('is DISTINCT for messages sent moments apart', () => {
+    const a = messageRef('msg_1787805728539_j782cvq')
+    const b = messageRef('msg_1787805890480_pi3wqxz')
+    expect(a).not.toBe(b)
   })
 
   it('is stable for the same id', () => {
@@ -177,6 +190,36 @@ describe('notifyAgent — pane readback', () => {
 
     const sent = mockRuntime.sendKeys.mock.calls[0][1] as string
     expect(sent).toContain(`[#${messageRef(BASE.messageId)}]`)
+  })
+
+  it('sends PLAIN text when an agent TUI is live in the pane', async () => {
+    mockIdle.hasHookReport.mockReturnValue(true)
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+
+    await notifyAgent(BASE)
+
+    const sent = mockRuntime.sendKeys.mock.calls[0][1] as string
+    expect(sent.startsWith('echo ')).toBe(false)
+    expect(sent).toContain('[MESSAGE]')
+  })
+
+  it('wraps in echo for a bare shell so the text is not EXECUTED', async () => {
+    mockIdle.hasHookReport.mockReturnValue(false)
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+
+    await notifyAgent(BASE)
+
+    const sent = mockRuntime.sendKeys.mock.calls[0][1] as string
+    expect(sent.startsWith("echo '")).toBe(true)
+  })
+
+  it('leads with the subject so stacked notifications are distinguishable', async () => {
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+
+    await notifyAgent(BASE)
+
+    const sent = mockRuntime.sendKeys.mock.calls[0][1] as string
+    expect(sent.indexOf('deploy failed')).toBeLessThan(sent.indexOf('sender'))
   })
 
   it('skips cleanly when the session is gone', async () => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.42",
+  "version": "0.36.43",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## The report

An agent appeared to receive the same message over and over. It was **eleven different messages** — one delivery each, server-side queue clean, `0 unread`. Two defects from v0.36.37 made them look identical.

## Fixed

**`messageRef` was not per-message.** It sliced the *first* 8 chars of `msg-<timestamp>-<random>`, but the entropy is at the end:

```
msg-1787802846153-bk2096t -> msg17878
msg_1787805728539_j782cvq -> msg17878   ← same
msg_1787805890480_pi3wqxz -> msg17878   ← same
```

Two consequences. The pane readback needle wasn't unique, so `confirmed` could be satisfied by a **stale ref still on screen from an earlier message** — a false positive in the exact mechanism built to eliminate false positives. And every notification read as one message repeating. Now takes the tail (`3bk2096t`, `9j782cvq`, `0pi3wqxz`).

**Notifications rendered as shell commands.** Every wake was wrapped in `echo '...'` so a bare shell wouldn't execute it. I kept that in v0.36.37 and called it cosmetic — it isn't. With a TUI agent in the pane it drops `echo '[MESSAGE] ...'` into the agent's transcript on every message.

v0.36.42's persisted hook status finally makes the two cases distinguishable: a live hook report means an agent TUI → send plain text; no report → keep `echo`, because an unnecessary `echo` is ugly but an unquoted message at a shell prompt is a command.

**Default format leads with the subject** — stacked in a transcript, sender-first lines were identical with the differentiator truncated off the right edge. `NOTIFICATION_FORMAT` still overrides.

## Testing

`955 passing (+4)`, build clean. Covers distinct refs for messages sent moments apart, plain text for a TUI, and `echo` retained for a bare shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)