### PR TITLE
fix(memory): embeddings run on CPU, sweep stops calling failures successes (v0.36.50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.50] - 2026-08-27 — Embeddings run on CPU (a whole host had been silently unable to index)
+
+### Fixed
+- **`device: 'auto'` selected CUDA on Linux and failed every batch.** `lib/rag/embeddings.ts` passed `device: 'auto'` with a comment claiming *"CPU in Node.js"* — but on Linux, transformers.js offers ONNX Runtime the `cuda` execution provider first, and `onnxruntime-node` ships CPU-only. Session creation threw `sessionOptions.executionProviders[0] is unsupported: 'cuda'` for **every** batch. The model still downloaded and logged `Loading... 100%`, so the host looked healthy while indexing nothing. macOS resolved `'auto'` to CPU, so the identical code worked there and the failure looked host-specific rather than like a bad default. Now explicitly `cpu`, overridable via `AIMAESTRO_EMBEDDING_DEVICE` on a host with a genuine CUDA-enabled build.
+
+  Verified on the affected 4-CPU, no-GPU host: **2,916 messages indexed in 7 minutes**, database `64 KB → 29 MB`, having been empty for months.
+- **The memory sweep counted failed runs as successes.** `runIndexDelta` reports failure by *returning* `{success: false}` rather than throwing, so catching exceptions alone was not enough. That is how the broken host reported `17 indexed, 0 failed, 0 messages` — the number that looked fine and hid the outage. The sweep now inspects `success` and surfaces the underlying error.
+
+### Notes
+- This was the third distinct fault behind "memory isn't working", after stale project bindings (0.36.48) and ancestor-only bindings (0.36.49). Only the third one had any GPU involvement, and it was not a performance problem: nothing was slow, nothing ran at all. CPU embedding on 4 cores indexes roughly 7 messages/second, which is entirely adequate.
+
 ## [0.36.49] - 2026-08-27 — Ancestor bindings no longer count as valid
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.36.49-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.36.50-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/lib/memory/sweep.ts
+++ b/lib/memory/sweep.ts
@@ -124,10 +124,19 @@ export async function sweepAgentMemory(opts: SweepOptions = {}): Promise<SweepRe
         conversationsDiscovered: r.new_conversations_discovered || 0,
         ms: Date.now() - t0,
       }
+      // runIndexDelta RETURNS {success:false} on failure rather than throwing,
+      // so catching exceptions alone counted broken runs as successes. That is
+      // how a host whose embedding provider was misconfigured reported
+      // "17 indexed, 0 failed, 0 messages" for months.
+      if (r.success === false) {
+        entry.error = (r as { error?: string }).error || 'index-delta reported failure'
+        failed++
+      } else {
+        indexed++
+      }
       agents.push(entry)
       markSwept(agentId, entry)
       messagesProcessed += entry.messagesProcessed
-      indexed++
     } catch (err) {
       const entry: SweepAgentResult = {
         agentId,

--- a/lib/rag/embeddings.ts
+++ b/lib/rag/embeddings.ts
@@ -33,7 +33,22 @@ async function getExtractor(): Promise<FeatureExtractionPipeline> {
 
     const ext = await pipeline('feature-extraction', MODEL, {
       dtype: 'q8',  // Quantized for speed (was: quantized: true)
-      device: 'auto',  // Let it choose best available (CPU in Node.js)
+      // CPU explicitly — NOT 'auto'.
+      //
+      // On Linux, transformers.js 'auto' offers ONNX Runtime the cuda execution
+      // provider first. onnxruntime-node ships CPU-only, so session creation
+      // throws `sessionOptions.executionProviders[0] is unsupported: 'cuda'`
+      // for EVERY batch. The model still downloads and logs "Loading... 100%",
+      // which makes it look healthy; nothing is ever embedded.
+      //
+      // Observed on a 4-CPU Linux host with no GPU: every agent reported
+      // "0 messages, success" for months while its conversations sat unindexed.
+      // macOS resolved 'auto' to CPU, so the same code worked there and the
+      // failure looked host-specific rather than like a bad default.
+      //
+      // Set AIMAESTRO_EMBEDDING_DEVICE to override on a host with a genuine
+      // CUDA-enabled onnxruntime build.
+      device: (process.env.AIMAESTRO_EMBEDDING_DEVICE as any) || 'cpu',
       progress_callback: (progress: any) => {
         if (progress.status === 'progress' && progress.progress) {
           console.log(`[Embeddings] Loading... ${Math.round(progress.progress)}%`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.36.49",
+  "version": "0.36.50",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/tests/memory-sweep.test.ts
+++ b/tests/memory-sweep.test.ts
@@ -66,6 +66,26 @@ describe('sweepAgentMemory', () => {
     expect(mockIndex.runIndexDelta).toHaveBeenCalledWith('agent-1')
   })
 
+  it('counts a returned {success:false} as failed, not indexed', async () => {
+    // runIndexDelta reports failure by RETURNING, not throwing. Catching only
+    // exceptions counted broken runs as successes — how a host with a
+    // misconfigured embedding provider reported "17 indexed, 0 failed,
+    // 0 messages" for months.
+    mockFs.readdirSync.mockReturnValue(['broken'])
+    mockIndex.runIndexDelta.mockResolvedValue({
+      success: false,
+      error: 'executionProviders[0] is unsupported: cuda',
+      total_messages_processed: 0,
+      new_conversations_discovered: 0,
+    })
+
+    const r = await sweepAgentMemory()
+
+    expect(r.indexed).toBe(0)
+    expect(r.failed).toBe(1)
+    expect(r.agents[0].error).toMatch(/cuda/)
+  })
+
   it('keeps going when one agent fails', async () => {
     mockFs.readdirSync.mockReturnValue(['good-1', 'bad', 'good-2'])
     mockIndex.runIndexDelta.mockImplementation(async (id: string) => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.36.49",
+  "version": "0.36.50",
   "releaseDate": "2026-08-27",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## The fault

`lib/rag/embeddings.ts` passed `device: 'auto'` with a comment claiming *"CPU in Node.js"*. On Linux, transformers.js offers ONNX Runtime the **cuda** provider first, and `onnxruntime-node` ships CPU-only:

```
[Delta Index] Error: Invalid argument: sessionOptions.executionProviders[0] is unsupported: 'cuda'
```

Every batch. The model still downloaded and logged `Loading... 100%`, so the host looked perfectly healthy while indexing **nothing**. macOS resolved `'auto'` to CPU, so identical code worked there and the failure read as host-specific rather than a bad default.

Now explicitly `cpu`, overridable with `AIMAESTRO_EMBEDDING_DEVICE`.

## Verified before claiming

On the affected host (4 CPUs, **no GPU**):

```
db@60s: 4160KB   Batch 185/559
t+3m    10636KB  Batch 427/559
t+5m    22588KB  Batch 22/22
t+7m    29284KB  Complete

{"success":true,"messagesProcessed":2916,"ms":420049}
```

**64 KB → 29 MB, 2,916 messages in 7 minutes**, after months empty.

This was never a performance problem. Nothing was slow — nothing ran. CPU embedding at ~7 msg/sec is entirely adequate.

## Second fix: the sweep lied

`runIndexDelta` reports failure by **returning** `{success: false}`, not throwing — so catching exceptions alone wasn't enough. That's how the broken host reported:

```
{'scanned': 17, 'indexed': 17, 'failed': 0, 'messagesProcessed': 0}
```

The reassuring number that hid the outage. The sweep now inspects `success` and surfaces the error.

## Context

Third distinct fault behind "memory isn't working", after stale project bindings (v0.36.48) and ancestor-only bindings (v0.36.49). Only this one involved a GPU at all.

`983 tests passing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)