### PR TITLE
fix(deploy): update-aimaestro.sh always syncs the plugin submodule (v0.36.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.47] - 2026-08-27 — update-aimaestro.sh always syncs the submodule
+
+### Fixed
+- **`update-aimaestro.sh` skipped the plugin submodule sync whenever the parent repo was already current.** The sync lived inside the "new commits available" branch, which made submodule freshness conditional on *parent* freshness — two independent things. If the parent was at the right commit but the submodule had drifted (an interrupted run, a manual `git pull` beforehand, a failed fetch), the script printed *"You're already on the latest version!"* and skipped the sync entirely, then reinstalled **stale** scripts and skills with no warning.
+
+  Observed on mini-lola right after v0.36.46: parent at the correct commit, submodule three commits behind, old skill descriptions still installed. Reproduced by rolling the submodule back and re-running — the script reported success and changed nothing.
+
+  The sync now runs on every path, with `git submodule sync --recursive` first in case `.gitmodules` moved, and reports the resulting commit so a stale submodule is visible in the output rather than silent.
+
+### Notes
+- This is the same class of bug as the v0.36.31 fix (which *added* the submodule update after `git pull`) — that fix was correct but placed on only one of the two code paths.
+
 ## [0.36.46] - 2026-08-27 — Ship the proactive skill descriptions to hosts
 
 0.36.45 fixed the skill descriptions upstream but did not bump the submodule, so nothing reached hosts — installs read the *built* submodule, not the source repo.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.46-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.47-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.46",
+  "version": "0.36.47",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/update-aimaestro.sh
+++ b/update-aimaestro.sh
@@ -188,15 +188,6 @@ else
     git pull origin main
     print_success "Code updated"
 
-    # Check out the submodule content the new pointer references. `git pull` moves
-    # the gitlink but does NOT update the submodule working tree — without this,
-    # install-plugin.sh below reinstalls STALE scripts (old statusline/hook/amp-*)
-    # from the previous submodule commit. --force to override any local drift.
-    print_step "$DOWNLOAD" "Updating plugin submodule..."
-    git submodule update --init --recursive --force \
-        && print_success "Plugin submodule updated" \
-        || print_warning "Submodule update had issues (plugin scripts may be stale)"
-
     # Detect ecosystem.config.js changes that require PM2 config reload
     if ! git diff --quiet "$BEFORE_SHA" HEAD -- ecosystem.config.js ecosystem.config.cjs 2>/dev/null; then
         ECOSYSTEM_CHANGED=true
@@ -228,6 +219,33 @@ fi
 
 echo ""
 print_step "$ROCKET" "Reinstalling scripts and skills..."
+
+# Check out the submodule content the recorded pointer references, on EVERY
+# path — not only when the parent had new commits.
+#
+# `git pull` moves the gitlink but does NOT update the submodule working tree,
+# so install-plugin.sh below would reinstall STALE scripts (old
+# statusline/hook/amp-*, old skill descriptions) from the previous submodule
+# commit.
+#
+# This used to live inside the "new commits available" branch. That made
+# submodule freshness conditional on PARENT freshness, which are independent:
+# if the parent is already current but the submodule drifted — an interrupted
+# earlier run, a manual `git pull` beforehand, a failed fetch — the script
+# printed "You're already on the latest version!" and skipped the sync
+# entirely, leaving stale scripts installed with no warning. Observed on
+# mini-lola after v0.36.46: parent at the right commit, submodule 3 commits
+# behind, old skill descriptions still installed.
+#
+# --force overrides local drift; sync first in case .gitmodules moved.
+print_step "$DOWNLOAD" "Syncing plugin submodule..."
+git submodule sync --recursive >/dev/null 2>&1
+if git submodule update --init --recursive --force >/dev/null 2>&1; then
+    print_success "Plugin submodule at $(git submodule status plugin 2>/dev/null | awk '{print substr($1,1,8)}')"
+else
+    print_warning "Submodule update had issues (plugin scripts may be stale)"
+fi
+echo ""
 
 # ── v0.21.26 fix: delegate to component installers ──────────────────────
 # Previously this section iterated separate script directories.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.46",
+  "version": "0.36.47",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## The bug

The submodule sync lived **inside the "new commits available" branch**, making submodule freshness conditional on *parent* freshness — two independent things.

If the parent was already at the right commit but the submodule had drifted (interrupted run, a manual `git pull` beforehand, a failed fetch), the script printed:

```
✅ You're already on the latest version!
```

…skipped the sync entirely, and then reinstalled **stale** scripts and skills with no warning.

## Observed and reproduced

Hit on mini-lola immediately after v0.36.46 — parent at the correct commit, submodule three commits behind, old skill descriptions still installed. Reproduced deterministically by rolling the submodule back and re-running:

```
rolled back to: +b645bba plugin
✅ You're already on the latest version!
after:          +b645bba plugin
(skill NOT updated)
```

The script reported success and changed nothing.

## Fix

The sync now runs on **every** path, with `git submodule sync --recursive` first in case `.gitmodules` moved, and prints the resulting commit so a stale submodule shows up in the output rather than silently.

## Note

Same class of bug as the v0.36.31 fix, which *added* the submodule update after `git pull` — that fix was right but landed on only one of the two code paths.

`973 tests passing`, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)