### PR TITLE
fix: ship the identity fix to hosts; record what differs on a staged wake (v0.37.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.8] - 2026-09-02 — Hosts get the identity fix; staged wakes record what differs
+
+### Fixed
+- **Hosts were still running the script that rewrites the identity it reads.** [claude-plugin#26](https://github.com/agentmessaging/claude-plugin/pull/26) merged upstream, but fresh installs (`install-plugin.sh`) and host updates read the **built** submodule, not `claude-plugin` directly — so nothing reached a host until the plugin was rebuilt ([plugins#32](https://github.com/23blocks-OS/ai-maestro-plugins/pull/32)) and the pointer bumped. That is this release. `--id` now beats an inherited `AMP_DIR`, `load_config()` is read-only, repair lives in `amp-init --repair-config` (which keeps keys, id and registrations, unlike `--force`), and `amp-init` completes an existing identity instead of minting a rival directory.
+
+### Added
+- **A staged wake now records what was different about the pane.** The failure does not hit every agent, which means something distinguishes the ones it hits — so instead of arguing about it, the warning carries the candidates measured at the moment of failure: `width`, `height`, `alternate_on`, `history_size`, `in_mode`, `command`, plus `hookReport` and `payloadChars`.
+  - **width** is the leading hypothesis. A narrow pane wraps the same notification into more lines, and line count is what pushes a TUI into treating input as a multi-line *paste* rather than a typed prompt — different submit semantics, same bytes. Our own fleet is already split 80 vs 101 columns.
+  - **alternate_on** would mean the fullscreen renderer, which handles input differently *and* keeps no scrollback — so it breaks the readback as well. Agents launched by hand rather than woken by AI Maestro miss `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`, which is exactly the shape of the sandbox workaround in the field report.
+  - **hookReport** distinguishes the two payload shapes: plain text to a live agent TUI, `echo '...'` to anything else. Different length, different quoting, plausibly different handling.
+- `describePane()` on the runtime interface, optional so a runtime that cannot introspect its pane reports nothing rather than guessing.
+
+### Notes
+- No behaviour change to delivery itself; 0.37.7 already stopped counting staged text as delivered. This makes the *cause* findable from logs instead of reproducible only in production.
+- 1066 tests passing.
+
 ## [0.37.7] - 2026-09-02 — Field report from a 50-agent estate: four of five findings
 
 A production estate (3Metas, ~50 agents across three hosts) reported five findings from one day of use. Four are fixed here; the fifth is a missing capability and is designed and logged rather than half-built. Every one of the four is the same shape this subsystem keeps producing: **a component reporting something it had not earned.**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.7-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,8 +2,8 @@
 
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
-**Last Updated:** 2026-08-28
-**Current Version:** v0.37.7
+**Last Updated:** 2026-09-02
+**Current Version:** v0.37.8
 
 ---
 

--- a/lib/agent-runtime.ts
+++ b/lib/agent-runtime.ts
@@ -35,6 +35,13 @@ export interface AgentRuntime {
   getWorkingDirectory(name: string): Promise<string>
   isInCopyMode(name: string): Promise<boolean>
   cancelCopyMode(name: string): Promise<void>
+  /**
+   * Pane properties that plausibly affect whether typed text SUBMITS.
+   *
+   * Optional: a runtime that cannot introspect its pane simply omits it, and
+   * callers treat the absence as "unknown" rather than as a value.
+   */
+  describePane?(name: string): Promise<Record<string, string>>
 
   // Lifecycle
   createSession(name: string, cwd: string): Promise<void>
@@ -139,6 +146,44 @@ export class TmuxRuntime implements AgentRuntime {
       return stdout.trim() === '1'
     } catch {
       return false
+    }
+  }
+
+  /**
+   * Pane properties captured when a wake fails, so the reason can be found
+   * rather than argued about.
+   *
+   * The staged-text failure does not hit every agent, which means something
+   * differs between the ones it hits and the ones it does not. Rather than
+   * theorise, record the candidates at the moment of failure: width (a narrow
+   * pane wraps the same notification into more lines, which is what pushes a
+   * TUI into treating it as a multi-line paste rather than a typed prompt),
+   * whether the alternate screen is on (the fullscreen renderer handles input
+   * differently and keeps no scrollback, so it also breaks the readback), and
+   * whether the pane is in copy mode or running something other than the agent.
+   */
+  async describePane(name: string): Promise<Record<string, string>> {
+    const FORMAT = [
+      'width=#{pane_width}',
+      'height=#{pane_height}',
+      'alternate_on=#{alternate_on}',
+      'history_size=#{history_size}',
+      'in_mode=#{pane_in_mode}',
+      'command=#{pane_current_command}',
+    ].join(' ')
+    try {
+      const { stdout } = await execAsync(`tmux display-message -t "${name}" -p "${FORMAT}"`)
+      return Object.fromEntries(
+        stdout
+          .trim()
+          .split(' ')
+          .map(pair => {
+            const at = pair.indexOf('=')
+            return at === -1 ? [pair, ''] : [pair.slice(0, at), pair.slice(at + 1)]
+          })
+      )
+    } catch {
+      return {}
     }
   }
 

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -382,9 +382,23 @@ export async function notifyAgent(options: NotificationOptions): Promise<Notific
       // the agent's input box, unsubmitted, after a clear-and-retype. Say so
       // precisely — "not seen in pane" would suggest the opposite problem and
       // send whoever reads the log looking in the wrong place.
+      // This failure does not hit every agent, so something differs between
+      // the ones it hits and the ones it does not. Record the candidates at the
+      // moment of failure rather than reasoning about them later: pane width
+      // (a narrow pane wraps the same notification into more lines, which is
+      // what pushes a TUI into treating it as a multi-line paste instead of a
+      // typed prompt), the alternate screen (a different renderer AND no
+      // scrollback), copy mode, and what is actually running in the pane.
+      // hookReport distinguishes the two payload shapes we send: plain text to
+      // a live agent TUI, `echo '...'` to anything else.
+      const paneInfo = (await runtime.describePane?.(`${sessionName}:0.0`).catch(() => ({}))) || {}
+      const context = Object.entries(paneInfo)
+        .map(([k, v]) => `${k}=${v}`)
+        .concat(`hookReport=${hasHookReport(sessionName)}`, `payloadChars=${notification.length}`)
+        .join(' ')
       console.warn(
         `[Notify] ✗ Notification to ${agentName} is STAGED in the input box, not submitted ` +
-          `(after ${NOTIFICATION_MAX_SENDS} sends). The agent has not seen it.`
+          `(after ${NOTIFICATION_MAX_SENDS} sends). The agent has not seen it. [${context}]`
       )
       return {
         success: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.7",
+  "version": "0.37.8",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.7",
+  "version": "0.37.8",
   "releaseDate": "2026-09-02",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
## 1. The identity fix reaches the hosts

[claude-plugin#26](https://github.com/agentmessaging/claude-plugin/pull/26) merged, but that alone changes nothing on any machine: `install-plugin.sh` and the host updater read the **built submodule**, not `claude-plugin` directly. So the chain is upstream merge → `build-plugin.sh --clean` → [plugins#32](https://github.com/23blocks-OS/ai-maestro-plugins/pull/32) → this pointer bump. Until now every host still ran the version where reading another agent's inbox rewrote that agent's config.

What lands: `--id` beats an inherited `AMP_DIR`; `load_config()` is read-only; repair moved to `amp-init --repair-config`, which preserves keys, id and registrations (`--force` generates new keys and was previously the only repair path); `amp-init` completes an existing identity instead of minting a rival directory.

## 2. Why the Enter fails on *some* agents

The staged-text failure does not hit every agent. That is information, not noise — something distinguishes the ones it hits. Rather than argue about which, the warning now carries the candidates measured **at the moment of failure**:

```
[Notify] ✗ Notification to <agent> is STAGED in the input box, not submitted
  [width=80 height=48 alternate_on=0 history_size=2871 in_mode=0 command=node
   hookReport=true payloadChars=214]
```

Ranked hypotheses, and why each is on the list:

- **`width`** — the leading one. A narrow pane wraps the same notification into more lines, and line count is what pushes a TUI into treating input as a multi-line **paste** rather than a typed prompt. Same bytes, different submit semantics. Our own fleet is already split 80 vs 101 columns. It also explains the reporter's odd result that Enter twice fails but *clear-and-retype* succeeds: the first send leaves the box in a paste state, clearing resets it.
- **`alternate_on`** — the fullscreen renderer handles input differently *and* keeps no scrollback, so it breaks the readback too. An agent launched by hand rather than woken by AI Maestro never gets `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` — which is exactly the shape of the sandbox workaround in the field report.
- **`hookReport`** — selects between two payload shapes: plain text to a live agent TUI, `echo '...'` to anything else. Different length, different quoting.
- **`in_mode`** — a pane in copy mode does not receive typed input at all.
- **`payloadChars`** — pairs with width to give the wrapped line count.

Adds an optional `describePane()` to the runtime interface. Optional on purpose: a runtime that cannot introspect its pane reports **nothing** rather than a guess.

This does not change delivery behaviour — 0.37.7 already stopped counting staged text as delivered. It makes the *cause* findable from logs rather than reproducible only in production.

**1066 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)