### PR TITLE
chore(plugin): bump submodule so hosts get the proactive skill descriptions (v0.36.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.46] - 2026-08-27 — Ship the proactive skill descriptions to hosts
+
+0.36.45 fixed the skill descriptions upstream but did not bump the submodule, so nothing reached hosts — installs read the *built* submodule, not the source repo.
+
+### Changed
+- **Plugin submodule bumped** `b645bba` → `130508e`, delivering the restored `memory-search` / `graph-query` / `docs-search` descriptions to every host on the next `update-aimaestro.sh`.
+
+### Notes
+- The bump was not a fast-forward. The pin carried **four fixes never merged to plugins main** — `session_id` on heartbeat, the full-featured hook superset, cwd-based identity resolution for detached sessions, and the statusline `CLAUDE_AGENT_NAME` fix — while main carried the skill fix. Bumping straight to main would have regressed detached-session identity. Resolved by merging main *into* the pinned lineage ([plugins#30](https://github.com/23blocks-OS/ai-maestro-plugins/pull/30)) and rebuilding, so one commit has both. Diff of built output against the old pin is exactly four files: the three SKILL.md descriptions and a generated README line.
+- Plugins main is now ahead of the app's pin for the first time in a while, so future bumps should be clean fast-forwards.
+
 ## [0.36.45] - 2026-08-27 — Memory subsystem: honest status, residency-free maintenance, health check
 
 Follow-on to 0.36.44. The audit found three separate reasons memory, the graph and the subconscious "seemed to be ignored" — none of which were the subsystems being broken.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.45-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.46-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.45",
+  "version": "0.36.46",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.45",
+  "version": "0.36.46",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Why

v0.36.45 fixed the skill descriptions upstream but left the submodule pinned — and installs read the **built submodule**, not the source repo. So the fix reached nobody.

## The bump was not a fast-forward

The pin (`b645bba`) carried **four fixes never merged to plugins main**:

```
f0b52bb feat(hook): send Claude Code session_id on heartbeat
f0d5c09 feat(hook): adopt the full-featured ai-maestro-hook (superset)
e2061f7 feat(amp): resolve identity by working directory for detached sessions
1ffc876 fix(statusline): read real env.CLAUDE_AGENT_NAME
```

while `main` carried the skill fix. **Bumping straight to main would have regressed detached-session identity** — precisely the failure the CLAUDE.md note warns about (*"fixes MUST land on that repo's main or a rebuild regresses"*).

Resolved by merging main *into* the pinned lineage ([plugins#30](https://github.com/23blocks-OS/ai-maestro-plugins/pull/30)) and rebuilding, so one commit has both.

## Verification

Diff of built output against the old pin is exactly four files:

```
plugins/ai-maestro/README.md                     | 2 +-
plugins/ai-maestro/skills/docs-search/SKILL.md   | 2 +-
plugins/ai-maestro/skills/graph-query/SKILL.md   | 2 +-
plugins/ai-maestro/skills/memory-search/SKILL.md | 2 +-
```

Confirmed intact after the merge: `amp-helper.sh` cwd-based identity resolution, `amp-statusline.sh` `CLAUDE_AGENT_NAME` handling.

`973 tests passing`, build clean. Plugins main is now ahead of the pin, so future bumps should fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)