### PR TITLE
fix(memory): an ancestor binding is not a valid binding (v0.36.49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.49] - 2026-08-27 — Ancestor bindings no longer count as valid
+
+### Fixed
+- **A binding pointing at an ANCESTOR of the agent's working directory was treated as valid**, so the re-discovery added in 0.36.48 never triggered for the most common real case. `pas-lola` is bound to `/home/jpelaez` while working in `/home/jpelaez/lola`: it scanned `~/.claude/projects/-home-jpelaez` (four conversations, all long deleted) and never touched `-home-jpelaez-lola`, where its real 23 conversations live. A fleet sweep after 0.36.48 confirmed it — 17 agents swept, **0 messages indexed**. A binding is now only considered valid if it points **at or below** the working directory.
+
 ## [0.36.48] - 2026-08-27 — Agent project bindings: agents can find their own conversations again
 
 A survey of 163 agents across three hosts found **87 with wrong or incomplete memory bindings**. Three defects in `lib/index-delta.ts`, each of which made an agent silently index nothing while reporting success.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.48-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.49-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/index-delta.ts
+++ b/lib/index-delta.ts
@@ -525,11 +525,17 @@ export async function runIndexDelta(
         ].filter((d): d is string => typeof d === 'string' && d.length > 0)
       )
     )
+    // A binding is only useful if it points AT the agent's working directory or
+    // BELOW it. An ancestor binding is too broad and indexes the wrong project:
+    // pas-lola was bound to /home/jpelaez while working in /home/jpelaez/lola,
+    // so it scanned ~/.claude/projects/-home-jpelaez (four conversations, all
+    // long deleted) and never touched -home-jpelaez-lola, where its real 23
+    // conversations live. Treating the ancestor as "related" kept it broken.
     const bindingLooksStale =
       boundPaths.length > 0 &&
       currentWds.length > 0 &&
       !boundPaths.some((b: string) =>
-        currentWds.some((wd) => b === wd || b.startsWith(wd + '/') || wd.startsWith(b + '/'))
+        currentWds.some((wd) => b === wd || b.startsWith(wd + '/'))
       )
 
     if (bindingLooksStale) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.48",
+  "version": "0.36.49",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.48",
+  "version": "0.36.49",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## Gap in v0.36.48

The re-discovery I added treated a binding pointing at an **ancestor** of the agent's working directory as valid, so it never triggered for the most common real case.

`pas-lola` is bound to `/home/jpelaez` while working in `/home/jpelaez/lola`. It scanned `~/.claude/projects/-home-jpelaez` — four conversations, all long deleted — and never touched `-home-jpelaez-lola`, where its real 23 conversations live.

Caught by sweeping the fleet after v0.36.48 shipped:

```
{'scanned': 17, 'indexed': 17, 'failed': 0, 'messagesProcessed': 0}
```

17 agents swept, **0 messages indexed**. The fix looked like it worked because nothing errored.

## Fix

A binding is valid only if it points **at** the working directory or **below** it. An ancestor is too broad — it indexes the wrong project and starves the right one.

`982 tests passing`, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)