### PR TITLE
test: prove the submission readback works on the fullscreen renderer (v0.37.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.9] - 2026-09-02 — The fullscreen readback, measured instead of assumed
+
+3Metas raised a concern against the 0.37.7 fix itself, and it was the right question: proof of submission requires the message to appear **above** the input box, and an agent on Claude Code's fullscreen renderer reports `history_size=0`. Their `3m-leads` is in exactly that state — it is their sandboxed manual launch, so it never received `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` — and it owns their live customer contact route.
+
+> your new proof-of-submission readback has no scrollback to read on the one agent that owns our live customer contact route
+
+### Verified
+- **It works, and now there is a test proving it.** Reproduced their state locally — a tmux session running Claude Code 2.1.252 launched without the env var: `alternate_on=1, history_size=0, 80x24` — sent a notification through the same two-step send, and captured the pane. Both fixtures in `tests/pane-staged-text.test.ts` are that raw capture. `history_size=0` removes the **scrollback**, not the screen: `capture-pane` still returns the visible screen, the fullscreen renderer draws the submitted prompt above its input box like any other, and the check runs within a second of sending. Submitted classifies as submitted; staged classifies as staged.
+- **The subtlety the test pins**: both the echoed prompt and the empty input box begin with `❯`. Splitting at the *first* prompt line would put the submitted message inside the input region and invert the verdict. Splitting at the *last* is what makes it correct — and that is now asserted rather than incidental.
+
+### Known limitation, stated rather than discovered later
+- On the alternate screen there is no history to fall back on, so a burst of output that scrolls the message off the visible screen before the poll reads as "not seen". That produces a **duplicate nudge** via the retry queue — never a lost message, and never a spurious clear-and-retype, because the needle is not in the input box.
+
+### Also
+- **The width hypothesis from 0.37.8 is disconfirmed.** 3Metas measured it: identical 80x24 geometry on both the clean agent and the deaf ones, and the two *wider* 102-column panes were among the deaf — the wrong direction. Their standing lead is now that the one clean agent was **adopted** rather than created by AI Maestro, so it was started differently. The 0.37.8 instrumentation records `command` (which for Claude Code carries the version) and `hookReport` at failure time, which is the discriminator that hypothesis needs.
+- Their caveat is load-bearing and worth repeating: that geometry was measured *now*, not at test time, and a pane can be resized. Recording it at the moment of failure is precisely why 0.37.8 does it there.
+
+### Notes
+- 1070 tests passing.
+
 ## [0.37.8] - 2026-09-02 — Hosts get the identity fix; staged wakes record what differs
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.8-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.37.8
+**Current Version:** v0.37.9
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.8",
+  "version": "0.37.9",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/tests/pane-staged-text.test.ts
+++ b/tests/pane-staged-text.test.ts
@@ -110,3 +110,100 @@ describe('paneStaged — positive evidence of NON-delivery', () => {
     expect(paneStaged(`❯ ${REF} hello`, REF)).toBe(true)
   })
 })
+
+
+/**
+ * The alternate screen — a real capture, not a hand-written mock.
+ *
+ * 3Metas raised this against the fix itself, and it is the right question to
+ * ask: the proof requires the message to appear ABOVE the input box, and an
+ * agent running Claude Code's fullscreen renderer reports `history_size=0`.
+ * Their `3m-leads` is in exactly that state — it is their sandboxed manual
+ * launch, so it never received `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` — and
+ * it owns their live customer contact route. Their concern:
+ *
+ *   "your new proof-of-submission readback has no scrollback to read on the
+ *    one agent that owns our live customer contact route."
+ *
+ * Reasonable, and empirically wrong. Reproduced locally (tmux session with
+ * Claude Code 2.1.252 launched without the env var: `alternate_on=1,
+ * history_size=0, 80x24` — their exact state), sent the notification through
+ * the same two-step send, and captured the pane. Both fixtures below are that
+ * raw capture.
+ *
+ * `history_size=0` removes the SCROLLBACK, not the screen. `capture-pane`
+ * still returns the visible screen, the fullscreen renderer draws the
+ * submitted prompt above its input box like any other, and the check runs
+ * within a second of sending — so the message is still on screen when we look.
+ *
+ * The residual risk is narrower and worth naming: if a burst of output scrolls
+ * the message off the visible screen before the poll, there is no history to
+ * fall back on, so it reads as "not seen". That produces a duplicate nudge via
+ * the retry queue — never a lost message, and never a spurious clear, because
+ * the needle is not in the input box.
+ */
+describe('alternate screen (fullscreen renderer) — captured from a live agent', () => {
+  const ALT_SUBMITTED = [
+    '',
+    ' ▐▛███▛█   Claude Code v2.1.252',
+    '▝▜██████▀  Opus 5 (1M context) · Claude Max',
+    '  ▝▝ ▝▝    /…/T/tmp.BAOVMPI8vL',
+    '',
+    '⚠ 1 MCP server needs authentication · run /mcp',
+    '',
+    '❯ [#zz9alt77] [MESSAGE] From: tester - alt screen readback probe - reply with',
+    '  the single word ACK',
+    '',
+    '⏺ ACK',
+    '',
+    '✻ Baked for 2s · done 3:29 PM',
+    '',
+    '                                        ✔ Update installed · Restart to update',
+    '─'.repeat(80),
+    '❯ ',
+    '─'.repeat(80),
+    '  AMP: not configured (run amp-init)                                       /rc',
+    '  Opus 5 (1M context) | ctx 6% | $0.63',
+    '  ⏸ plan mode on (shift+tab to cycle) · ← 1 agent',
+  ].join('\n')
+
+  const ALT_STAGED = [
+    '',
+    '⚠ 1 MCP server needs authentication · run /mcp',
+    '',
+    '✻ Baked for 2s · done 3:29 PM',
+    '',
+    '                                        ✔ Update installed · Restart to update',
+    '─'.repeat(80),
+    '❯ [#zz9stg88] staged probe never submitted',
+    '─'.repeat(80),
+    '  AMP: not configured (run amp-init)                                       /rc',
+    '  Opus 5 (1M context) | ctx 6% | $0.63',
+    '  ⏸ plan mode on (shift+tab to cycle)',
+  ].join('\n')
+
+  it('proves submission with no scrollback at all', () => {
+    expect(paneSubmitted(ALT_SUBMITTED, '[#zz9alt77]')).toBe(true)
+    expect(paneStaged(ALT_SUBMITTED, '[#zz9alt77]')).toBe(false)
+  })
+
+  it('still catches staged text in the fullscreen input box', () => {
+    expect(paneStaged(ALT_STAGED, '[#zz9stg88]')).toBe(true)
+    expect(paneSubmitted(ALT_STAGED, '[#zz9stg88]')).toBe(false)
+  })
+
+  it('splits at the input box, not at the echoed prompt above it', () => {
+    // Both lines begin with ❯. Taking the FIRST prompt line would put the
+    // submitted message inside the "input" region and invert the verdict.
+    const { input } = splitPaneAtInput(ALT_SUBMITTED)
+    expect(input).not.toContain('zz9alt77')
+    expect(input).toContain('AMP: not configured')
+  })
+
+  it('is not confused by the status footer below the input box', () => {
+    // The footer sits AFTER the input line, so anything matched there belongs
+    // to the input region — which is why the needle must be a per-message ref
+    // and not a generic string like "MESSAGE".
+    expect(splitPaneAtInput(ALT_SUBMITTED).accepted).toContain('the single word ACK')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.8",
+  "version": "0.37.9",
   "releaseDate": "2026-09-02",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
3Metas raised this against the [0.37.7](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.37.7) fix itself, and it was the right question to ask:

> your new proof-of-submission readback has no scrollback to read on the one agent that owns our live customer contact route

Proof of submission requires the message to appear **above** the input box, and an agent on Claude Code's fullscreen renderer reports `history_size=0`. Their `3m-leads` is in exactly that state — their sandboxed manual launch, so it never received `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`. It is also the only agent on that host with `alternate_on=1`, which incidentally **confirms that candidate as real on their estate**, produced by accident.

## Measured, not assumed

Reproduced their state locally: a tmux session running Claude Code 2.1.252 launched without the env var —

```
alt=1 hist=0 w=80 h=24 cmd=2.1.252
```

— sent a notification through the same two-step send, captured the pane, and ran the real `paneSubmitted` / `paneStaged` against it:

```
alt-submitted.txt  submitted=true   staged=false
alt-staged.txt     submitted=false  staged=true
```

Both fixtures in the test are that raw capture. The agent even replied `⏺ ACK`.

**`history_size=0` removes the scrollback, not the screen.** `capture-pane` still returns the visible screen, the fullscreen renderer draws the submitted prompt above its input box like any other renderer, and the check runs within a second of sending — so the message is still on screen when we look.

## The subtlety this pins

Both the echoed prompt and the empty input box begin with `❯`:

```
❯ [#zz9alt77] [MESSAGE] From: tester - alt screen readback probe…   ← submitted
…
❯                                                                   ← input box
```

Splitting at the **first** prompt line would put the submitted message inside the "input" region and invert the verdict. Splitting at the **last** is what makes it correct, and that is now asserted rather than incidental.

## Known limitation, stated rather than discovered later

With no history to fall back on, a burst of output that scrolls the message off the visible screen before the poll reads as "not seen". That is a **duplicate nudge** via the retry queue — never a lost message, and never a spurious clear-and-retype, because the needle is not in the input box.

## The width hypothesis is disconfirmed

3Metas measured it and I was wrong. Identical 80x24 on both the clean agent and the deaf ones, and the two **wider** 102-column panes were among the deaf — the wrong direction entirely.

Their standing lead is better: the one clean agent was **adopted** rather than created by AI Maestro, so it was started differently. All four agents sharing its Claude Code version are adopted, and no built agent is. Version is likely a proxy for how the session was started. The 0.37.8 instrumentation records `command` (which for Claude Code carries the version) and `hookReport` at failure time — the discriminator that hypothesis needs.

Their caveat is load-bearing and worth repeating: that geometry was measured *now*, not at test time, and a pane can be resized. Recording it at the moment of failure is exactly why 0.37.8 does it there.

**1070 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)