### PR TITLE
fix(docs): show file names, not markdown titles (v0.37.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.5] - 2026-08-28 — Docs viewer shows file names
+
+### Fixed
+- **The browse list displayed markdown titles instead of file names.** The label was `doc.title || filename`, and `title` is the document's H1 — so a `CLAUDE.md` beginning `# GM — \`3m-gm\`` rendered as **"GM — 3m-gm"**. Observed across agents: `3m-gm` → `"GM — \`3m-gm\`"`, `3m-sales` → `"Sales Manager / BD — \`3m-sales\`"`. The same file looked like a different one in every agent, extensions were invisible, and there was no way to tell which file you were about to open. File names are now the label (monospace, with extension); the markdown title is shown beside them as secondary context, and omitted when it merely repeats the name.
+- **Sorting used the title too**, so files scattered unpredictably — `CLAUDE.md` sorted under "G" because its heading began with "GM". Now sorts by file name.
+- The open-document header leads with the file name; the markdown title sits underneath as context.
+
+### Notes
+- Search results still lead with the title, which is correct there — you are looking for content, not for a file. Only the browse tree changed.
+- Together with 0.37.3 and 0.37.4 this closes out the docs tab behaving like a file browser: real folder names, no pseudo-root, real file names.
+
 ## [0.37.4] - 2026-08-28 — Docs viewer behaves like a file browser
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/components/DocumentationPanel.tsx
+++ b/components/DocumentationPanel.tsx
@@ -330,11 +330,24 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
     .filter((k) => k !== '(root)')
     .sort((a, b) => a.localeCompare(b))
 
-  const sortByName = (a: DocumentMeta, b: DocumentMeta) => {
-    const nameA = (a.title || a.filePath.split('/').pop() || '').toLowerCase()
-    const nameB = (b.title || b.filePath.split('/').pop() || '').toLowerCase()
-    return nameA.localeCompare(nameB)
+  // A file browser shows FILE NAMES. `title` is the document's markdown H1,
+  // which is useful context but is not the file: a CLAUDE.md whose first
+  // heading is "# GM — `3m-gm`" was displayed as "GM — 3m-gm", so the same file
+  // looked like a different one in every agent and you could not tell what you
+  // were about to open. Name is primary; title is secondary detail.
+  const fileName = (doc: DocumentMeta) => doc.filePath.split('/').pop() || doc.filePath
+
+  /** Title worth showing beside the name — omit when it just repeats it. */
+  const subtitleFor = (doc: DocumentMeta) => {
+    const name = fileName(doc)
+    if (!doc.title) return null
+    const t = doc.title.trim()
+    if (!t || t === name) return null
+    return t
   }
+
+  const sortByName = (a: DocumentMeta, b: DocumentMeta) =>
+    fileName(a).toLowerCase().localeCompare(fileName(b).toLowerCase())
 
   // Files sitting at the top level of the indexed directory.
   const rootDocs = [...(documentsByFolder['(root)'] || [])].sort(sortByName)
@@ -666,7 +679,10 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
                                 }`}
                               >
                                 <TypeIcon className="w-3.5 h-3.5 flex-shrink-0" style={{ color: typeConfig.color }} />
-                                <span className="text-sm truncate">{doc.title || doc.filePath.split('/').pop()}</span>
+                                <span className="text-sm truncate font-mono">{fileName(doc)}</span>
+                                {subtitleFor(doc) && (
+                                  <span className="text-xs text-gray-500 truncate">{subtitleFor(doc)}</span>
+                                )}
                               </button>
                             )
                           })}
@@ -692,7 +708,10 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
                       title={doc.filePath}
                     >
                       <TypeIcon className="w-4 h-4 flex-shrink-0" style={{ color: typeConfig.color }} />
-                      <span className="text-sm truncate">{doc.title || doc.filePath.split('/').pop()}</span>
+                      <span className="text-sm truncate font-mono">{fileName(doc)}</span>
+                      {subtitleFor(doc) && (
+                        <span className="text-xs text-gray-500 truncate">{subtitleFor(doc)}</span>
+                      )}
                     </button>
                   )
                 })}
@@ -733,7 +752,10 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
                               }`}
                             >
                               <File className="w-3.5 h-3.5 text-gray-500 flex-shrink-0" />
-                              <span className="text-sm truncate">{doc.title || doc.filePath.split('/').pop()}</span>
+                              <span className="text-sm truncate font-mono">{fileName(doc)}</span>
+                              {subtitleFor(doc) && (
+                                <span className="text-xs text-gray-500 truncate">{subtitleFor(doc)}</span>
+                              )}
                             </button>
                           ))}
                         </div>
@@ -753,7 +775,16 @@ export default function DocumentationPanel({ sessionName, agentId, workingDirect
               ) : selectedDoc && docContent ? (
                 <div className="p-6">
                   <div className="mb-4">
-                    <h2 className="text-xl font-semibold mb-2">{docContent.title}</h2>
+                    {/* Filename leads, as in any file viewer. The markdown H1
+                        is shown under it as context, not as the identity of
+                        the file. */}
+                    <h2 className="text-xl font-semibold mb-1 font-mono">
+                      {docContent.filePath?.split('/').pop() || docContent.title}
+                    </h2>
+                    {docContent.title &&
+                      docContent.title !== docContent.filePath?.split('/').pop() && (
+                        <p className="text-sm text-gray-300 mb-2">{docContent.title}</p>
+                      )}
                     <div className="flex items-center gap-3 text-sm text-gray-400">
                       <span className="flex items-center gap-1">
                         <FileText className="w-4 h-4" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.4",
+  "version": "0.37.5",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/tests/docs-folder-grouping.test.ts
+++ b/tests/docs-folder-grouping.test.ts
@@ -123,3 +123,54 @@ describe('docs folder grouping', () => {
     expect(folderKeys).not.toContain('(root)')
   })
 })
+
+/**
+ * The browse list is a file browser, so it must show FILE NAMES.
+ *
+ * `title` is the document's markdown H1. Displaying it instead of the filename
+ * meant a CLAUDE.md beginning "# GM — `3m-gm`" rendered as "GM — 3m-gm": the
+ * same file looked like a different one in every agent, extensions vanished,
+ * and you could not tell which file you were about to open.
+ */
+describe('document labels', () => {
+  const fileName = (d: { filePath: string }) => d.filePath.split('/').pop() || d.filePath
+  const subtitleFor = (d: { filePath: string; title?: string }) => {
+    const name = fileName(d)
+    if (!d.title) return null
+    const t = d.title.trim()
+    return !t || t === name ? null : t
+  }
+
+  it('labels a document with its filename, including the extension', () => {
+    const doc = { filePath: '/repo/CLAUDE.md', title: 'GM — `3m-gm`' }
+    expect(fileName(doc)).toBe('CLAUDE.md')
+  })
+
+  it('keeps the markdown title only as secondary context', () => {
+    const doc = { filePath: '/repo/CLAUDE.md', title: 'GM — `3m-gm`' }
+    expect(subtitleFor(doc)).toBe('GM — `3m-gm`')
+  })
+
+  it('does not repeat the name when the title is just the filename', () => {
+    expect(subtitleFor({ filePath: '/repo/CLAUDE.md', title: 'CLAUDE.md' })).toBeNull()
+  })
+
+  it('handles a missing title', () => {
+    const doc = { filePath: '/repo/notes.md' }
+    expect(fileName(doc)).toBe('notes.md')
+    expect(subtitleFor(doc)).toBeNull()
+  })
+
+  it('sorts by filename, not by title', () => {
+    // Sorting by title scattered files unpredictably: "GM — 3m-gm" sorted
+    // under G while the file is CLAUDE.md.
+    const docs = [
+      { filePath: '/repo/ZEBRA.md', title: 'Aardvark' },
+      { filePath: '/repo/APPLE.md', title: 'Zulu' },
+    ]
+    const sorted = [...docs].sort((a, b) =>
+      fileName(a).toLowerCase().localeCompare(fileName(b).toLowerCase())
+    )
+    expect(sorted.map(fileName)).toEqual(['APPLE.md', 'ZEBRA.md'])
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.4",
+  "version": "0.37.5",
   "releaseDate": "2026-08-28",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## The problem

The browse list labelled documents with `doc.title || filename` — and `title` is the markdown **H1**.

So a `CLAUDE.md` beginning `# GM — \`3m-gm\`` rendered as **"GM — 3m-gm"**. Confirmed across agents:

```
3m-gm      CLAUDE.md  title = "GM — `3m-gm`"
3m-sales   CLAUDE.md  title = "Sales Manager / BD — `3m-sales`"
```

The same file looked like a different one in every agent, **extensions were invisible**, and you couldn't tell which file you were about to open.

## Fix

File names are the label — monospace, extension included. The markdown title is kept as secondary context beside the name, and dropped when it just repeats the name.

Sorting used the title too, so `CLAUDE.md` sorted under "G" because its heading began with "GM". Now sorts by file name.

The open-document header leads with the file name, title underneath.

## Unchanged

Search results still lead with the title — correct there, since you're looking for content, not a file. Only the browse tree changed.

## Context

With v0.37.3 (root files hidden behind an absolute-path folder) and v0.37.4 (fake "Root" folder), this closes out the docs tab behaving like a file browser rather than something invented for the occasion.

`1017 passing (+5)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)