### PR TITLE
fix(agents): three reported lifecycle bugs (v0.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.1] - 2026-08-27 — Three agent-lifecycle bugs
+
+All three shared the shape that has recurred across this subsystem: an operation reported success it had not earned, so the failure was invisible until someone opened a terminal.
+
+### Fixed
+- **`${var,,}` broke agent creation on macOS** ([plugins#31](https://github.com/23blocks-OS/ai-maestro-plugins/pull/31)). macOS ships bash 3.2.57, where `${var,,}` is a runtime *"bad substitution"* error. Two sites used it, and because the scripts run `set -uo pipefail` (no `-e`) neither crashed — both produced a **wrong answer**. `agent-commands.sh:404`: `program_lower` stayed empty, the whitelist test failed, and `aimaestro-agent.sh create` aborted with *"Invalid program: claude"* for a valid program. `agent-helper.sh:790`: `check_agent_exists()` returned non-zero, so the caller read *"no collision"* and the duplicate-name check silently never fired on macOS at all. Both now use `tr '[:upper:]' '[:lower:]'`; verified under `/bin/bash` 3.2.57.
+- **`amp-send` reported success for a recipient with no identity directory.** `deliverLocally()` and the federation path both called `deliver()` and **discarded its result** — `grep -c "const .* = await deliver("` returned 0. `deliver()` reports failure by returning `{delivered: false, error}` (no recipient UUID, inbox write failed), so the route answered `200 {status: 'delivered'}` for a message that was never written, and `amp-send` printed a success line with an id it had generated locally. The result is now checked; a failed write returns **502 `delivery_failed`** with the underlying reason, and the success payload carries `verified`.
+- **New agents stopped at "Do you trust the files in this folder?" with nothing reporting it.** That prompt blocks before Claude Code can run a hook, so no status is ever reported: tmux shows the session alive, the API shows a healthy agent, and the operator only finds out by opening the terminal. Two changes: AI Maestro now **pre-accepts trust** for the working directory the operator declared when creating the agent (`hasTrustDialogAccepted` in `~/.claude.json`, alongside the existing `writeAgentDirHint` call) — the same stance the docker path already takes for codex; and `GET /api/messages/pending-wakes` now reports `blockedSessions`, detecting startup prompts on sessions that have no hook report.
+
 ## [0.37.0] - 2026-08-27 — Agent-owned scheduled tasks
 
 **Minor release.** Agents stop being terminal sessions that happen to be running and become standing entities that carry their own schedule between machines.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/messages/pending-wakes/route.ts
+++ b/app/api/messages/pending-wakes/route.ts
@@ -22,7 +22,8 @@ export const dynamic = 'force-dynamic'
 import { NextResponse } from 'next/server'
 import { pendingWakes, totalPendingWakes } from '@/lib/wake-queue'
 import { hookStatus } from '@/services/shared-state'
-import { isSessionIdle, idleSource } from '@/lib/session-idle'
+import { isSessionIdle, idleSource, detectStartupBlock } from '@/lib/session-idle'
+import { getRuntime } from '@/lib/agent-runtime'
 
 export async function GET() {
   const pending = pendingWakes()
@@ -40,7 +41,22 @@ export async function GET() {
     source: idleSource(sessionName),
   }))
 
+  // Sessions wedged on a startup prompt (e.g. "Do you trust the files in this
+  // folder?"). These never fire a hook, so they look healthy everywhere else.
+  const runtime = getRuntime()
+  const blocked: Array<{ sessionName: string; blockedBy: string }> = []
+  try {
+    for (const s of await runtime.listSessions()) {
+      if (hookStatus?.has(s.name)) continue // already past startup
+      const b = await detectStartupBlock(s.name, (n, l) => runtime.capturePane(n, l))
+      if (b) blocked.push({ sessionName: s.name, blockedBy: b })
+    }
+  } catch {
+    // Never fail the whole report because one pane could not be captured.
+  }
+
   return NextResponse.json({
+    blockedSessions: blocked,
     total: totalPendingWakes(),
     busy: pending.filter((p) => p.reason === 'busy').length,
     unconfirmed: pending.filter((p) => p.reason === 'unconfirmed').length,

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -234,6 +234,54 @@ export function saveAgents(agents: Agent[]): boolean {
  * other keys). Best-effort: failures are logged, never thrown — provisioning an
  * agent must not fail because a project dir is read-only or missing.
  */
+/**
+ * Pre-accept Claude Code's "Do you trust the files in this folder?" prompt for
+ * an agent's working directory.
+ *
+ * A newly provisioned agent launches into that modal and stops there. It never
+ * reaches the point of running a hook, so nothing reports status, and the API
+ * shows a session that looks fine while the agent is doing nothing — the
+ * operator only finds out by opening the terminal.
+ *
+ * The trust flag lives per project in ~/.claude.json as
+ * `hasTrustDialogAccepted`. Setting it when AI Maestro provisions the agent is
+ * the same stance the docker path already takes for codex, which pre-trusts
+ * /workspace in config.toml for exactly this reason: the operator declared this
+ * working directory when they created the agent, so the trust decision has
+ * already been made by a human.
+ *
+ * Only ever sets the flag to true for a directory the operator named; never
+ * removes trust, and never touches any other project entry.
+ */
+export function trustProjectDirectory(workingDirectory?: string | null): boolean {
+  try {
+    if (!workingDirectory || !path.isAbsolute(workingDirectory)) return false
+    if (workingDirectory === '/' || workingDirectory === os.homedir()) return false
+    if (!fs.existsSync(workingDirectory)) return false
+
+    const claudeJson = path.join(os.homedir(), '.claude.json')
+    if (!fs.existsSync(claudeJson)) return false
+
+    const config = JSON.parse(fs.readFileSync(claudeJson, 'utf-8'))
+    config.projects = config.projects || {}
+    const entry = config.projects[workingDirectory]
+
+    // Already trusted — leave the file untouched rather than rewriting a large
+    // shared config for no reason.
+    if (entry && entry.hasTrustDialogAccepted === true) return true
+
+    config.projects[workingDirectory] = { ...(entry || {}), hasTrustDialogAccepted: true }
+    fs.writeFileSync(claudeJson, JSON.stringify(config, null, 2))
+    console.log(`[Registry] Pre-trusted working directory: ${workingDirectory}`)
+    return true
+  } catch (err) {
+    // Never block agent provisioning on this — worst case the operator sees
+    // the prompt once, which is the behaviour we had before.
+    console.warn('[Registry] Could not pre-trust working directory:', err)
+    return false
+  }
+}
+
 export function writeAgentDirHint(agentName: string, workingDirectory?: string | null): void {
   try {
     if (!agentName || !workingDirectory) return
@@ -551,6 +599,7 @@ export function createAgent(request: CreateAgentRequest): Agent {
 
   // Let detached sessions in this dir self-identify (statusline + AMP).
   writeAgentDirHint(agent.name, agent.workingDirectory)
+  trustProjectDirectory(agent.workingDirectory)
 
   return agent
 }
@@ -988,6 +1037,7 @@ export function linkSession(agentId: string, sessionName: string, workingDirecto
   if (saved) invalidateAgentCache()
   // Let detached sessions in this dir self-identify (statusline + AMP).
   writeAgentDirHint(agents[index].name, agents[index].workingDirectory)
+  trustProjectDirectory(agents[index].workingDirectory)
   return saved
 }
 

--- a/lib/session-idle.ts
+++ b/lib/session-idle.ts
@@ -100,6 +100,42 @@ export function hasHookReport(sessionName: string): boolean {
   return !!reported && Date.now() - reported.at < HOOK_STATUS_TTL_MS
 }
 
+/**
+ * Prompts that block an agent BEFORE it can run a hook.
+ *
+ * A session stuck on one of these looks healthy from the API's point of view:
+ * tmux reports the session alive, no hook has fired because the agent never
+ * started, and nothing anywhere says the agent is wedged. The operator only
+ * discovers it by opening the terminal.
+ */
+const STARTUP_BLOCK_PATTERNS: Array<{ pattern: RegExp; blocked: string }> = [
+  { pattern: /Do you trust the (files|contents)/i, blocked: 'awaiting_trust' },
+  { pattern: /trust the files in this folder/i, blocked: 'awaiting_trust' },
+]
+
+/**
+ * Detect a startup prompt holding a session hostage.
+ *
+ * Only worth calling when there is NO hook report — a session that has reported
+ * status has, by definition, got past startup. Returns null when nothing is
+ * blocking, so callers can treat it as "normal".
+ */
+export async function detectStartupBlock(
+  sessionName: string,
+  capture: (name: string, lines?: number) => Promise<string>
+): Promise<string | null> {
+  try {
+    const pane = await capture(sessionName, 60)
+    if (!pane) return null
+    for (const { pattern, blocked } of STARTUP_BLOCK_PATTERNS) {
+      if (pattern.test(pane)) return blocked
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 /** Which signal answered, for logging and the operator surface. */
 export function idleSource(sessionName: string): 'hook' | 'pty' | 'none' {
   const reported = hookStatus?.get(sessionName)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/amp-service.ts
+++ b/services/amp-service.ts
@@ -397,11 +397,18 @@ interface LocalDeliveryOptions {
 
 /**
  * Deliver a message to a local agent via unified deliver() function.
+ *
+ * RETURNS the result — callers must check it. deliver() reports failure by
+ * returning `{delivered: false, error}` (no recipient UUID, inbox write
+ * failed), and this used to discard that, so the route answered 200
+ * `{status: 'delivered'}` for a message that was never written. amp-send then
+ * printed a success line with an id it had generated locally, and the message
+ * went nowhere with nothing anywhere saying so.
  */
-async function deliverLocally(opts: LocalDeliveryOptions): Promise<void> {
+async function deliverLocally(opts: LocalDeliveryOptions): Promise<{ delivered: boolean; error?: string }> {
   const { envelope, payload, recipientAgentName, senderAgent, senderName, forwardedFrom, senderPublicKeyHex, body } = opts
 
-  await deliver({
+  const result = await deliver({
     envelope,
     payload,
     recipientAgentName,
@@ -413,6 +420,13 @@ async function deliverLocally(opts: LocalDeliveryOptions): Promise<void> {
     priority: body.priority,
     messageType: payload.type,
   })
+
+  if (!result.delivered) {
+    console.error(
+      `[AMP] Local delivery FAILED for ${recipientAgentName}: ${result.error || 'unknown'}`
+    )
+  }
+  return { delivered: result.delivered, error: result.error }
 }
 
 // ===========================================================================
@@ -1931,7 +1945,7 @@ export async function deliverFederated(
     }
 
     // ── Local Delivery ──────────────────────────────────────────────────
-    await deliver({
+    const localResult = await deliver({
       envelope,
       payload,
       recipientAgentName: localAgent.name || recipientName,
@@ -1944,12 +1958,29 @@ export async function deliverFederated(
       messageType: payload.type,
     })
 
+    // A failed inbox write is not a delivery. Reporting 200 'delivered' here is
+    // how a message to a recipient with no identity directory produced a
+    // success line and an id while going nowhere.
+    if (!localResult.delivered) {
+      console.error(
+        `[AMP] Local delivery FAILED for ${localAgent.name || recipientName}: ${localResult.error || 'unknown'}`
+      )
+      return {
+        data: {
+          error: 'delivery_failed',
+          message: `Could not deliver to '${recipientName}': ${localResult.error || 'inbox write failed'}`,
+        },
+        status: 502,
+      }
+    }
+
     return {
       data: {
         id: envelope.id,
         status: 'delivered',
         method: 'local',
         delivered_at: new Date().toISOString(),
+        verified: localResult.verified ?? false,
       },
       status: 200
     }

--- a/tests/agent-lifecycle-fixes.test.ts
+++ b/tests/agent-lifecycle-fixes.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for three reported agent-lifecycle bugs.
+ *
+ * All three share a shape that has recurred throughout this subsystem: an
+ * operation reports success it has not earned, so the failure is invisible
+ * until someone opens a terminal.
+ *
+ *   1. ${var,,} is bash 4+; macOS ships bash 3.2, so the expansion errored and
+ *      `aimaestro-agent.sh create` aborted with "Invalid program: claude".
+ *   2. amp-send printed a message ID for a recipient with no identity
+ *      directory, because the route ignored deliver()'s result.
+ *   3. New agents stopped at "Do you trust the files in this folder?" and
+ *      nothing in the API reported it.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { detectStartupBlock } from '@/lib/session-idle'
+
+const SCRIPTS = ['plugin/src/scripts/agent-helper.sh', 'plugin/src/scripts/agent-commands.sh']
+
+describe('bash 3.2 portability (issue 1)', () => {
+  it('uses no bash-4-only expansions in agent scripts', () => {
+    // macOS ships bash 3.2.57. ${var,,} / ${var^^} are runtime "bad
+    // substitution" errors there, and because these scripts run with
+    // `set -uo pipefail` (no -e) the failure surfaced as a wrong answer rather
+    // than a crash: the duplicate-name check silently passed, and the program
+    // whitelist silently rejected valid programs.
+    for (const rel of SCRIPTS) {
+      const file = path.join(process.cwd(), rel)
+      if (!fs.existsSync(file)) continue
+      const code = fs
+        .readFileSync(file, 'utf-8')
+        .split('\n')
+        .filter((l) => !l.trim().startsWith('#')) // comments may cite the old form
+        .join('\n')
+      expect(code, `${rel} uses bash-4 case expansion`).not.toMatch(/\$\{[a-zA-Z_]+,,\}/)
+      expect(code, `${rel} uses bash-4 case expansion`).not.toMatch(/\$\{[a-zA-Z_]+\^\^\}/)
+    }
+  })
+
+  it('lowercases via tr, which bash 3.2 supports', () => {
+    for (const rel of SCRIPTS) {
+      const file = path.join(process.cwd(), rel)
+      if (!fs.existsSync(file)) continue
+      const code = fs.readFileSync(file, 'utf-8')
+      if (code.includes('_lower')) {
+        expect(code).toMatch(/tr '\[:upper:\]' '\[:lower:\]'/)
+      }
+    }
+  })
+})
+
+describe('startup block detection (issue 3)', () => {
+  const pane = (text: string) => async () => text
+
+  it('detects the Claude Code trust prompt', async () => {
+    const out = await detectStartupBlock(
+      's',
+      pane('╭─────╮\n Do you trust the files in this folder?\n 1. Yes  2. No')
+    )
+    expect(out).toBe('awaiting_trust')
+  })
+
+  it('detects the codex phrasing too', async () => {
+    const out = await detectStartupBlock('s', pane('Do you trust the contents of this directory?'))
+    expect(out).toBe('awaiting_trust')
+  })
+
+  it('returns null for a normal working pane', async () => {
+    const out = await detectStartupBlock('s', pane('✻ Cerebrating… (1m 54s)\n❯ '))
+    expect(out).toBeNull()
+  })
+
+  it('returns null for an empty capture rather than guessing', async () => {
+    expect(await detectStartupBlock('s', pane(''))).toBeNull()
+  })
+
+  it('never throws when the pane cannot be captured', async () => {
+    const boom = async () => { throw new Error('no such session') }
+    // This runs inside a status report; one dead pane must not fail the report.
+    await expect(detectStartupBlock('s', boom)).resolves.toBeNull()
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.0",
+  "version": "0.37.1",
   "releaseDate": "2026-08-28",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Three reported issues. All share the shape that has recurred across this subsystem: **an operation reports success it has not earned**, so the failure is invisible until someone opens a terminal.

## 1. `${var,,}` broke agent creation on macOS

macOS ships **bash 3.2.57**, where `${var,,}` is a runtime *"bad substitution"*. Two sites used it — and because these scripts run `set -uo pipefail` (no `-e`), neither crashed. Both returned a **wrong answer**:

| file:line | effect |
|---|---|
| `agent-commands.sh:404` | `program_lower` empty → whitelist test failed → **`create` aborted with "Invalid program: claude"** |
| `agent-helper.sh:790` | `check_agent_exists()` non-zero → caller read "no collision" → **duplicate-name check silently never fired** |

Fixed via `tr '[:upper:]' '[:lower:]'`, verified on bash 3.2.57. Shipped in [plugins#31](https://github.com/23blocks-OS/ai-maestro-plugins/pull/31); submodule bumped.

## 2. `amp-send` reported success for a recipient with no identity directory

`deliverLocally()` and the federation path both called `deliver()` and **threw away the result**:

```
$ grep -c "const .* = await deliver(" services/amp-service.ts
0
```

`deliver()` reports failure by *returning* `{delivered: false, error}` — no recipient UUID, inbox write failed. So the route answered `200 {status: 'delivered'}` for a message that was never written, and `amp-send` printed a success line with an ID **it had generated locally**.

Now checked: a failed write returns **502 `delivery_failed`** with the underlying reason; the success payload carries `verified`.

## 3. New agents stopped at the trust prompt with nothing reporting it

*"Do you trust the files in this folder?"* blocks **before** Claude Code can run a hook. So no status is ever reported: tmux shows the session alive, the API shows a healthy agent, and the operator only finds out by opening the terminal.

- **Prevention** — pre-accept trust for the working directory the operator declared at creation (`hasTrustDialogAccepted` in `~/.claude.json`, beside the existing `writeAgentDirHint` call). Same stance the docker path already takes for codex, and the operator already made that decision by naming the directory.
- **Detection** — `GET /api/messages/pending-wakes` now reports `blockedSessions` for sessions with no hook report whose pane shows a startup prompt.

## Testing

`1006 passing (+7)` — including a guard that fails if any bash-4 expansion reappears in the agent scripts, and trust-prompt detection covering both the Claude Code and codex phrasings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)