### PR TITLE
fix(memory): honest subconscious status + residency-free maintenance (v0.36.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.45] - 2026-08-27 — Memory subsystem: honest status, residency-free maintenance, health check
+
+Follow-on to 0.36.44. The audit found three separate reasons memory, the graph and the subconscious "seemed to be ignored" — none of which were the subsystems being broken.
+
+### Fixed
+- **The subconscious status endpoint started the subconscious it was reporting on.** `GET /api/agents/[id]/subconscious` called `agentRegistry.getAgent()`, which loads the agent and starts its timers — its own docstring said *"This will initialize the agent if it doesn't exist yet."* So the dashboard indicator was self-fulfilling (opening the UI made agents look active), and every render evicted other agents from the 10-slot LRU to render a badge. It now reports the live object only if the agent is **already** resident, otherwise falls back to the `status.json` that `Agent.writeStatusFile()` has been maintaining for exactly this purpose — with `isRunning` forced false, since an agent absent from the registry is not running whatever the file last claimed. Starting remains a POST: an action, not an observation.
+- **Skill descriptions no longer wait to be asked** (in `ai-maestro-plugins`, [PR #29](https://github.com/23blocks-OS/ai-maestro-plugins/pull/29)). `memory-search`, `graph-query` and `docs-search` had their descriptions rewritten during the v0.22.0 plugin refactor from imperatives into keyword matchers — *"Use when the user asks to 'search memory'"* rather than *"search BEFORE starting new work"*. A skill's description is the only thing deciding whether a model reaches for it, so agents stopped consulting memory on their own. Restored the imperative framing while keeping the explicit-request phrases.
+
+### Added
+- **`lib/memory/sweep.ts` + `POST /api/memory/sweep`** — maintenance that does not require residency. Indexing only ever needed an agent id (`runIndexDelta` opens the database itself), but it ran from an Agent object's timer, and Agent objects live in a 10-slot LRU. With 125 agents that meant an agent was indexed only if something loaded it, loading the 11th cancelled the 1st's timers, and consolidation — gated on being resident at 2 AM — essentially never ran. The sweep walks agent directories instead: no hydration, no eviction, no LRU pressure. Same shape as Letta's sleep-time agents, where maintenance runs on a lifecycle independent of the primary.
+- **`scripts/test-memory-systems.sh`** — the answer to "is there any way to test this?". Checks the things that were actually wrong rather than mere liveness: are ids deterministic, how many databases were written this week, does memory search return results, is the graph populated, **does querying status change status**, and can maintenance run off the LRU.
+- **UI**: the subconscious indicator now shows "last active" for inactive agents, distinguishing *never indexed* from *indexed an hour ago, since evicted*.
+
+### Notes
+- Running the health check on this host reports 10/127 databases indexed this week and a 4.3 GB database — both expected until the sweep is scheduled and `scripts/dedupe-agent-memory.mjs` is applied. The point is that these are now **visible** rather than silent.
+- The plugin submodule pointer is deliberately **not** bumped. The skill fix is merged upstream, but `ai-maestro-plugins` main has since diverged into a marketplace restructure with in-progress branches; adopting it is a reviewed decision, not a side effect of this change.
+
 ## [0.36.44] - 2026-08-27 — Deterministic message IDs (agent memory was 8x duplicated)
 
 Investigating why agent memory and the subconscious "seemed to be ignored" led to a 36 GB pile of duplicated data and a one-line cause.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.44-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.45-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/memory/sweep/route.ts
+++ b/app/api/memory/sweep/route.ts
@@ -1,0 +1,37 @@
+/**
+ * POST /api/memory/sweep — run memory maintenance across agents on disk.
+ * GET  /api/memory/sweep — which agents are eligible and when each was last swept.
+ *
+ * Indexing never needed a resident Agent object; it only needed an agent id.
+ * See lib/memory/sweep.ts for why running it off the LRU matters.
+ *
+ * Reads live state, so it must stay dynamic — a statically prerendered handler
+ * would serve a build-time snapshot.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { sweepAgentMemory, listIndexableAgents } from '@/lib/memory/sweep'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return NextResponse.json({ eligible: listIndexableAgents().length })
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const result = await sweepAgentMemory({
+      limit: body.limit,
+      minAgeMs: body.minAgeMs,
+      only: body.only,
+    })
+    return NextResponse.json({ success: true, ...result })
+  } catch (error) {
+    console.error('[Memory Sweep API] Error:', error)
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/AgentSubconsciousIndicator.tsx
+++ b/components/AgentSubconsciousIndicator.tsx
@@ -7,6 +7,8 @@ interface ExtendedAgentSubconsciousStatus {
   exists: boolean
   initialized: boolean
   isRunning: boolean
+  /** Last time the subconscious wrote its status file (non-resident agents). */
+  lastUpdated?: number | null
   isWarmingUp: boolean
   status: {
     startedAt: number | null
@@ -54,6 +56,15 @@ function formatTimeAgo(timestamp: number | null): string {
 interface Props {
   agentId: string | undefined
   hostUrl?: string  // Base URL for remote hosts
+}
+
+/** Compact "3h ago" style relative time for the last-active line. */
+function formatAgo(ts: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000))
+  if (s < 60) return `${s}s ago`
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
 }
 
 export function AgentSubconsciousIndicator({ agentId, hostUrl }: Props) {
@@ -190,6 +201,17 @@ export function AgentSubconsciousIndicator({ agentId, hostUrl }: Props) {
                     {isRunning ? 'Running' : isWarmingUp ? 'Warming Up' : 'Inactive'}
                   </span>
                 </div>
+
+                {/* An inactive agent is the normal case, not an error: the
+                    subconscious only runs while the agent is resident in the
+                    registry's LRU. Showing when it last ran distinguishes
+                    "never indexed" from "indexed an hour ago, since evicted". */}
+                {!isRunning && status.lastUpdated ? (
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-gray-400">Last active</span>
+                    <span className="text-gray-400">{formatAgo(status.lastUpdated as number)}</span>
+                  </div>
+                ) : null}
 
                 {status.status && (
                   <>

--- a/lib/memory/sweep.ts
+++ b/lib/memory/sweep.ts
@@ -1,0 +1,153 @@
+/**
+ * Memory maintenance sweep — indexing that does not require residency.
+ *
+ * WHY
+ *
+ * Memory maintenance used to run only from an Agent object's timer, and Agent
+ * objects only exist inside `agentRegistry`, an LRU capped at 10. With 125
+ * agents on this host that meant:
+ *
+ *   - an agent was indexed only if something happened to load it
+ *   - loading the 11th agent evicted the 1st, cancelling its timers
+ *   - consolidation, gated on being resident at 2 AM, essentially never ran
+ *
+ * Measured before this existed: 8 of 125 agent databases had been written in
+ * the previous 7 days, and two of three "running" agents reported
+ * `lastMemoryRun: null`.
+ *
+ * The work itself never needed the Agent object. `runIndexDelta(agentId)` takes
+ * an id and opens the database itself. So the sweep walks agent directories on
+ * disk and calls it directly — no hydration, no eviction, no LRU pressure, and
+ * no dependency on which ten agents happen to be loaded.
+ *
+ * This is the same shape as Letta's sleep-time agents: maintenance runs on a
+ * lifecycle independent of the primary, rather than piggybacking on it.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+export interface SweepAgentResult {
+  agentId: string
+  messagesProcessed: number
+  conversationsDiscovered: number
+  ms: number
+  error?: string
+}
+
+export interface SweepResult {
+  scanned: number
+  indexed: number
+  failed: number
+  messagesProcessed: number
+  ms: number
+  agents: SweepAgentResult[]
+}
+
+export interface SweepOptions {
+  /** Cap agents processed in one pass. Keeps a sweep bounded on a big host. */
+  limit?: number
+  /** Skip agents whose last successful index is newer than this (ms). */
+  minAgeMs?: number
+  /** Process only these agent ids. */
+  only?: string[]
+}
+
+const AGENTS_DIR = () => path.join(os.homedir(), '.aimaestro', 'agents')
+
+/** Agent ids that have a database on disk — the set worth sweeping. */
+export function listIndexableAgents(): string[] {
+  try {
+    return fs
+      .readdirSync(AGENTS_DIR())
+      .filter((id) => fs.existsSync(path.join(AGENTS_DIR(), id, 'agent.db')))
+  } catch {
+    return []
+  }
+}
+
+/** When this agent was last swept, from the marker the sweep writes. */
+function lastSweptAt(agentId: string): number {
+  try {
+    const p = path.join(AGENTS_DIR(), agentId, 'last-sweep.json')
+    return JSON.parse(fs.readFileSync(p, 'utf-8')).at ?? 0
+  } catch {
+    return 0
+  }
+}
+
+function markSwept(agentId: string, result: Omit<SweepAgentResult, 'agentId'>): void {
+  try {
+    const p = path.join(AGENTS_DIR(), agentId, 'last-sweep.json')
+    fs.writeFileSync(p, JSON.stringify({ at: Date.now(), ...result }, null, 2))
+  } catch {
+    // A missing marker only means the agent gets swept again sooner.
+  }
+}
+
+/**
+ * Index every eligible agent once.
+ *
+ * Sequential on purpose. Each `runIndexDelta` opens a CozoDB file and may call
+ * the embedding model; running 125 of those concurrently would be far more
+ * disruptive than the slow path is valuable. One agent failing never stops the
+ * sweep — a single corrupt database must not strand the other 124.
+ */
+export async function sweepAgentMemory(opts: SweepOptions = {}): Promise<SweepResult> {
+  const { limit, minAgeMs = 0, only } = opts
+  const started = Date.now()
+
+  let candidates = only ?? listIndexableAgents()
+  if (minAgeMs > 0) {
+    candidates = candidates.filter((id) => Date.now() - lastSweptAt(id) >= minAgeMs)
+  }
+  // Oldest first, so a limited sweep makes progress across the fleet instead of
+  // re-visiting the same head of the list every time.
+  candidates.sort((a, b) => lastSweptAt(a) - lastSweptAt(b))
+  if (limit) candidates = candidates.slice(0, limit)
+
+  const { runIndexDelta } = await import('@/lib/index-delta')
+
+  const agents: SweepAgentResult[] = []
+  let indexed = 0
+  let failed = 0
+  let messagesProcessed = 0
+
+  for (const agentId of candidates) {
+    const t0 = Date.now()
+    try {
+      const r = await runIndexDelta(agentId)
+      const entry: SweepAgentResult = {
+        agentId,
+        messagesProcessed: r.total_messages_processed || 0,
+        conversationsDiscovered: r.new_conversations_discovered || 0,
+        ms: Date.now() - t0,
+      }
+      agents.push(entry)
+      markSwept(agentId, entry)
+      messagesProcessed += entry.messagesProcessed
+      indexed++
+    } catch (err) {
+      const entry: SweepAgentResult = {
+        agentId,
+        messagesProcessed: 0,
+        conversationsDiscovered: 0,
+        ms: Date.now() - t0,
+        error: err instanceof Error ? err.message : String(err),
+      }
+      agents.push(entry)
+      markSwept(agentId, entry)
+      failed++
+    }
+  }
+
+  return {
+    scanned: candidates.length,
+    indexed,
+    failed,
+    messagesProcessed,
+    ms: Date.now() - started,
+    agents,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.44",
+  "version": "0.36.45",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/test-memory-systems.sh
+++ b/scripts/test-memory-systems.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Health check for the memory, graph and subconscious subsystems.
+#
+# These three were reported as "not working" and turned out to be three
+# different problems: the data was 8x duplicated, maintenance only ran for
+# agents resident in a 10-slot LRU, and the status endpoint STARTED the
+# subconscious it claimed to observe. None of that was visible from the UI,
+# because nothing distinguished "healthy" from "never ran".
+#
+# So this checks the things that were actually wrong, not just liveness:
+#   - is memory indexed, and does search return results?
+#   - is the graph populated?
+#   - is the subconscious running, and has it run recently?
+#   - are message IDs deterministic (the duplication bug)?
+#   - does asking about status change status? (the observer bug)
+#
+# Usage:
+#   ./scripts/test-memory-systems.sh                 # all local agents
+#   ./scripts/test-memory-systems.sh <agent-id>
+#   BASE=http://100.80.12.6:23000 ./scripts/test-memory-systems.sh
+
+set -uo pipefail
+BASE="${BASE:-http://localhost:23000}"
+TARGET="${1:-}"
+PASS=0; FAIL=0; WARN=0
+
+g() { printf '\033[0;32m%s\033[0m\n' "$1"; }
+r() { printf '\033[0;31m%s\033[0m\n' "$1"; }
+y() { printf '\033[1;33m%s\033[0m\n' "$1"; }
+c() { printf '\033[0;36m%s\033[0m\n' "$1"; }
+ok()   { g "  PASS  $1"; PASS=$((PASS+1)); }
+no()   { r "  FAIL  $1"; FAIL=$((FAIL+1)); }
+warn() { y "  WARN  $1"; WARN=$((WARN+1)); }
+
+command -v jq >/dev/null || { r "jq required"; exit 1; }
+curl -sf -m8 "$BASE/api/sessions" >/dev/null || { r "AI Maestro not answering at $BASE"; exit 1; }
+
+c "== memory / graph / subconscious health =="
+echo "base: $BASE"
+
+# ── 1. Deterministic message IDs ────────────────────────────────────────────
+# The duplication bug: ids contained Math.random(), so :put could never upsert
+# and every re-index inserted a copy.
+c $'\n[1] message id determinism'
+if grep -q "Math.random" lib/rag/ingest.ts 2>/dev/null; then
+  no "lib/rag/ingest.ts still uses Math.random() for message ids — re-indexing will duplicate"
+else
+  ok "message ids are deterministic (no Math.random in ingest)"
+fi
+
+# ── 2. Agent inventory ──────────────────────────────────────────────────────
+c $'\n[2] agent databases'
+DBS=$(find "$HOME/.aimaestro/agents" -maxdepth 2 -name agent.db 2>/dev/null | wc -l | tr -d ' ')
+FRESH=$(find "$HOME/.aimaestro/agents" -maxdepth 2 -name agent.db -mtime -7 2>/dev/null | wc -l | tr -d ' ')
+echo "  databases: $DBS   written in last 7d: $FRESH"
+if [ "$DBS" -gt 0 ] && [ "$FRESH" -eq 0 ]; then
+  no "no agent database written in 7 days — maintenance is not running"
+elif [ "$DBS" -gt 20 ] && [ "$FRESH" -lt $((DBS / 10)) ]; then
+  warn "only $FRESH/$DBS databases touched this week — most agents are never indexed"
+else
+  ok "$FRESH/$DBS databases indexed recently"
+fi
+
+# Largest DB — a multi-GB file suggests duplication that predates the id fix.
+BIGGEST=$(find "$HOME/.aimaestro/agents" -maxdepth 2 -name agent.db -exec du -m {} \; 2>/dev/null | sort -rn | head -1)
+BIG_MB=$(echo "$BIGGEST" | cut -f1)
+if [ -n "${BIG_MB:-}" ] && [ "$BIG_MB" -gt 1000 ]; then
+  warn "largest database is ${BIG_MB} MB — run scripts/dedupe-agent-memory.mjs (dry run first)"
+else
+  ok "largest database ${BIG_MB:-0} MB"
+fi
+
+# ── 3. Pick a target agent ──────────────────────────────────────────────────
+if [ -z "$TARGET" ]; then
+  TARGET=$(curl -s -m8 "$BASE/api/sessions" | jq -r '[(.sessions // .)[] | .agentId] | map(select(. != null))[0] // empty')
+fi
+[ -z "$TARGET" ] && { r "no agent found"; exit 1; }
+c $'\n[3] target agent: '"${TARGET:0:8}"
+
+# ── 4. Memory search actually returns results ───────────────────────────────
+c $'\n[4] memory search'
+MEM=$(curl -s -m30 "$BASE/api/agents/$TARGET/memory?action=stats" 2>/dev/null)
+PROJECTS=$(echo "$MEM" | jq -r '.projects | length' 2>/dev/null || echo 0)
+if [ "${PROJECTS:-0}" -gt 0 ]; then
+  ok "memory indexed ($PROJECTS project(s))"
+else
+  warn "no indexed projects for this agent — nothing to search"
+fi
+
+if [ -x "$HOME/.local/bin/memory-search.sh" ]; then
+  HITS=$(AIM_AGENT_ID="$TARGET" timeout 40 "$HOME/.local/bin/memory-search.sh" "agent" 2>/dev/null | grep -c "Score:" || true)
+  if [ "${HITS:-0}" -gt 0 ]; then ok "memory-search returned $HITS result(s)"
+  else warn "memory-search returned no results (empty index, or search is broken)"; fi
+else
+  warn "memory-search.sh not installed (run ./install-plugin.sh)"
+fi
+
+# ── 5. Graph populated ──────────────────────────────────────────────────────
+c $'\n[5] code graph'
+if [ -x "$HOME/.local/bin/graph-find-by-type.sh" ]; then
+  GHITS=$(AIM_AGENT_ID="$TARGET" timeout 40 "$HOME/.local/bin/graph-find-by-type.sh" function 2>/dev/null | wc -l | tr -d ' ')
+  if [ "${GHITS:-0}" -gt 2 ]; then ok "graph query returned $GHITS line(s)"
+  else warn "graph appears empty for this agent — has it been indexed?"; fi
+else
+  warn "graph-*.sh not installed (run ./install-plugin.sh)"
+fi
+
+# ── 6. Subconscious status must not START the subconscious ──────────────────
+# Before v0.36.45 the GET called agentRegistry.getAgent(), which loads the
+# agent and starts its timers — the monitor created the state it reported, and
+# evicted other agents from the 10-slot LRU to do it.
+c $'\n[6] subconscious status is an observation, not an action'
+S1=$(curl -s -m20 "$BASE/api/agents/$TARGET/subconscious" | jq -r '.isRunning' 2>/dev/null)
+sleep 1
+S2=$(curl -s -m20 "$BASE/api/agents/$TARGET/subconscious" | jq -r '.isRunning' 2>/dev/null)
+echo "  isRunning: first=$S1 second=$S2"
+if [ "$S1" = "false" ] && [ "$S2" = "true" ]; then
+  no "querying status STARTED the subconscious — the indicator is self-fulfilling"
+else
+  ok "status query did not change status"
+fi
+
+# ── 7. Maintenance can run without residency ────────────────────────────────
+c $'\n[7] residency-free maintenance sweep'
+SWEEP=$(curl -s -m10 "$BASE/api/memory/sweep" 2>/dev/null | jq -r '.eligible' 2>/dev/null)
+if [ -n "${SWEEP:-}" ] && [ "$SWEEP" != "null" ]; then
+  ok "sweep endpoint live — $SWEEP agent(s) eligible (not capped by the 10-slot LRU)"
+else
+  no "sweep endpoint missing — maintenance still depends on agent residency"
+fi
+
+echo
+if [ "$FAIL" -eq 0 ]; then g "== $PASS passed, $WARN warning(s), 0 failed =="; exit 0
+else r "== $PASS passed, $WARN warning(s), $FAIL failed =="; exit 1; fi

--- a/services/agents-subconscious-service.ts
+++ b/services/agents-subconscious-service.ts
@@ -5,17 +5,83 @@
  * Routes are thin wrappers that call these functions.
  */
 
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { agentRegistry } from '@/lib/agent'
 import { type ServiceResult, notInitialized, invalidRequest } from '@/services/service-errors'
+
+/**
+ * Last status the agent's subconscious wrote to disk.
+ *
+ * Agent.writeStatusFile() exists to decouple the dashboard from loading agents,
+ * which is exactly what this read path needs — see getSubconsciousStatus.
+ */
+function readStatusFile(agentId: string): Record<string, unknown> | null {
+  try {
+    const p = path.join(os.homedir(), '.aimaestro', 'agents', agentId, 'status.json')
+    return JSON.parse(fs.readFileSync(p, 'utf-8'))
+  } catch {
+    return null
+  }
+}
 
 // ── Public Functions ────────────────────────────────────────────────────────
 
 /**
- * Get the subconscious status for an agent.
- * This will initialize the agent if it doesn't exist yet.
+ * Get the subconscious status for an agent — WITHOUT starting it.
+ *
+ * This used to call agentRegistry.getAgent(), which loads the agent and starts
+ * its subconscious. That made the dashboard indicator self-fulfilling: opening
+ * the UI started the very thing it claimed to be observing, and every render
+ * evicted other agents from the 10-slot LRU to do it. A monitor must not create
+ * the state it reports.
+ *
+ * So: report the live object only if the agent is ALREADY resident. Otherwise
+ * fall back to the status file, which Agent.writeStatusFile() maintains for
+ * exactly this purpose — but force isRunning to false, because an agent absent
+ * from the registry is not running in this process no matter what the file's
+ * last write claimed. The historical counters stay useful, and `lastUpdated`
+ * lets the UI say how long ago it was last alive.
+ *
+ * Starting a subconscious is a POST (triggerSubconsciousAction) — an action,
+ * not an observation.
  */
 export async function getSubconsciousStatus(agentId: string): Promise<ServiceResult<Record<string, unknown>>> {
-  const agent = await agentRegistry.getAgent(agentId)
+  const agent = agentRegistry.getExistingAgent(agentId)
+
+  if (!agent) {
+    const file = readStatusFile(agentId)
+    return {
+      data: {
+        success: true,
+        exists: !!file,
+        initialized: false,
+        resident: false,
+        isRunning: false,
+        isWarmingUp: false,
+        lastUpdated: file?.lastUpdated ?? null,
+        status: file
+          ? {
+              startedAt: file.startedAt,
+              memoryCheckInterval: file.memoryCheckInterval,
+              messageCheckInterval: file.messageCheckInterval,
+              lastMemoryRun: file.lastMemoryRun,
+              lastMessageRun: file.lastMessageRun,
+              lastMemoryResult: file.lastMemoryResult,
+              lastMessageResult: file.lastMessageResult,
+              totalMemoryRuns: file.totalMemoryRuns,
+              totalMessageRuns: file.totalMessageRuns,
+              cumulativeMessagesIndexed: file.cumulativeMessagesIndexed,
+              cumulativeConversationsIndexed: file.cumulativeConversationsIndexed,
+            }
+          : null,
+        consolidation: (file?.consolidation as Record<string, unknown>) ?? null,
+        memoryStats: null,
+      },
+      status: 200,
+    }
+  }
 
   const subconscious = agent.getSubconscious()
   const status = subconscious?.getStatus() || null
@@ -36,6 +102,7 @@ export async function getSubconsciousStatus(agentId: string): Promise<ServiceRes
       success: true,
       exists: true,
       initialized: true,
+      resident: true,
       isRunning: status?.isRunning || false,
       isWarmingUp: false,
       status: status ? {

--- a/tests/memory-sweep.test.ts
+++ b/tests/memory-sweep.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for lib/memory/sweep.ts.
+ *
+ * Maintenance used to run only from an Agent object's timer, and Agent objects
+ * live in a 10-slot LRU. With 125 agents that meant an agent was indexed only
+ * if something happened to load it, and loading the 11th evicted the 1st along
+ * with its timers. Measured: 8 of 125 databases written in 7 days.
+ *
+ * The sweep exists so indexing depends on an agent id and a file on disk, not
+ * on which ten agents happen to be resident.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockFs, mockIndex } = vi.hoisted(() => ({
+  mockFs: {
+    readdirSync: vi.fn(() => [] as string[]),
+    existsSync: vi.fn(() => true),
+    readFileSync: vi.fn(() => '{}'),
+    writeFileSync: vi.fn(),
+  },
+  mockIndex: { runIndexDelta: vi.fn() },
+}))
+
+vi.mock('fs', () => ({ default: mockFs, ...mockFs }))
+vi.mock('@/lib/index-delta', () => mockIndex)
+
+import { sweepAgentMemory, listIndexableAgents } from '@/lib/memory/sweep'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFs.existsSync.mockReturnValue(true)
+  mockFs.readFileSync.mockReturnValue('{}')
+  mockIndex.runIndexDelta.mockResolvedValue({
+    total_messages_processed: 3,
+    new_conversations_discovered: 1,
+  })
+})
+
+describe('listIndexableAgents', () => {
+  it('lists agent dirs that have a database', () => {
+    mockFs.readdirSync.mockReturnValue(['a', 'b', 'c'])
+    expect(listIndexableAgents()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns empty rather than throwing when the dir is missing', () => {
+    mockFs.readdirSync.mockImplementation(() => { throw new Error('ENOENT') })
+    expect(listIndexableAgents()).toEqual([])
+  })
+})
+
+describe('sweepAgentMemory', () => {
+  it('indexes every agent — not just the ten a registry could hold', async () => {
+    mockFs.readdirSync.mockReturnValue(Array.from({ length: 125 }, (_, i) => `agent-${i}`))
+
+    const r = await sweepAgentMemory()
+
+    expect(r.scanned).toBe(125)
+    expect(r.indexed).toBe(125)
+    expect(mockIndex.runIndexDelta).toHaveBeenCalledTimes(125)
+  })
+
+  it('indexes by agent id, never hydrating an Agent object', async () => {
+    mockFs.readdirSync.mockReturnValue(['agent-1'])
+    await sweepAgentMemory()
+    expect(mockIndex.runIndexDelta).toHaveBeenCalledWith('agent-1')
+  })
+
+  it('keeps going when one agent fails', async () => {
+    mockFs.readdirSync.mockReturnValue(['good-1', 'bad', 'good-2'])
+    mockIndex.runIndexDelta.mockImplementation(async (id: string) => {
+      if (id === 'bad') throw new Error('corrupt database')
+      return { total_messages_processed: 1, new_conversations_discovered: 0 }
+    })
+
+    const r = await sweepAgentMemory()
+
+    // One broken database must not strand the other 124.
+    expect(r.indexed).toBe(2)
+    expect(r.failed).toBe(1)
+    expect(r.agents.find((a) => a.agentId === 'bad')?.error).toMatch(/corrupt/)
+  })
+
+  it('honours a limit so a sweep stays bounded on a big host', async () => {
+    mockFs.readdirSync.mockReturnValue(Array.from({ length: 50 }, (_, i) => `a${i}`))
+    const r = await sweepAgentMemory({ limit: 5 })
+    expect(r.scanned).toBe(5)
+    expect(mockIndex.runIndexDelta).toHaveBeenCalledTimes(5)
+  })
+
+  it('processes only the requested agents when told to', async () => {
+    const r = await sweepAgentMemory({ only: ['x', 'y'] })
+    expect(r.scanned).toBe(2)
+    expect(mockIndex.runIndexDelta).toHaveBeenCalledWith('x')
+    expect(mockIndex.runIndexDelta).toHaveBeenCalledWith('y')
+  })
+
+  it('skips agents swept more recently than minAgeMs', async () => {
+    mockFs.readdirSync.mockReturnValue(['recent', 'stale'])
+    mockFs.readFileSync.mockImplementation((p: any) =>
+      String(p).includes('recent')
+        ? JSON.stringify({ at: Date.now() })
+        : JSON.stringify({ at: Date.now() - 86_400_000 })
+    )
+
+    const r = await sweepAgentMemory({ minAgeMs: 3_600_000 })
+
+    expect(r.scanned).toBe(1)
+    expect(mockIndex.runIndexDelta).toHaveBeenCalledWith('stale')
+  })
+
+  it('totals the work done', async () => {
+    mockFs.readdirSync.mockReturnValue(['a', 'b'])
+    const r = await sweepAgentMemory()
+    expect(r.messagesProcessed).toBe(6)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.44",
+  "version": "0.36.45",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Follow-on to [v0.36.44](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.36.44). Three separate reasons memory, the graph and the subconscious "seemed to be ignored" — **none of them the subsystems being broken.**

## 1. The status endpoint started what it reported on

`GET /api/agents/[id]/subconscious` called `agentRegistry.getAgent()`, which loads the agent and starts its timers. Its own docstring said so:

> *"This will initialize the agent if it doesn't exist yet."*

So the dashboard indicator was **self-fulfilling** — opening the UI made agents look active — and every render evicted other agents from the 10-slot LRU to draw a badge. It's how I first noticed: checking status started three subconsciouses.

Now it reports the live object only when the agent is **already** resident, otherwise reads the `status.json` that `Agent.writeStatusFile()` has been maintaining for exactly this purpose, with `isRunning` forced false — an agent absent from the registry isn't running whatever the file last claimed.

Verified on a cold agent:
```json
{"resident":false,"isRunning":false,"exists":true,"lastUpdated":1770569654446}
loads triggered: 0
```

## 2. Maintenance required residency

Indexing only ever needed an agent id — `runIndexDelta` opens the database itself — but it ran from an Agent object's timer, and Agent objects live in that same 10-slot LRU. With 125 agents: an agent was indexed only if something loaded it, loading the 11th cancelled the 1st's timers, and consolidation (gated on residency *at 2 AM*) essentially never ran. Measured: 8 of 125 databases written in 7 days.

`lib/memory/sweep.ts` + `POST /api/memory/sweep` walk agent directories instead — no hydration, no eviction, no LRU pressure. Same shape as [Letta's sleep-time agents](https://docs.letta.com/guides/agents/architectures/sleeptime/), where maintenance has a lifecycle independent of the primary.

## 3. Skills waited to be asked

Handled upstream in [ai-maestro-plugins#29](https://github.com/23blocks-OS/ai-maestro-plugins/pull/29). The three skills had their descriptions rewritten during the v0.22.0 refactor from imperatives into keyword matchers. A skill description is the only thing deciding whether a model reaches for the tool.

## Testing it

`scripts/test-memory-systems.sh` checks what was actually wrong, not liveness:

```
[1] message id determinism      PASS
[2] agent databases             WARN  10/127 touched this week
                                WARN  largest 4289 MB — run dedupe
[5] code graph                  PASS  8 lines
[6] status is an observation    PASS  query did not change status
[7] residency-free sweep        PASS  127 eligible (not capped by LRU)
```

Those warnings are correct and the point: previously invisible, now surfaced.

`973 tests passing (+9)`, build clean.

## Deliberate omission

**The plugin submodule pointer is not bumped.** The skill fix is merged upstream, but `ai-maestro-plugins` main has since diverged into a marketplace restructure with in-progress branches. Adopting that is a reviewed decision, not a side effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)