### PR TITLE
fix: verify the 5-minute inbox poll's wake, and correct the docs that hid it (v0.37.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.10] - 2026-09-02 — The wake that was actually delivering had no proof at all
+
+3Metas retracted a message tonight, and the retraction was worth more than the claim. They had called four agents deaf using a 2m19s observation window, published it, then found all four had answered at **4m22s–4m31s** — clustered within 9 seconds of each other.
+
+That timing is the finding. **It is a 5-minute poll, and it is ours.**
+
+### Fixed
+- **`Agent.checkMessages()` — the 5-minute inbox poll — reported success on HTTP 200.** It POSTs a "you have N unread" prompt to the session command endpoint, and `sendCommand` returned `success: true` the instant `sendKeys` returned. That proves bytes reached tmux and nothing more: it is the identical unearned claim fixed in 0.37.7 for the message-wake path, surviving untouched in a **second implementation nobody had looked at**.
+
+  It matters more than the first one, not less. When a push wake stages in an input box and never submits, **this is what rescues it five minutes later** — which is exactly how the failure stayed invisible for months. Messages did arrive. They arrived up to five minutes late, by a different route than the one everyone was watching.
+
+  `sendCommand` now takes `verify: true` (opt-in, so canvas/chat/meeting injection are unaffected) and returns `submitted` / `staged` from a real pane readback, reusing 0.37.7's proof-of-submission.
+- **The poll now names the mechanism**: `✓ Inbox poll wake SUBMITTED — delivered by the 5-min poll, not by push`. Without that, a poll-delivered wake is indistinguishable in the logs from a push-delivered one, so *"push works"* stays an assumption rather than a measurement. Expect this line to be common.
+
+### Corrected documentation that was actively misleading
+- `CLAUDE.md` and two comments in `lib/agent.ts` stated message polling was **disabled by default**, "replaced by push notifications". The code has always been `config.messagePollingEnabled !== false` — **on unless explicitly disabled**. Anyone reading the docs would have concluded there was no safety net under push, and would have misread an agent that "eventually" woke. Both now say enabled, with the measurement that proves it.
+
+### The methodological point, kept because it is the actual lesson
+3Metas held the number that would have prevented their error — a measured 3m48s response time, which they had quoted to us in writing hours earlier — and chose a 2m19s window for a test of the same phenomenon. Their words:
+
+> A negative result inside a window shorter than the known response time is not a result. It is the clock. We published it as biology. **The window could only say ABSENT, never SLOW — so slow came back as absent.**
+
+That is the same defect this changelog has been about for three releases: an instrument that cannot express the thing it is measuring. Our readback window was 1 second per send, sized against nothing in particular. It is now 12 polls × 250 ms with the reasoning written down beside it, so the next person changing it knows what it has to outlast.
+
+### Notes
+- 1078 tests passing. 8 new, covering the poll path's verdicts and specifically that a slow render is not reported as absent.
+
 ## [0.37.9] - 2026-09-02 — The fullscreen readback, measured instead of assumed
 
 3Metas raised a concern against the 0.37.7 fix itself, and it was the right question: proof of submission requires the message to appear **above** the input box, and an agent on Claude Code's fullscreen renderer reports `history_size=0`. Their `3m-leads` is in exactly that state — it is their sandboxed manual launch, so it never received `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` — and it owns their live customer contact route.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,9 +227,13 @@ The subconscious does NOT need remote API calls to access agent data - everythin
 **Subconscious timers (v0.18.10+):**
 - `maintainMemory()` - Indexes conversations for semantic search (runs periodically)
 - `triggerConsolidation()` - Long-term memory consolidation (runs periodically)
-- `checkMessages()` - **DISABLED by default** (push notifications replace polling)
+- `checkMessages()` - **ENABLED by default**, every 5 minutes
 
-Message polling was removed in favor of push notifications. When messages arrive, agents receive instant tmux notifications instead of waiting for the next poll cycle. To re-enable polling (not recommended), set `messagePollingEnabled: true` in the subconscious config.
+**This entry previously said polling was disabled and had been "replaced by push notifications". That was wrong, and the error mattered.** The code default is `config.messagePollingEnabled !== false` — i.e. on unless explicitly turned off — and the poll is not a legacy leftover. It is the fallback that actually delivers when a push wake reaches the pane but never submits.
+
+Measured on a customer estate (2026-09-02): four agents that a push wake had not woken all answered 4m22s–4m31s after the message, clustered within 9 seconds of each other. That is this 5-minute poll firing, not push. Anyone reading the old note would have believed there was no safety net underneath push — and would have drawn the wrong conclusion from an agent that "eventually" woke.
+
+Set `messagePollingEnabled: false` to turn it off. Do not, unless you have proven the push path submits on every agent in the fleet.
 
 ### 3. Session Discovery Pattern
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.9-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.10-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/sessions/[id]/command/route.ts
+++ b/app/api/sessions/[id]/command/route.ts
@@ -27,6 +27,7 @@ export async function POST(
     const result = await sendCommand(sessionName, body.command, {
       requireIdle: body.requireIdle,
       addNewline: body.addNewline,
+      verify: body.verify,
     })
 
     return toResponse(result)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.37.9
+**Current Version:** v0.37.10
 
 ---
 

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -49,7 +49,13 @@ interface AgentConfig {
 interface SubconsciousConfig {
   memoryCheckInterval?: number  // How often to check for new conversations (default: 5 minutes)
   messageCheckInterval?: number // How often to check for messages (default: 5 minutes) - DEPRECATED
-  messagePollingEnabled?: boolean // Enable message polling (default: false - use push notifications instead)
+  // Enable the 5-minute inbox poll. DEFAULT: ENABLED (`!== false` below).
+  // This comment previously claimed the default was false "because push
+  // notifications replace polling", and CLAUDE.md said the same. Both were
+  // wrong, and the error mattered: the poll is not a legacy leftover, it is the
+  // fallback that actually delivers when a push wake fails to submit. Anyone
+  // reading the old comment would have believed there was no safety net.
+  messagePollingEnabled?: boolean
   consolidationEnabled?: boolean // Enable long-term memory consolidation (default: true)
   consolidationHour?: number    // Hour of day to run consolidation (default: 2 = 2 AM)
 }
@@ -82,7 +88,7 @@ interface SubconsciousStatus {
   startedAt: number | null
   memoryCheckInterval: number
   messageCheckInterval: number
-  messagePollingEnabled: boolean  // false = using push notifications (default)
+  messagePollingEnabled: boolean  // default TRUE — see AgentConfig above
   activityState: 'active' | 'idle' | 'disconnected'
   staggerOffset: number
   lastMemoryRun: number | null
@@ -635,7 +641,14 @@ class AgentSubconscious {
         prompt = `${urgentFlag}You have ${unreadCount} new messages${sendersInfo}. Please check your inbox.`
       }
 
-      // Send the natural language prompt to Claude Code
+      // Send the natural language prompt to Claude Code.
+      //
+      // `verify: true` because this path had NO readback at all: it reported
+      // success on HTTP 200, which proves bytes reached tmux and nothing more.
+      // That is the same unearned claim the message-wake path was fixed for in
+      // 0.37.7, surviving in a second implementation nobody had looked at —
+      // and this is the one that actually delivers most of the time, because a
+      // push wake that fails to submit is rescued here five minutes later.
       const commandResponse = await fetch(
         `${getSelfApiBase()}/api/sessions/${encodeURIComponent(sessionName)}/command`,
         {
@@ -644,20 +657,29 @@ class AgentSubconscious {
           body: JSON.stringify({
             command: prompt.trim(),
             requireIdle: true,
-            addNewline: true  // Press Enter to submit the prompt to Claude
+            addNewline: true,  // Press Enter to submit the prompt to Claude
+            verify: true
           })
         }
       )
 
+      const tag = `[Agent ${this.agentId.substring(0, 8)}]`
       if (commandResponse.ok) {
         const result = await commandResponse.json()
-        if (result.success) {
-          console.log(`[Agent ${this.agentId.substring(0, 8)}] ✓ Sent message notification to Claude (${unreadCount} unread)`)
+        // Name the mechanism. Without this, a poll-delivered wake is
+        // indistinguishable in the logs from a push-delivered one, so "push
+        // works" stays an assumption instead of a measurement.
+        if (result.submitted) {
+          console.log(`${tag} ✓ Inbox poll wake SUBMITTED (${unreadCount} unread) — delivered by the 5-min poll, not by push`)
+        } else if (result.staged) {
+          console.warn(`${tag} ✗ Inbox poll wake STAGED in the input box, not submitted (${unreadCount} unread) — the agent has NOT seen it`)
+        } else if (result.success) {
+          console.log(`${tag} ~ Inbox poll wake sent, unverified (${unreadCount} unread)`)
         }
       } else {
         const result = await commandResponse.json()
         if (result.idle === false) {
-          console.log(`[Agent ${this.agentId.substring(0, 8)}] Session busy, skipping message notification`)
+          console.log(`${tag} Session busy, skipping message notification`)
         }
       }
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.9",
+  "version": "0.37.10",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -37,6 +37,7 @@ import { sessionActivity, agentActivity, terminalSessions, hookStatus as hookSta
 import { isSessionIdle, IDLE_THRESHOLD_MS } from '@/lib/session-idle'
 import { getRuntime } from '@/lib/agent-runtime'
 import { resolveProgramCommand, isNoProgram } from '@/lib/program-command'
+import { paneSubmitted, paneStaged } from '@/lib/notification-service'
 import crypto from 'crypto'
 import { type ServiceResult, missingField, notFound, alreadyExists, invalidField, operationFailed, serviceError } from '@/services/service-errors'
 
@@ -871,13 +872,26 @@ export async function renameSession(oldName: string, newName: string): Promise<S
 }
 
 /**
+ * Readback window for `sendCommand({ verify: true })`.
+ *
+ * Sized from the lesson 3Metas paid for: they judged four agents "deaf" using a
+ * 2m19s observation window when their own measured response time was 3m48s, and
+ * a window shorter than the thing it measures can only say ABSENT, never SLOW —
+ * so slow came back as absent. A TUI echo is sub-second, but 1s left no margin
+ * on a loaded host, and the cost of reading slow as absent here is a duplicate
+ * nudge on every busy agent.
+ */
+const COMMAND_VERIFY_POLLS = 12
+const COMMAND_VERIFY_DELAY_MS = 250
+
+/**
  * Send a command to a tmux session.
  */
 export async function sendCommand(
   sessionName: string,
   command: string,
-  options: { requireIdle?: boolean; addNewline?: boolean } = {}
-): Promise<ServiceResult<{ success: boolean; sessionName: string; commandSent?: string; method?: string; wasIdle?: boolean; idle?: boolean; timeSinceActivity?: number; idleThreshold?: number }>> {
+  options: { requireIdle?: boolean; addNewline?: boolean; verify?: boolean } = {}
+): Promise<ServiceResult<{ success: boolean; sessionName: string; commandSent?: string; method?: string; wasIdle?: boolean; idle?: boolean; timeSinceActivity?: number; idleThreshold?: number; submitted?: boolean; staged?: boolean }>> {
   const requireIdle = options.requireIdle !== false
   const addNewline = options.addNewline !== false
 
@@ -903,6 +917,31 @@ export async function sendCommand(
   await runtime.sendKeys(sessionName, command, { literal: true, enter: addNewline })
 
   sessionActivity.set(sessionName, Date.now())
+
+  // Opt-in readback. `sendKeys` returning proves bytes reached tmux and nothing
+  // more — the same unearned claim that made the message-wake path report eight
+  // deaf agents as delivered. This route is the 5-minute inbox poll's wake, and
+  // it was never verified at all, so it has been quietly reporting success for
+  // every nudge that staged in an input box and never submitted.
+  //
+  // Off by default: most callers (canvas, chat inject, meetings) send commands
+  // whose text is not expected to echo back the way a prompt does, and paying
+  // ~1s of polling for them would be waste.
+  if (options.verify && addNewline) {
+    let submitted = false
+    let staged = false
+    for (let poll = 0; poll < COMMAND_VERIFY_POLLS; poll++) {
+      await new Promise(resolve => setTimeout(resolve, COMMAND_VERIFY_DELAY_MS))
+      const pane = await runtime.capturePane(sessionName, 120).catch(() => '')
+      if (!pane) continue
+      if (paneSubmitted(pane, command)) { submitted = true; break }
+      if (paneStaged(pane, command)) { staged = true; break }
+    }
+    return {
+      data: { success: true, sessionName, commandSent: command, method: 'tmux-send-keys', wasIdle: true, submitted, staged },
+      status: 200,
+    }
+  }
 
   return { data: { success: true, sessionName, commandSent: command, method: 'tmux-send-keys', wasIdle: true }, status: 200 }
 }

--- a/tests/poll-wake-verification.test.ts
+++ b/tests/poll-wake-verification.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The SECOND wake path — the 5-minute inbox poll — and why it needed the same
+ * fix as the first.
+ *
+ * `Agent.checkMessages()` runs every 5 minutes, and when it finds unread mail
+ * it calls `triggerMessageCheck()`, which POSTs to the session command endpoint
+ * and reports success on HTTP 200. HTTP 200 proves `sendKeys` returned, which
+ * proves bytes reached tmux — exactly the unearned claim that made the message
+ * wake report eight deaf agents as delivered, surviving untouched in a second
+ * implementation nobody had looked at.
+ *
+ * It matters more than the first one, not less. When a push wake stages in an
+ * input box and never submits, THIS is what rescues it five minutes later —
+ * which is how the failure stayed invisible for months. Measured on a customer
+ * estate: four agents a push wake had not woken all answered 4m22s–4m31s after
+ * the message, clustered within 9 seconds. That is a 5-minute poll, not a push.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockRuntime = {
+  sendKeys: vi.fn().mockResolvedValue(undefined),
+  capturePane: vi.fn().mockResolvedValue(''),
+  sessionExists: vi.fn().mockResolvedValue(true),
+  cancelCopyMode: vi.fn().mockResolvedValue(undefined),
+}
+
+vi.mock('@/lib/agent-runtime', () => ({ getRuntime: vi.fn(() => mockRuntime) }))
+
+const state = vi.hoisted(() => ({ sessionActivity: new Map<string, number>(), agentActivity: new Map() }))
+vi.mock('@/services/shared-state', () => state)
+
+import { sendCommand } from '@/services/sessions-service'
+
+const SESSION = 'agent-0'
+const PROMPT = 'You have a new message from alice about "deploy failed". Please check your inbox.'
+
+/** Submitted: the prompt is echoed ABOVE the input box. */
+const SUBMITTED = `> ${PROMPT}\n\n  On it.\n\n╭────╮\n│ >  │\n╰────╯`
+/** Staged: it is still sitting IN the input box. */
+const STAGED = `  earlier output\n╭────╮\n│ > ${PROMPT}\n╰────╯`
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  state.sessionActivity.clear()
+  mockRuntime.sessionExists.mockResolvedValue(true)
+  mockRuntime.sendKeys.mockResolvedValue(undefined)
+})
+
+describe('sendCommand — unverified by default', () => {
+  it('does not read the pane back unless asked', async () => {
+    // Canvas, chat inject and meeting inject all use this route and send text
+    // that is not expected to echo like a prompt. Polling for them is waste.
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false })
+    expect(res.data).toMatchObject({ success: true })
+    expect(mockRuntime.capturePane).not.toHaveBeenCalled()
+  })
+
+  it('reports no verdict when it did not verify', async () => {
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false })
+    expect((res.data as any)?.submitted).toBeUndefined()
+    expect((res.data as any)?.staged).toBeUndefined()
+  })
+})
+
+describe('sendCommand — verify: true', () => {
+  it('confirms submission when the prompt lands above the input box', async () => {
+    mockRuntime.capturePane.mockResolvedValue(SUBMITTED)
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false, verify: true })
+    expect(res.data).toMatchObject({ submitted: true, staged: false })
+  })
+
+  it('reports STAGED when the prompt is still in the input box', async () => {
+    // This is the case the poll used to report as success.
+    mockRuntime.capturePane.mockResolvedValue(STAGED)
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false, verify: true })
+    expect(res.data).toMatchObject({ submitted: false, staged: true })
+  })
+
+  it('reports neither when the pane shows something else entirely', async () => {
+    mockRuntime.capturePane.mockResolvedValue('unrelated output\n> ')
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false, verify: true })
+    expect(res.data).toMatchObject({ submitted: false, staged: false })
+  })
+
+  it('still reports success — the send happened, only the proof is separate', async () => {
+    // `success` means the command was issued. It must never be read as
+    // "the agent received it"; that is what `submitted` is for.
+    mockRuntime.capturePane.mockResolvedValue(STAGED)
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false, verify: true })
+    expect(res.data).toMatchObject({ success: true })
+  })
+
+  it('waits for a slow render instead of calling it absent', async () => {
+    // The lesson 3Metas paid for: they judged four agents deaf using a 2m19s
+    // window when their own measured response time was 3m48s. A window shorter
+    // than the thing it measures can only say ABSENT, never SLOW.
+    mockRuntime.capturePane
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('  still rendering\n> ')
+      .mockResolvedValue(SUBMITTED)
+    const res = await sendCommand(SESSION, PROMPT, { requireIdle: false, verify: true })
+    expect(res.data).toMatchObject({ submitted: true })
+  })
+
+  it('does not verify when no Enter was sent — there is nothing to submit', async () => {
+    await sendCommand(SESSION, PROMPT, { requireIdle: false, verify: true, addNewline: false })
+    expect(mockRuntime.capturePane).not.toHaveBeenCalled()
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.9",
+  "version": "0.37.10",
   "releaseDate": "2026-09-02",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
3Metas retracted a message tonight. **The retraction was worth more than the claim.**

They had called four agents deaf using a 2m19s observation window and published it. Then all four answered:

```
probe sent                   21:39:08Z
their check window closed    21:41:27Z   2m19s   ← called them deaf
customers-intercambio-pm     21:43:30Z   4m22s
customers-zoom-pm            21:43:34Z   4m26s
ppm-app                      21:43:34Z   4m26s
3metas-tct                   21:43:39Z   4m31s
```

**That timing is the finding.** Four agents waking within 9 seconds of each other, ~4.5 minutes after the message, is not a push. It is a periodic pull — and it is ours. `messageCheckInterval` is `300000`.

## The second wake path had no proof at all

`Agent.checkMessages()` runs every 5 minutes. On finding unread mail it calls `triggerMessageCheck()`, which POSTs a "you have N unread" prompt to the session command endpoint — and `sendCommand` returned `success: true` the instant `sendKeys` returned.

That proves bytes reached tmux and nothing more. **It is the identical unearned claim fixed in [0.37.7](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.37.7) for the message-wake path, surviving untouched in a second implementation nobody had looked at.**

And it matters *more* than the first one, not less. When a push wake stages in an input box and never submits, **this is what rescues it five minutes later** — which is exactly how the failure stayed invisible for months. Messages did arrive. They arrived up to five minutes late, by a route nobody was watching, while the route everyone *was* watching reported success it had not earned.

`sendCommand` now accepts `verify: true` and returns `submitted` / `staged` from a real pane readback, reusing 0.37.7's proof-of-submission. Opt-in, so canvas, chat inject and meeting inject — which send text that is not expected to echo like a prompt — are unaffected and pay nothing.

## The poll now names itself

```
✓ Inbox poll wake SUBMITTED (2 unread) — delivered by the 5-min poll, not by push
✗ Inbox poll wake STAGED in the input box, not submitted — the agent has NOT seen it
```

Without this, a poll-delivered wake is indistinguishable in the logs from a push-delivered one, so *"push works"* stays an assumption instead of a measurement. I expect the first line to be common, and that is the point.

## Documentation that was actively misleading

`CLAUDE.md` and two comments in `lib/agent.ts` stated message polling was **disabled by default**, "replaced by push notifications".

The code has always been `config.messagePollingEnabled !== false` — **on unless explicitly disabled**. The poll is not a legacy leftover; it is the fallback that delivers when a push wake fails to submit. Anyone reading the docs would have concluded there was no safety net under push, and would have drawn the wrong conclusion from an agent that "eventually" woke. Corrected, with the measurement that proves it.

## The methodological point, which is the actual lesson

3Metas held the number that would have prevented their error — a measured 3m48s response time, which they had quoted to us in writing hours earlier — and chose a 2m19s window for a test of the same phenomenon.

> A negative result inside a window shorter than the known response time is not a result. It is the clock. We published it as biology. **The window could only say ABSENT, never SLOW — so slow came back as absent.**

That is the same defect these releases have been about throughout: an instrument that cannot express the thing it measures. Our own readback window was 1 second per send, sized against nothing in particular. It is now 12 × 250 ms with the reasoning written beside it, so the next person changing it knows what it has to outlast.

**1078 tests passing.** 8 new, including one asserting that a slow render is not reported as absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)