### PR TITLE
docs(backlog): log deferred ideas from the competitor benchmarks (v0.37.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.6] - 2026-08-28 — Backlog: deferred ideas from the competitor benchmarks
+
+### Added
+- **Five backlog entries** capturing what the Paseo / Open Session / opensessions analyses produced but nobody logged. They were living in gitignored benchmark docs and in one session's context, which is where ideas go to die.
+  - **#15 QR-code pairing for mobile app → host registration** — Paseo's pairing UX (public key in the URL *fragment*, so the page server never sees it; the host refuses commands until the handshake completes), running over our existing Tailscale transport. Explicitly **not** their relay: Tailscale gives real network identity and ACLs, and their own docs treat it as first-class.
+  - **#16 Fresh-context scheduled tasks (`fresh: true`)** — the v0.37.0 scheduler lands every `prompt` in the agent's existing context. Correct for internal maintenance, a prompt-injection surface for anything triggered by external input. Open Session ships both modes and makes the trade explicit.
+  - **#17 Read-only agent tier** — `permissionMode` has no "can read, cannot write" level. **Two independent competitors converged on this primitive** (Paseo's committee agents cannot modify files; Open Session has an `ask` mode), which is the strongest signal in the benchmark set.
+  - **#18 Agent status push contract** — agent state is inferred from hooks, pane readback, and heuristics that grep the terminal for a trust prompt. That inference is what let a host index **nothing for months** while reporting healthy (0.36.48–0.36.50). Logged with the caveat we already paid for: only *deterministic code* reporting is worth anything — an agent that chooses to report is the same unreliable narrator.
+  - **#19 Git worktree isolation per task** — flagged by both Paseo and Open Session; open question is how it squares with `workingDirectory` being a stored agent property.
+
+### Notes
+- `docs/BACKLOG.md` header was stale at v0.29.16 / 2026-01-03; refreshed.
+- No functional change. Docs only.
+
 ## [0.37.5] - 2026-08-28 — Docs viewer shows file names
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.6-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,8 +2,8 @@
 
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
-**Last Updated:** 2026-01-03
-**Current Version:** v0.29.16
+**Last Updated:** 2026-08-28
+**Current Version:** v0.37.6
 
 ---
 
@@ -691,6 +691,107 @@ Add "Memory" tab to AI Maestro dashboard:
 ---
 
 ## Next (v0.6.x)
+
+### 15. QR-Code Pairing for Mobile App → Host Registration
+
+**Status:** Planned
+**Priority:** High
+**Effort:** Medium (2-3 days)
+**Source:** Competitor analysis — Paseo (`docs/benchmark/paseo-comparison.md`)
+
+**Problem:**
+Registering a host with the mobile app means finding the machine's Tailscale IP, editing config, and typing it in. Hosts arrive through our discovery process, but the *app → host* association is still manual and is the onboarding cliff for anyone who has not already internalised the mesh.
+
+**Proposed Solution:**
+Take Paseo's pairing UX — **not** their relay. Render a pairing URL as a QR code with the host's public key **in the URL fragment** (fragments are never sent to the web server, so whatever serves the page never sees the key). The phone posts its public key, both sides derive a shared secret, and **the host accepts no commands until the handshake completes**.
+
+This is transport-agnostic: it runs over our existing Tailscale mesh and replaces "find the IP, edit config, type it in" with "scan this". Paseo documents Tailscale as a first-class alternative to their own relay, so the pairing layer and the transport layer are genuinely separable.
+
+**Explicitly out of scope:** replacing Tailscale with a relay. Tailscale gives real network identity, ACLs, and no third party in the data path.
+
+**Benefits:**
+- Removes the single hardest step in mobile onboarding — the surface we intend to monetise
+- Adds a real authorization boundary: an unpaired client cannot issue commands
+
+---
+
+### 16. Fresh-Context Scheduled Tasks (`fresh: true`)
+
+**Status:** Planned
+**Priority:** High
+**Effort:** Small (≤1 day)
+**Source:** Competitor analysis — Open Session (`docs/benchmark/opensession-comparison.md`)
+
+**Problem:**
+The agent-owned scheduler (v0.37.0) has a `prompt` action, and every scheduled prompt lands in the agent's **existing** context. For internal maintenance that is correct — continuity is the point. For anything triggered by external input it is wrong, and it is a **prompt-injection surface**: a hostile support ticket or Slack message inherits everything the agent already knows and everything it is already permitted to do.
+
+**Proposed Solution:**
+Add `fresh: true` to `ScheduledTask`. A fresh task runs in a clean context and returns; a normal task resumes the agent's session as today.
+
+Open Session shipped both and made the trade explicit — their *automations* are "amnesiac, every run starts clean", their *goals* resume a single session "so context carries, and the agent remembers what it already tried". They did not pick one, and neither should we: amnesia is a safety feature when the input is untrusted, continuity is what long-running work needs.
+
+**Files:** `lib/agent-schedule.ts`, `lib/agent-schedule-runner.ts`
+
+---
+
+### 17. Read-Only Agent Tier
+
+**Status:** Planned
+**Priority:** Medium
+**Effort:** Medium (2-3 days)
+**Source:** Competitor analysis — Paseo *and* Open Session
+
+**Problem:**
+`permissionMode` is `supervised` / `smartAuto` / `fullAutonomy` — every tier can write. There is no way to spawn an agent that may read the repo and reason about it but **cannot modify a file**.
+
+**Proposed Solution:**
+A read-only tier beside the existing `permissionMode` values.
+
+**Two independent competitors converged on this primitive**, which is the strongest signal in the benchmark set: Paseo's `/paseo-committee` spawns high-reasoning analysis agents that cannot modify files, and Open Session's sessions run in `ask` (read-only) / `code` / `scratch` modes. Both use it for the same job — analysis, second opinions, review — where write access is pure downside risk.
+
+**Benefits:**
+- Makes analysis/committee patterns safe to run at high autonomy
+- The natural permission tier for any agent acting on external input (pairs with #16)
+
+---
+
+### 18. Agent Status Push Contract
+
+**Status:** Planned
+**Priority:** Medium
+**Effort:** Medium (2-3 days)
+**Source:** Competitor analysis — opensessions (`docs/benchmark/opensessions-comparison.md`)
+
+**Problem:**
+Agent state is **inferred**: Claude Code hooks when they fire, pane readback when they do not, and heuristics like `detectStartupBlock()` grepping the terminal for *"Do you trust the files in this folder?"*. Inference has cost us real days — a trust prompt blocking a host silently, and a CUDA failure that left an entire host indexing **nothing for months** while the subsystem reported healthy (v0.36.48–0.36.50).
+
+**Proposed Solution:**
+A documented HTTP endpoint that **agents and scripts push their own status, progress, and logs to**, complementing hooks rather than replacing them. Deterministic code reporting what it actually did — not the agent being asked to remember to report.
+
+Extend the status vocabulary while we are there: `idle` / `active` / `waiting_for_input` / `permission_request` has no notion of **finished-with-an-error** or **interrupted**, which is exactly what an operator scanning a fleet wants to see. opensessions marks threads `done` / `error` / `interrupted`.
+
+**Also cheap and high-signal from the same source:** git branch and detected localhost ports in the agent list.
+
+**Caveat, learned the hard way:** this only works for callers that are deterministic code. An agent that *chooses* to POST is the same unreliable narrator we already have — see the delivery-confirmation work in v0.36.37–38.
+
+---
+
+### 19. Git Worktree Isolation Per Task
+
+**Status:** Planned
+**Priority:** Medium
+**Effort:** Large (full cycle)
+**Source:** Competitor analysis — Paseo *and* Open Session
+
+**Problem:**
+Parallel agents share a checkout, so two agents working the same repo collide on branch state and the working tree.
+
+**Proposed Solution:**
+Give each task/workspace its own git worktree. Both competitors build on this: Open Session's workspace "holds a repo, a branch, a worktree directory and any attached repos", and Paseo exposes worktrees, diffs, branches and PRs in-product.
+
+**Open question:** how this interacts with `workingDirectory` being a **stored** agent property (see CLAUDE.md, Agent-First Architecture). A worktree is per-task and ephemeral; the agent's directory is not. Likely the worktree belongs to the task, not the agent.
+
+---
 
 ### 3. Slack Integration for Agent Communication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.5",
+  "version": "0.37.6",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.37.5",
-  "releaseDate": "2026-08-28",
+  "version": "0.37.6",
+  "releaseDate": "2026-08-29",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
Five ideas came out of the Paseo / Open Session / opensessions analyses and were never logged anywhere durable — they lived in gitignored benchmark docs and in one session's context.

| # | Item | Source |
|---|---|---|
| 15 | QR-code pairing for mobile app → host registration | Paseo |
| 16 | Fresh-context scheduled tasks (`fresh: true`) | Open Session |
| 17 | Read-only agent tier | **Paseo *and* Open Session** |
| 18 | Agent status push contract | opensessions |
| 19 | Git worktree isolation per task | **Paseo *and* Open Session** |

Two of the five were arrived at independently by two competitors, which is the strongest signal in the set.

Each entry records what we already paid to learn:

- **#15** takes Paseo's *pairing UX*, explicitly **not** their relay — Tailscale gives real network identity and ACLs, and their own docs treat it as first-class.
- **#16** names the actual defect: the v0.37.0 scheduler lands every `prompt` in the agent's existing context, which is right for maintenance and a **prompt-injection surface** for anything triggered by external input.
- **#18** carries the caveat this session earned: only *deterministic code* reporting status is worth anything. An agent that chooses to POST is the same unreliable narrator behind the delivery-confirmation work in 0.36.37–38.

Also refreshed the `docs/BACKLOG.md` header, stale at v0.29.16 / 2026-01-03.

**Docs only — no functional change.** 1017 tests passing, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)