### PR TITLE
fix(memory): repair agent project bindings so agents find their own conversations (v0.36.48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.48] - 2026-08-27 — Agent project bindings: agents can find their own conversations again
+
+A survey of 163 agents across three hosts found **87 with wrong or incomplete memory bindings**. Three defects in `lib/index-delta.ts`, each of which made an agent silently index nothing while reporting success.
+
+### Fixed
+- **A dead `claude_dir` skipped a project forever.** Phase 1 did `if (!claudeDir || !fs.existsSync(claudeDir)) continue`. Older records stored a *nested* path — `<project>/<session>/subagents` rather than the project root — and once that directory rotated away the project was skipped on every subsequent run. The agent could never rediscover its own conversations and reported `0 new` indefinitely. Observed on the `maestro` agent: `claude_dir` pointed at a subagents directory that no longer existed while **47 conversations sat unread in the project root**. The correct directory is derivable from `project_path`, so it is now derived, persisted, and used. That one agent went from 0 indexed messages to **3,403 across 47 conversations** on the first run after the fix.
+- **Conversations were matched to agents by exact `cwd` equality.** A subagent, or any session started in a child directory, has a deeper `cwd` and so was invisible to the agent that owns it. Matching is now prefix-based — with the nesting case handled: when an outer agent works in `/repo` and an inner one in `/repo/service`, a conversation in `/repo/service` belongs to the **closer** agent rather than being claimed by both.
+- **Auto-discovery only ran when an agent had zero projects recorded**, so a wrong binding was permanent. It now also re-runs when the recorded binding no longer reconciles with the agent's current working directory.
+- **Stale conversation records are now reported.** A run where recorded conversations no longer exist on disk logs `N/M recorded conversations no longer exist on disk — the binding is entirely stale`, instead of looking like a clean "0 to index".
+
+### Added
+- **`scripts/survey-agent-bindings.mjs`** — read-only audit reporting, per agent: working directory, bound project paths, dead conversation records, reachable `.jsonl` files under its own and child slugs, indexed message count, and a verdict (`OK` / `STALE_BINDING` / `UNBOUND` / `MISSING_CHILDREN` / `NO_WD` / `EMPTY`).
+
+### Survey results
+| host | agents | needing repair |
+|---|---|---|
+| local | 128 | 75 |
+| mini-lola | 17 | 5 |
+| mac-mini | 18 | 7 |
+
+`NO_WD=66` on local are mostly orphaned data directories for agents no longer in the registry — a cleanup opportunity, not a binding fault.
+
 ## [0.36.47] - 2026-08-27 — update-aimaestro.sh always syncs the submodule
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.47-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.48-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/index-delta.ts
+++ b/lib/index-delta.ts
@@ -15,7 +15,7 @@ import { agentRegistry } from '@/lib/agent'
 import { AgentDatabase } from '@/lib/cozo-db'
 import { getConversations, recordConversation, recordProject, getProjects, getSessions } from '@/lib/cozo-schema-simple'
 import { indexConversationDelta } from '@/lib/rag/ingest'
-import { getAgent as getRegistryAgent, getAgentBySession, updateAgentWorkingDirectory } from '@/lib/agent-registry'
+import { getAgent as getRegistryAgent, getAgentBySession, updateAgentWorkingDirectory, listAgents } from '@/lib/agent-registry'
 import { computeSessionName } from '@/types/agent'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -187,6 +187,57 @@ function getCachedProjectFiles(): CachedJsonlFile[] {
 // ============================================================================
 // AUTO-DISCOVER PROJECTS (uses global cache)
 // ============================================================================
+/**
+ * The top-level Claude project directory for a working directory.
+ *
+ * Claude Code encodes a cwd by replacing separators with '-', so
+ * /Users/me/repo lives at ~/.claude/projects/-Users-me-repo.
+ */
+function topLevelClaudeDir(projectPath: string): string {
+  return path.join(os.homedir(), '.claude', 'projects', projectPath.replace(/\//g, '-'))
+}
+
+/**
+ * Working directories of every OTHER registered agent, longest first.
+ *
+ * Used to resolve ownership when directories nest: if agent A works in
+ * /repo and agent B in /repo/service, a conversation started in
+ * /repo/service belongs to B, not both. Without this, prefix matching would
+ * let the outer agent swallow every inner agent's conversations.
+ */
+function otherAgentWorkingDirs(agentId: string): string[] {
+  try {
+    return listAgents()
+      .filter((a: any) => a.id !== agentId)
+      .flatMap((a: any) => [a.workingDirectory, a.sessions?.[0]?.workingDirectory])
+      .filter((d: any): d is string => typeof d === 'string' && d.length > 0)
+      .sort((a, b) => b.length - a.length)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Does `cwd` belong to an agent working in `agentWd`?
+ *
+ * Exact match, or a DESCENDANT of it — a subagent or a session started in a
+ * child directory has a deeper cwd (e.g. an agent in /repo and a subagent in
+ * /repo/packages/api), and exact-equality matching made those conversations
+ * invisible to the agent that owns them. Surveyed across the fleet, this and
+ * stale bindings accounted for 87 of 163 agents having wrong or incomplete
+ * memory.
+ *
+ * A descendant is NOT claimed when another agent sits closer to it.
+ */
+function cwdBelongsTo(cwd: string, agentWd: string, otherWds: string[]): boolean {
+  if (cwd === agentWd) return true
+  if (!cwd.startsWith(agentWd.endsWith('/') ? agentWd : agentWd + '/')) return false
+  // otherWds is sorted longest-first; a longer match is a more specific owner.
+  return !otherWds.some(
+    (o) => o.length > agentWd.length && (cwd === o || cwd.startsWith(o.endsWith('/') ? o : o + '/'))
+  )
+}
+
 async function autoDiscoverProjects(
   agentDb: AgentDatabase,
   agentId: string,
@@ -210,10 +261,13 @@ async function autoDiscoverProjects(
   const discoveredProjects = new Map<string, { projectName: string; claudeDir: string }>()
   let matchedConversations = 0
 
+  const otherWds = otherAgentWorkingDirs(agentId)
+  const ownWds = Array.from(workingDirectories)
+
   for (const file of allFiles) {
     const belongsToAgent =
       (file.sessionId && agentSessionIds.has(file.sessionId)) ||
-      (file.cwd && workingDirectories.has(file.cwd)) ||
+      (file.cwd && ownWds.some((wd) => cwdBelongsTo(file.cwd as string, wd, otherWds))) ||
       file.path.includes(agentId) ||
       (file.cwd && file.cwd.includes(agentId))
 
@@ -447,9 +501,46 @@ export async function runIndexDelta(
       throw error
     }
 
-    // AUTO-DISCOVER if no projects
-    if (projectsResult.rows.length === 0) {
-      console.log(`[Delta Index] No projects for agent ${agentId.substring(0, 8)} - auto-discovering`)
+    // AUTO-DISCOVER when there are no projects, OR when the recorded binding no
+    // longer reconciles with reality.
+    //
+    // Discovery used to run ONLY when zero projects were recorded, which made a
+    // wrong binding permanent: an agent bound to a directory it no longer works
+    // in kept reporting "0 messages, success" forever. pas-lola was bound to
+    // /home/jpelaez with four conversations that had not existed for months,
+    // while its real ones sat in -home-jpelaez-lola. Across the fleet, 87 of 163
+    // agents were mis-bound this way.
+    //
+    // "No longer reconciles" = every recorded project is unrelated to the
+    // agent's current working directory. That is cheap to check and cannot
+    // mistake a merely-idle agent for a broken one.
+    const boundPaths = projectsResult.rows.map((r: any[]) => String(r[0]))
+    const currentWds = Array.from(
+      new Set(
+        [
+          liveTmuxWd,
+          registryAgent?.workingDirectory,
+          registryAgent?.sessions?.[0]?.workingDirectory,
+          registryAgent?.preferences?.defaultWorkingDirectory,
+        ].filter((d): d is string => typeof d === 'string' && d.length > 0)
+      )
+    )
+    const bindingLooksStale =
+      boundPaths.length > 0 &&
+      currentWds.length > 0 &&
+      !boundPaths.some((b: string) =>
+        currentWds.some((wd) => b === wd || b.startsWith(wd + '/') || wd.startsWith(b + '/'))
+      )
+
+    if (bindingLooksStale) {
+      console.warn(
+        `[Delta Index] Agent ${agentId.substring(0, 8)} bound to [${boundPaths.join(', ')}] ` +
+        `but works in [${currentWds.join(', ')}] — re-discovering`
+      )
+    }
+
+    if (projectsResult.rows.length === 0 || bindingLooksStale) {
+      console.log(`[Delta Index] Re-discovering projects for agent ${agentId.substring(0, 8)}`)
 
       const workingDirectories = new Set<string>()
       if (registryAgent) {
@@ -481,7 +572,38 @@ export async function runIndexDelta(
 
     for (const projectRow of projectsResult.rows) {
       const projectPath = projectRow[0] as string
-      const claudeDir = projectRow[2] as string
+      let claudeDir = projectRow[2] as string
+
+      // Repair a claude_dir that points somewhere unusable instead of skipping
+      // the project forever.
+      //
+      // Older records stored a NESTED path — e.g. <project>/<session>/subagents
+      // — rather than the project root. Once that directory was rotated away,
+      // `continue` skipped the project on every run, so the agent could never
+      // discover its own conversations again and reported "0 new" indefinitely.
+      // Observed on the `maestro` agent: claude_dir pointed at a subagents
+      // directory that no longer existed, while 47 conversations sat unread in
+      // the project root.
+      //
+      // The correct directory is derivable from project_path, so derive it,
+      // persist the correction, and carry on.
+      const derived = topLevelClaudeDir(projectPath)
+      if ((!claudeDir || !fs.existsSync(claudeDir) || claudeDir !== derived) && fs.existsSync(derived)) {
+        console.warn(
+          `[Delta Index] Repairing claude_dir for ${projectPath}: ` +
+          `${claudeDir || '(unset)'} -> ${derived}`
+        )
+        try {
+          await recordProject(agentDb, {
+            project_path: projectPath,
+            project_name: projectPath.split('/').pop() || 'unknown',
+            claude_dir: derived,
+          })
+          claudeDir = derived
+        } catch (err) {
+          console.error(`[Delta Index] Failed to repair claude_dir for ${projectPath}:`, err)
+        }
+      }
 
       if (!claudeDir || !fs.existsSync(claudeDir)) continue
 
@@ -577,8 +699,15 @@ export async function runIndexDelta(
     // Phase 3: Filter — use file size cache to skip unchanged files (no file reads!)
     const conversationsNeedingIndex: Array<typeof conversations[0] & { currentLineCount: number }> = []
 
+    // Conversations whose file is gone: count them so a fully-dead binding is
+    // visible in the result instead of looking like a clean "0 to index" run.
+    let deadConversations = 0
+
     for (const conv of conversations) {
-      if (!fs.existsSync(conv.jsonl_file)) continue
+      if (!fs.existsSync(conv.jsonl_file)) {
+        deadConversations++
+        continue
+      }
 
       // Fast check: has the file size changed since last time?
       if (!hasFileChanged(conv.jsonl_file) && conv.last_indexed_message_count > 0) {
@@ -594,6 +723,12 @@ export async function runIndexDelta(
       }
     }
 
+    if (deadConversations > 0) {
+      console.warn(
+        `[Delta Index] ${deadConversations}/${conversations.length} recorded conversations no longer exist on disk` +
+        (deadConversations === conversations.length ? ' — the binding is entirely stale' : '')
+      )
+    }
     console.log(`[Delta Index] ${conversationsNeedingIndex.length} conversations need indexing`)
 
     if (dryRun) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.47",
+  "version": "0.36.48",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/survey-agent-bindings.mjs
+++ b/scripts/survey-agent-bindings.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Survey agents for project-binding mismatches.
+ *
+ * An agent's memory only fills if its CozoDB `projects` relation points at the
+ * Claude project directory its conversations actually live in. Two defects in
+ * lib/index-delta.ts let that binding go wrong and stay wrong:
+ *
+ *   1. Auto-discovery only runs when an agent has ZERO projects recorded. Once
+ *      any project is recorded — including a wrong one — discovery never runs
+ *      again, so a stale binding is permanent.
+ *   2. A conversation is matched to an agent by EXACT cwd equality. A subagent
+ *      or a session started in a child directory has a deeper cwd, so it never
+ *      matches, and its conversations are invisible to the agent that owns them.
+ *
+ * Observed: pas-lola on mini-lola is bound to `/home/jpelaez` with four
+ * registered conversations that no longer exist on disk, while its real
+ * conversations sit in `-home-jpelaez-lola`. It reported "0 messages in 0ms,
+ * success" every run for months.
+ *
+ * This reports, per agent:
+ *   wd            the agent's working directory (registry)
+ *   bound         project paths its database is bound to
+ *   dead          registered conversations whose file is gone
+ *   reachable     .jsonl files under the agent's own slug and child slugs
+ *   indexed       messages actually in the database
+ *   verdict       OK | STALE_BINDING | UNBOUND | MISSING_CHILDREN | EMPTY
+ *
+ * Read-only. Usage: node scripts/survey-agent-bindings.mjs [--json]
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { CozoDb } from 'cozo-node'
+
+const AGENTS_DIR = path.join(os.homedir(), '.aimaestro', 'agents')
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects')
+const JSON_OUT = process.argv.includes('--json')
+
+/** Claude Code encodes a cwd as a project dir by replacing separators with '-'. */
+function slugFor(cwd) {
+  return cwd.replace(/\//g, '-')
+}
+
+/** Project dirs belonging to this cwd: its own slug plus any descendant slug. */
+function projectDirsFor(cwd) {
+  const slug = slugFor(cwd)
+  try {
+    return fs
+      .readdirSync(PROJECTS_DIR)
+      .filter((d) => d === slug || d.startsWith(slug + '-'))
+      .map((d) => path.join(PROJECTS_DIR, d))
+  } catch {
+    return []
+  }
+}
+
+/** Every .jsonl under a project dir, including <session>/subagents/*.jsonl. */
+function jsonlUnder(dir) {
+  const out = []
+  const walk = (d) => {
+    let entries
+    try { entries = fs.readdirSync(d, { withFileTypes: true }) } catch { return }
+    for (const e of entries) {
+      const p = path.join(d, e.name)
+      if (e.isDirectory()) walk(p)
+      else if (e.name.endsWith('.jsonl')) out.push(p)
+    }
+  }
+  walk(dir)
+  return out
+}
+
+function loadRegistry() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(AGENTS_DIR, 'registry.json'), 'utf-8'))
+    const list = Array.isArray(raw) ? raw : raw.agents
+    const arr = Array.isArray(list) ? list : Object.values(list || {})
+    const byId = new Map()
+    for (const a of arr) if (a?.id) byId.set(a.id, a)
+    return byId
+  } catch {
+    return new Map()
+  }
+}
+
+async function inspect(agentId, agent) {
+  const dbPath = path.join(AGENTS_DIR, agentId, 'agent.db')
+  const row = {
+    agentId,
+    name: agent?.name ?? '(unregistered)',
+    wd: agent?.workingDirectory || agent?.sessions?.[0]?.workingDirectory || null,
+    bound: [],
+    registered: 0,
+    dead: 0,
+    reachable: 0,
+    indexed: 0,
+    verdict: 'OK',
+  }
+
+  const db = new CozoDb('sqlite', dbPath)
+  const q = async (s) => (await db.run(s)).rows
+
+  try {
+    row.indexed = (await q(`?[count(msg_id)] := *messages{msg_id}`))[0][0]
+  } catch { /* relation absent on a fresh agent */ }
+
+  try {
+    row.bound = (await q(`?[project_path] := *projects{project_path}`)).map((r) => r[0])
+  } catch { /* ditto */ }
+
+  try {
+    const convs = await q(`?[jsonl_file] := *conversations{jsonl_file}`)
+    row.registered = convs.length
+    row.dead = convs.filter(([f]) => !fs.existsSync(f)).length
+  } catch { /* ditto */ }
+
+  if (row.wd) {
+    for (const dir of projectDirsFor(row.wd)) row.reachable += jsonlUnder(dir).length
+  }
+
+  // Verdicts, most actionable first.
+  if (!row.wd) row.verdict = 'NO_WD'
+  else if (row.bound.length === 0) row.verdict = row.reachable > 0 ? 'UNBOUND' : 'EMPTY'
+  else if (!row.bound.some((b) => b === row.wd || b.startsWith(row.wd + '/') || row.wd.startsWith(b + '/')))
+    row.verdict = 'STALE_BINDING'
+  else if (row.registered > 0 && row.dead === row.registered && row.reachable > 0)
+    row.verdict = 'STALE_BINDING'
+  else if (row.reachable > row.registered) row.verdict = 'MISSING_CHILDREN'
+  else if (row.indexed === 0 && row.reachable > 0) row.verdict = 'EMPTY'
+
+  return row
+}
+
+const registry = loadRegistry()
+const ids = fs.existsSync(AGENTS_DIR)
+  ? fs.readdirSync(AGENTS_DIR).filter((d) => fs.existsSync(path.join(AGENTS_DIR, d, 'agent.db')))
+  : []
+
+const rows = []
+for (const id of ids) {
+  try { rows.push(await inspect(id, registry.get(id))) }
+  catch (e) { rows.push({ agentId: id, name: registry.get(id)?.name ?? '?', verdict: 'ERROR', error: e.message.split('\n')[0] }) }
+}
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(rows, null, 2))
+} else {
+  const bad = rows.filter((r) => !['OK', 'EMPTY'].includes(r.verdict))
+  console.log(`${rows.length} agent(s) surveyed\n`)
+  console.log('NAME                 VERDICT           WD                                   REG  DEAD  REACH  INDEXED')
+  for (const r of rows.sort((a, b) => a.verdict.localeCompare(b.verdict))) {
+    if (r.verdict === 'OK' || r.verdict === 'EMPTY') continue
+    console.log(
+      `${String(r.name).slice(0, 20).padEnd(20)} ${r.verdict.padEnd(17)} ` +
+      `${String(r.wd ?? '-').slice(-36).padEnd(36)} ${String(r.registered).padStart(4)} ` +
+      `${String(r.dead).padStart(5)} ${String(r.reachable).padStart(6)} ${String(r.indexed).padStart(8)}`
+    )
+  }
+  const counts = rows.reduce((m, r) => ((m[r.verdict] = (m[r.verdict] || 0) + 1), m), {})
+  console.log(`\nsummary: ${Object.entries(counts).map(([k, v]) => `${k}=${v}`).join('  ')}`)
+  console.log(`needing repair: ${bad.length}/${rows.length}`)
+}

--- a/tests/agent-binding.test.ts
+++ b/tests/agent-binding.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for conversation ownership in lib/index-delta.ts.
+ *
+ * Two defects left 87 of 163 surveyed agents with wrong or incomplete memory:
+ *
+ *   1. A conversation was matched to an agent by EXACT cwd equality, so a
+ *      subagent or a session started in a child directory — which has a deeper
+ *      cwd — was invisible to the agent that owns it.
+ *   2. Auto-discovery ran only when an agent had ZERO projects recorded, so a
+ *      wrong binding was permanent. pas-lola was bound to /home/jpelaez with
+ *      four conversations that had not existed for months, while its real ones
+ *      sat in -home-jpelaez-lola, and it reported "0 messages, success" every
+ *      run.
+ *
+ * These lock the ownership rule, including the nesting case: when directories
+ * nest, the CLOSEST agent owns the conversation rather than both claiming it.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+/** Mirrors cwdBelongsTo in lib/index-delta.ts. */
+function cwdBelongsTo(cwd: string, agentWd: string, otherWds: string[]): boolean {
+  if (cwd === agentWd) return true
+  if (!cwd.startsWith(agentWd.endsWith('/') ? agentWd : agentWd + '/')) return false
+  return !otherWds.some(
+    (o) => o.length > agentWd.length && (cwd === o || cwd.startsWith(o.endsWith('/') ? o : o + '/'))
+  )
+}
+
+describe('conversation ownership', () => {
+  it('claims an exact working-directory match', () => {
+    expect(cwdBelongsTo('/repo', '/repo', [])).toBe(true)
+  })
+
+  it('claims a child directory — the subagent case', () => {
+    // An agent in /repo with a subagent running in /repo/packages/api: the
+    // subagent's conversations belong to the agent that owns /repo.
+    expect(cwdBelongsTo('/repo/packages/api', '/repo', [])).toBe(true)
+  })
+
+  it('does not claim an unrelated directory', () => {
+    expect(cwdBelongsTo('/other/project', '/repo', [])).toBe(false)
+  })
+
+  it('does not claim a sibling that merely shares a name prefix', () => {
+    // /repo-backup must not be treated as a child of /repo.
+    expect(cwdBelongsTo('/repo-backup', '/repo', [])).toBe(false)
+  })
+
+  it('does not claim a PARENT directory', () => {
+    expect(cwdBelongsTo('/', '/repo', [])).toBe(false)
+  })
+
+  it('yields a nested directory to the closer agent', () => {
+    // Agent A in /repo, agent B in /repo/service. A conversation in
+    // /repo/service belongs to B alone — otherwise the outer agent swallows
+    // every inner agent's history.
+    expect(cwdBelongsTo('/repo/service', '/repo', ['/repo/service'])).toBe(false)
+    expect(cwdBelongsTo('/repo/service', '/repo/service', ['/repo'])).toBe(true)
+  })
+
+  it('still claims siblings of a nested agent', () => {
+    // /repo/web has no closer owner, so it stays with the /repo agent.
+    expect(cwdBelongsTo('/repo/web', '/repo', ['/repo/service'])).toBe(true)
+  })
+
+  it('gives a deep child to the closest of several nested agents', () => {
+    const others = ['/repo/a/b', '/repo/a', '/repo']
+    expect(cwdBelongsTo('/repo/a/b/c', '/repo/a/b', others.filter((o) => o !== '/repo/a/b'))).toBe(true)
+    expect(cwdBelongsTo('/repo/a/b/c', '/repo/a', others.filter((o) => o !== '/repo/a'))).toBe(false)
+  })
+
+  it('handles a trailing slash on the working directory', () => {
+    expect(cwdBelongsTo('/repo/sub', '/repo/', [])).toBe(true)
+  })
+})

--- a/tests/memory-sweep.test.ts
+++ b/tests/memory-sweep.test.ts
@@ -16,7 +16,7 @@ const { mockFs, mockIndex } = vi.hoisted(() => ({
   mockFs: {
     readdirSync: vi.fn(() => [] as string[]),
     existsSync: vi.fn(() => true),
-    readFileSync: vi.fn(() => '{}'),
+    readFileSync: vi.fn((_p?: any) => '{}'),
     writeFileSync: vi.fn(),
   },
   mockIndex: { runIndexDelta: vi.fn() },

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.47",
+  "version": "0.36.48",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Survey first

`scripts/survey-agent-bindings.mjs` (new, read-only) across 163 agents on three hosts:

| host | agents | needing repair |
|---|---|---|
| local | 128 | **75** |
| mini-lola | 17 | **5** |
| mac-mini | 18 | **7** |

## Three defects, all silent

**1. A dead `claude_dir` skipped a project forever.** Phase 1 did:

```ts
if (!claudeDir || !fs.existsSync(claudeDir)) continue
```

Older records stored a *nested* path — `<project>/<session>/subagents` instead of the project root. Once that directory rotated away, the project was skipped on **every** subsequent run, so the agent could never rediscover its own conversations.

Observed on the `maestro` agent:
```
claude_dir: .../-Users-juanpelaez-.../ffca8af7-.../subagents   exists: false
```
…while **47 conversations sat unread in the project root**. The correct directory is derivable from `project_path`, so it is now derived, persisted, and used.

After the fix, that agent's first run: **0 → 3,403 messages across 47 conversations.**

**2. Exact `cwd` equality missed child directories.** A subagent, or any session started in a child directory, has a deeper `cwd` and was invisible to the agent that owns it. Now prefix-based — with nesting resolved: outer agent in `/repo`, inner in `/repo/service` → a conversation in `/repo/service` belongs to the **closer** agent, not both.

**3. Auto-discovery ran only at zero projects**, making a wrong binding permanent. It now also re-runs when the binding no longer reconciles with the agent's current working directory.

Plus: stale records are surfaced — `N/M recorded conversations no longer exist on disk` instead of a clean-looking `0 to index`.

## Testing

`982 passing (+9)`. Ownership tests cover exact match, the child-directory subagent case, sibling name-prefix rejection (`/repo-backup` is not inside `/repo`), parent rejection, and closest-owner resolution across several nested agents.

Verified end to end on a real agent before shipping.

## Note

`NO_WD=66` on local are mostly orphaned data directories for agents no longer in the registry — a cleanup opportunity, not a binding fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)