### PR TITLE
fix(docs): root-level files were hidden behind an absolute-path folder (v0.37.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.3] - 2026-08-28 — Docs tab: root-level files were hidden behind an absolute-path folder
+
+### Fixed
+- **Root-level documents (CLAUDE.md, README.md…) appeared to be missing from the Docs tab.** They were indexed and present in the data the whole time. The folder grouping stripped only the agent's registered `workingDirectory` from each path; when that drifted from the `project_path` the documents were actually indexed under, the prefix never matched, the path stayed **absolute**, and because an absolute path always contains `/`, the `(root)` bucket was never produced at all. Root files were filed under a folder row literally named `/Users/.../jarvis/v2` instead of `Root`. Observed on `23blocks-api-jarvis`: registered at `.../jarvis/api`, docs indexed under `.../jarvis/v2`. Grouping now prefers each document's own `project_path`, falls back to the prop, and when neither matches uses the immediate parent directory name — **never an absolute path as a folder label**. Same stale-binding class as the memory faults fixed in 0.36.48–0.36.49.
+- **The browse list silently truncated.** `action=list` orders by `-updated_at` and applies a limit, so anything hidden was disproportionately *stable* files — precisely the ones a reader goes looking for. One agent has 340 documents against a 200 limit. The list endpoint now returns `total` and `truncated`, the UI requests 500, and shows a **"Showing N of M"** badge when the set is cut.
+
+### Changed
+- `action=list` returns `projectPath` per document.
+- The `Root` folder is expanded by default. Every folder started collapsed, and a single collapsed `Root` row is easy to scan past among a dozen siblings.
+
+### Notes
+- The indexer was never at fault: `**/*.md` matches root files under glob 10.3.10, and CLAUDE.md was present in the `documents` relation for every agent checked.
+- `23blocks-api-jarvis` still has a genuine binding drift — its registered working directory and its indexed project path disagree. The display now handles it correctly, but re-indexing that agent against its current directory is a separate cleanup.
+
 ## [0.37.2] - 2026-08-27 — Agents that were running come back after a server restart
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/components/DocumentationPanel.tsx
+++ b/components/DocumentationPanel.tsx
@@ -40,6 +40,8 @@ interface DocumentMeta {
   filePath: string
   title: string
   docType: string
+  /** Directory this document was actually indexed under. */
+  projectPath?: string
   updatedAt?: number
 }
 
@@ -86,6 +88,7 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
   const [success, setSuccess] = useState<string | null>(null)
   const [stats, setStats] = useState<DocStats | null>(null)
   const [documents, setDocuments] = useState<DocumentMeta[]>([])
+  const [docTotal, setDocTotal] = useState<number | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState<SearchResult[]>([])
   const [searching, setSearching] = useState(false)
@@ -128,11 +131,21 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
     if (!agentId) return
 
     try {
-      const response = await fetch(`${baseUrl}/api/agents/${agentId}/docs?action=list&limit=200`)
+      const response = await fetch(`${baseUrl}/api/agents/${agentId}/docs?action=list&limit=500`)
       const data = await response.json()
 
       if (data.success) {
-        setDocuments(data.result || [])
+        const docs: DocumentMeta[] = data.result || []
+        setDocuments(docs)
+        // The listing is ordered by most-recently-updated and then truncated,
+        // so a hidden remainder is disproportionately made up of stable files.
+        // Report it rather than quietly showing a window.
+        setDocTotal(typeof data.total === 'number' ? data.total : docs.length)
+
+        // Expand the root bucket by default. Every folder starts collapsed,
+        // and a single collapsed "Root" row is easy to scan past when there
+        // are a dozen sibling folders.
+        setExpandedTypes((prev) => (prev.size === 0 ? new Set(['folder:(root)']) : prev))
       }
     } catch (err) {
       console.error('Failed to fetch documents:', err)
@@ -274,17 +287,40 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
     return acc
   }, {} as Record<string, DocumentMeta[]>)
 
-  // Group documents by folder (relative to working directory)
+  // Group documents by folder, relative to the directory each document was
+  // actually indexed under.
+  //
+  // This used to strip only the agent's registered workingDirectory. When that
+  // drifted from the indexed project_path — which happens, e.g. an agent
+  // registered at .../jarvis/api whose docs were indexed under .../jarvis/v2 —
+  // the prefix never matched, the path stayed ABSOLUTE, and since an absolute
+  // path always contains '/', the '(root)' bucket was never produced at all.
+  // Root files such as CLAUDE.md were then filed under a folder row literally
+  // named "/Users/.../jarvis/v2" instead of "Root", so they looked missing.
+  //
+  // Prefer the document's own project_path, fall back to the prop, and if
+  // neither matches use just the parent directory name — never an absolute
+  // path as a folder label.
   const documentsByFolder = documents.reduce((acc, doc) => {
-    // Get relative path from working directory
+    const base = doc.projectPath || workingDirectory
     let relativePath = doc.filePath
-    if (workingDirectory && doc.filePath.startsWith(workingDirectory)) {
-      relativePath = doc.filePath.slice(workingDirectory.length).replace(/^\//, '')
+    let matched = false
+    if (base && doc.filePath.startsWith(base)) {
+      relativePath = doc.filePath.slice(base.length).replace(/^\//, '')
+      matched = true
     }
 
-    // Extract folder path (everything except the filename)
     const parts = relativePath.split('/')
-    const folderPath = parts.length > 1 ? parts.slice(0, -1).join('/') : '(root)'
+    let folderPath: string
+    if (parts.length <= 1) {
+      folderPath = '(root)'
+    } else if (matched) {
+      folderPath = parts.slice(0, -1).join('/')
+    } else {
+      // Unknown base: show the immediate parent directory rather than an
+      // absolute path, so the list stays readable even when bindings drift.
+      folderPath = parts[parts.length - 2] || '(root)'
+    }
 
     if (!acc[folderPath]) acc[folderPath] = []
     acc[folderPath].push(doc)
@@ -386,6 +422,19 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
               <span className="text-gray-400">Docs:</span>
               <span className="font-medium">{stats.documents}</span>
             </div>
+            {/* The browse list is capped and ordered by most-recently-updated,
+                so anything hidden is disproportionately stable files. Say so
+                rather than presenting a window as the whole set. */}
+            {docTotal !== null && docTotal > documents.length && (
+              <div
+                className="flex items-center gap-1.5 px-2 py-1 bg-yellow-900/40 border border-yellow-700/50 rounded"
+                title={`Showing the ${documents.length} most recently updated of ${docTotal} documents. Re-index or narrow the project to see the rest.`}
+              >
+                <span className="text-yellow-300">
+                  Showing {documents.length} of {docTotal}
+                </span>
+              </div>
+            )}
             <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-800 rounded">
               <BookOpen className="w-3.5 h-3.5 text-green-400" />
               <span className="text-gray-400">Sections:</span>

--- a/components/WtermView.tsx
+++ b/components/WtermView.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import { useRef, useState, useCallback, useEffect } from 'react'
+import type { Session } from '@/types/session'
+
+interface WtermViewProps {
+  session: Session
+}
+
+export default function WtermView({ session }: WtermViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const wtermRef = useRef<any>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [isConnected, setIsConnected] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [ready, setReady] = useState(false)
+
+  const connect = useCallback(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${protocol}//${window.location.host}/term?name=${encodeURIComponent(session.id)}`
+
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setIsConnected(true)
+      setError(null)
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const parsed = JSON.parse(event.data)
+        if (parsed.type) return
+      } catch {
+        // Not JSON — terminal data
+      }
+      const wt = wtermRef.current
+      if (!wt) return
+      wt.write(event.data)
+      // Always scroll to bottom — especially important during initial history dump
+      const el = wt.element as HTMLElement
+      if (el) {
+        requestAnimationFrame(() => {
+          el.scrollTop = el.scrollHeight
+        })
+      }
+    }
+
+    ws.onclose = () => {
+      setIsConnected(false)
+      reconnectRef.current = setTimeout(connect, 3000)
+    }
+
+    ws.onerror = () => {
+      setError('WebSocket connection failed')
+    }
+  }, [session.id])
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    let destroyed = false
+    let styleEl: HTMLStyleElement | null = null
+    let resizeObserver: ResizeObserver | null = null
+
+    async function init() {
+      const { WTerm } = await import('@wterm/dom')
+
+      if (destroyed || !containerRef.current) return
+
+      // Inject scoped CSS — removed on cleanup so it doesn't leak to Terminal v1
+      if (!document.querySelector('style[data-wterm-scoped]')) {
+        styleEl = document.createElement('style')
+        styleEl.setAttribute('data-wterm-scoped', 'true')
+        styleEl.textContent = getWtermScopedCSS()
+        document.head.appendChild(styleEl)
+      }
+
+      // Disable wterm's built-in autoResize — we handle it ourselves
+      // because wterm's ResizeObserver can race with flex layout
+      const wt = new WTerm(containerRef.current, {
+        autoResize: false,
+        cursorBlink: true,
+        onData: (data: string) => {
+          if (wsRef.current?.readyState === WebSocket.OPEN) {
+            wsRef.current.send(data)
+          }
+        },
+        onResize: (cols: number, rows: number) => {
+          if (wsRef.current?.readyState === WebSocket.OPEN) {
+            wsRef.current.send(JSON.stringify({ type: 'resize', cols, rows }))
+          }
+        },
+      })
+
+      await wt.init()
+      if (destroyed) { wt.destroy(); return }
+
+      wtermRef.current = wt
+
+      // Our own ResizeObserver on the container — fires after layout settles
+      function fitToContainer() {
+        if (!containerRef.current || !wtermRef.current) return
+        const rect = containerRef.current.getBoundingClientRect()
+        if (rect.width === 0 || rect.height === 0) return
+
+        const measured = (wtermRef.current as any)._measureCharSize?.()
+        if (!measured) return
+
+        const cs = getComputedStyle(containerRef.current)
+        const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0)
+        const padY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0)
+
+        const cols = Math.max(1, Math.floor((rect.width - padX) / measured.charWidth))
+        const rows = Math.max(1, Math.floor((rect.height - padY) / measured.rowHeight))
+
+        if (cols !== (wtermRef.current as any).cols || rows !== (wtermRef.current as any).rows) {
+          wtermRef.current.resize(cols, rows)
+        }
+      }
+
+      resizeObserver = new ResizeObserver(() => {
+        fitToContainer()
+      })
+      resizeObserver.observe(containerRef.current)
+
+      // Also fit after a short delay to catch any late layout
+      setTimeout(fitToContainer, 50)
+      setTimeout(fitToContainer, 200)
+
+      setReady(true)
+    }
+
+    init().catch(err => {
+      console.error('[wterm] Init failed:', err)
+      setError('Failed to initialize wterm: ' + String(err))
+    })
+
+    return () => {
+      destroyed = true
+      if (resizeObserver) resizeObserver.disconnect()
+      wtermRef.current?.destroy()
+      wtermRef.current = null
+      if (styleEl) {
+        styleEl.remove()
+        styleEl = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!ready) return
+    connect()
+    return () => {
+      if (reconnectRef.current) clearTimeout(reconnectRef.current)
+      wsRef.current?.close()
+      wsRef.current = null
+    }
+  }, [ready, connect])
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#0a0a0a]">
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-800 border-b border-gray-700 text-xs flex-shrink-0">
+        <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />
+        <span className="text-cyan-400 font-medium">wterm v2</span>
+        <span className="text-gray-600">|</span>
+        <span className="text-gray-500">{session.id}</span>
+        {error && <span className="text-red-400 ml-auto">{error}</span>}
+        <span className="ml-auto text-gray-600 italic">DOM rendering · native select/copy/find</span>
+      </div>
+      <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden wterm-embed" />
+    </div>
+  )
+}
+
+function getWtermScopedCSS(): string {
+  return `
+    .wterm-embed.wterm {
+      --term-fg: #d4d4d4;
+      --term-bg: #0a0a0a;
+      --term-cursor: #aeafad;
+      --term-color-0: #1e1e1e;
+      --term-color-1: #f44747;
+      --term-color-2: #6a9955;
+      --term-color-3: #d7ba7d;
+      --term-color-4: #569cd6;
+      --term-color-5: #c586c0;
+      --term-color-6: #4ec9b0;
+      --term-color-7: #d4d4d4;
+      --term-color-8: #808080;
+      --term-color-9: #f44747;
+      --term-color-10: #6a9955;
+      --term-color-11: #d7ba7d;
+      --term-color-12: #569cd6;
+      --term-color-13: #c586c0;
+      --term-color-14: #4ec9b0;
+      --term-color-15: #ffffff;
+      --term-font-family: 'Menlo', 'Consolas', 'DejaVu Sans Mono', 'Courier New', monospace;
+      --term-font-size: 13px;
+      --term-line-height: 1.25;
+      --term-row-height: 17px;
+      position: relative;
+      background: var(--term-bg);
+      color: var(--term-fg);
+      font-family: var(--term-font-family);
+      font-size: var(--term-font-size);
+      line-height: var(--term-line-height);
+      padding: 4px 8px;
+      border-radius: 0;
+      box-shadow: none;
+      outline: none;
+      overflow: hidden;
+      width: 100%;
+      height: 100%;
+    }
+    .wterm-embed.wterm:focus,
+    .wterm-embed.wterm:focus-visible {
+      outline: none;
+    }
+    .wterm-embed .term-grid {
+      display: block;
+      white-space: pre;
+      contain: layout paint style;
+      will-change: contents;
+    }
+    .wterm-embed .term-row {
+      display: block;
+      height: var(--term-row-height);
+      line-height: var(--term-row-height);
+      contain: layout style;
+    }
+    .wterm-embed .term-row > span {
+      display: inline-block;
+      height: var(--term-row-height);
+      vertical-align: top;
+    }
+    .wterm-embed .term-block {
+      width: 1ch;
+      overflow: hidden;
+    }
+    .wterm-embed .term-cursor {
+      outline: 1px solid var(--term-cursor);
+      outline-offset: -1px;
+    }
+    .wterm-embed.wterm.focused .term-cursor {
+      background: var(--term-cursor);
+      color: var(--term-bg);
+      outline: none;
+    }
+    .wterm-embed.wterm.focused.cursor-blink .term-cursor {
+      animation: wterm-cursor-blink 1s step-end infinite;
+    }
+    @keyframes wterm-cursor-blink {
+      0%, 100% { background: var(--term-cursor); color: var(--term-bg); }
+      50% { background: transparent; color: inherit; }
+    }
+    .wterm-embed.wterm.has-scrollback {
+      overflow-y: auto;
+    }
+    .wterm-embed.wterm ::selection {
+      background: rgba(86, 156, 214, 0.3);
+    }
+  `
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.2",
+  "version": "0.37.3",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/agents-docs-service.ts
+++ b/services/agents-docs-service.ts
@@ -100,30 +100,62 @@ export async function queryDocs(
     case 'list': {
       const listLimit = limit || 50
 
+      // project_path is returned so the UI can compute a path relative to the
+      // directory each document was actually indexed under. Relying on the
+      // agent's registered workingDirectory breaks whenever the two drift, and
+      // they do — see the note on the folder grouping in DocumentationPanel.
       let query = `
-        ?[doc_id, file_path, title, doc_type, updated_at] :=
-          *documents{doc_id, file_path, title, doc_type, updated_at}
+        ?[doc_id, file_path, title, doc_type, project_path, updated_at] :=
+          *documents{doc_id, file_path, title, doc_type, project_path, updated_at}
       `
 
       if (project) {
         query = `
-          ?[doc_id, file_path, title, doc_type, updated_at] :=
+          ?[doc_id, file_path, title, doc_type, project_path, updated_at] :=
             *documents{doc_id, file_path, title, doc_type, project_path, updated_at},
             project_path = '${project.replace(/'/g, "''")}'
         `
       }
 
+      // Count before truncating so the caller can tell that it is seeing a
+      // window rather than the whole set. Silently returning the N most
+      // recently updated docs hides stable files — exactly the ones a reader
+      // is most likely to go looking for.
+      let total = 0
+      try {
+        const countResult = await agentDb.run(
+          project
+            ? `?[count(doc_id)] := *documents{doc_id, project_path}, project_path = '${project.replace(/'/g, "''")}'`
+            : `?[count(doc_id)] := *documents{doc_id}`
+        )
+        total = (countResult.rows?.[0]?.[0] as number) ?? 0
+      } catch {
+        // Count is advisory; never fail the listing because of it.
+      }
+
       query += ` :order -updated_at :limit ${listLimit}`
 
       const docsResult = await agentDb.run(query)
-      result = docsResult.rows.map((row: any[]) => ({
+      const docs = docsResult.rows.map((row: any[]) => ({
         docId: row[0],
         filePath: row[1],
         title: row[2],
         docType: row[3],
-        updatedAt: row[4],
+        projectPath: row[4],
+        updatedAt: row[5],
       }))
-      break
+
+      return {
+        data: {
+          success: true,
+          agent_id: agentId,
+          action,
+          result: docs,
+          total: total || docs.length,
+          truncated: total > docs.length,
+        },
+        status: 200,
+      }
     }
 
     default:

--- a/tests/docs-folder-grouping.test.ts
+++ b/tests/docs-folder-grouping.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the docs-tab folder grouping (components/DocumentationPanel.tsx).
+ *
+ * The reported symptom: subfolders and their files showed in the Docs tab, but
+ * root-level files like CLAUDE.md appeared to be missing.
+ *
+ * They were indexed and present in the data the whole time. The grouping
+ * stripped only the agent's registered `workingDirectory` from each file path.
+ * When that drifted from the `project_path` the documents were actually
+ * indexed under — observed on a real agent registered at
+ * `/blocks/jarvis/api` whose docs were indexed under `/blocks/jarvis/v2` —
+ * the prefix never matched, the path stayed ABSOLUTE, and because an absolute
+ * path always contains '/', the `(root)` bucket was never produced at all.
+ * CLAUDE.md was filed under a folder row literally named
+ * "/Users/.../jarvis/v2" instead of "Root".
+ *
+ * This mirrors the grouping logic so the behaviour is pinned without mounting
+ * the component.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+interface Doc {
+  filePath: string
+  projectPath?: string
+}
+
+/** Mirrors documentsByFolder in DocumentationPanel.tsx. */
+function groupByFolder(documents: Doc[], workingDirectory?: string): Record<string, string[]> {
+  return documents.reduce((acc, doc) => {
+    const base = doc.projectPath || workingDirectory
+    let relativePath = doc.filePath
+    let matched = false
+    if (base && doc.filePath.startsWith(base)) {
+      relativePath = doc.filePath.slice(base.length).replace(/^\//, '')
+      matched = true
+    }
+
+    const parts = relativePath.split('/')
+    let folderPath: string
+    if (parts.length <= 1) folderPath = '(root)'
+    else if (matched) folderPath = parts.slice(0, -1).join('/')
+    else folderPath = parts[parts.length - 2] || '(root)'
+
+    ;(acc[folderPath] ||= []).push(parts[parts.length - 1])
+    return acc
+  }, {} as Record<string, string[]>)
+}
+
+const REPO = '/Users/me/repo'
+
+describe('docs folder grouping', () => {
+  it('puts root-level files under (root)', () => {
+    const g = groupByFolder(
+      [
+        { filePath: `${REPO}/CLAUDE.md`, projectPath: REPO },
+        { filePath: `${REPO}/README.md`, projectPath: REPO },
+        { filePath: `${REPO}/docs/setup.md`, projectPath: REPO },
+      ],
+      REPO
+    )
+    expect(g['(root)']).toEqual(['CLAUDE.md', 'README.md'])
+    expect(g['docs']).toEqual(['setup.md'])
+  })
+
+  it('keeps nested folders intact', () => {
+    const g = groupByFolder([{ filePath: `${REPO}/docs/api/auth.md`, projectPath: REPO }], REPO)
+    expect(g['docs/api']).toEqual(['auth.md'])
+  })
+
+  it('REGRESSION: still finds root files when workingDirectory has drifted', () => {
+    // The real failure. The agent is registered at /jarvis/api but its docs
+    // were indexed under /jarvis/v2. Grouping must follow the document's own
+    // project_path, not the stale prop.
+    const INDEXED = '/Users/me/blocks/jarvis/v2'
+    const REGISTERED = '/Users/me/blocks/jarvis/api'
+
+    const g = groupByFolder(
+      [
+        { filePath: `${INDEXED}/CLAUDE.md`, projectPath: INDEXED },
+        { filePath: `${INDEXED}/docs/api.md`, projectPath: INDEXED },
+      ],
+      REGISTERED
+    )
+
+    expect(g['(root)']).toEqual(['CLAUDE.md'])
+    expect(g['docs']).toEqual(['api.md'])
+    // The old behaviour produced a folder named after the absolute path.
+    expect(Object.keys(g).some((k) => k.startsWith('/'))).toBe(false)
+  })
+
+  it('never labels a folder with an absolute path when no base matches', () => {
+    // Neither project_path nor workingDirectory available or matching: fall
+    // back to the immediate parent directory so the list stays readable.
+    const g = groupByFolder([{ filePath: '/somewhere/else/deep/notes.md' }], undefined)
+    expect(Object.keys(g)).toEqual(['deep'])
+    expect(Object.keys(g).some((k) => k.startsWith('/'))).toBe(false)
+  })
+
+  it('treats a bare filename as root', () => {
+    expect(groupByFolder([{ filePath: 'CLAUDE.md' }], REPO)['(root)']).toEqual(['CLAUDE.md'])
+  })
+
+  it('sorts (root) first', () => {
+    // Matches the component's sort: root is always the top row, so it can
+    // never be scrolled out of view.
+    const keys = ['zebra', '(root)', 'docs'].sort((a, b) => {
+      if (a === '(root)') return -1
+      if (b === '(root)') return 1
+      return a.localeCompare(b)
+    })
+    expect(keys[0]).toBe('(root)')
+  })
+})

--- a/tests/session-restore.test.ts
+++ b/tests/session-restore.test.ts
@@ -20,7 +20,7 @@ import type { PersistedSession } from '@/lib/session-persistence'
 
 const { mockFs } = vi.hoisted(() => ({
   mockFs: {
-    existsSync: vi.fn(() => true),
+    existsSync: vi.fn((_p?: any): boolean => true),
     readFileSync: vi.fn((_p?: any): string => '[]'),
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2",
+  "version": "0.37.3",
   "releaseDate": "2026-08-28",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## The report

> Subfolders show, files inside subfolders show, but individual root files like CLAUDE.md don't.

## What was actually happening

They were indexed and on screen the whole time — under a folder row named with an **absolute path**.

The grouping stripped only the agent's registered `workingDirectory`:

```js
if (workingDirectory && doc.filePath.startsWith(workingDirectory)) { ...strip... }
const folderPath = parts.length > 1 ? parts.slice(0, -1).join('/') : '(root)'
```

When `workingDirectory` drifts from the `project_path` the docs were indexed under, the prefix never matches → the path stays **absolute** → an absolute path always contains `/` → **`(root)` is never produced**.

Reproduced on `23blocks-api-jarvis` (registered `.../jarvis/api`, docs indexed under `.../jarvis/v2`):

```
docs: 48 | folders produced: 17
has "(root)" bucket: false
CLAUDE.md grouped under: "/Users/juanpelaez/23blocks/blocks/jarvis/v2"
```

Same stale-binding class as the memory faults in v0.36.48–49.

## Fix

Prefer each document's own `project_path`, fall back to the prop, and when neither matches use the immediate parent directory name — **never an absolute path as a folder label**. `action=list` now returns `projectPath`.

Verified live on that same agent after the fix:

```
has (root) bucket: True
root files: CLAUDE.md, FRONTEND_API_STANDARDS.md, MIGRATION_GUIDE_AGENT_STREAMING.md, ...
absolute-path folders: []
```

## Second, separate fault

The browse list **silently truncated**. `action=list` orders by `-updated_at` then limits — so whatever is hidden is disproportionately *stable* files, exactly the ones someone goes looking for. One agent has **340 docs against a 200 limit**, with no indication.

Now returns `total` + `truncated`, UI requests 500, and shows **"Showing N of M"** when cut.

## Also

`Root` is expanded by default — every folder started collapsed, and one collapsed `Root` row is easy to scan past among a dozen siblings.

## Ruled out

The indexer. `**/*.md` matches root files under glob 10.3.10, and CLAUDE.md was in the `documents` relation for every agent checked. Also ruled out paging/viewport: `(root)` sorts first, so it can never scroll out of view.

## Testing

`1012 passing (+6)`, including a regression case built from the real drifted paths and an assertion that no folder label ever starts with `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)