### PR TITLE
fix: ship the registration + stray-identity fixes to hosts (v0.37.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.13] - 2026-09-02 — Registration no longer looks like it failed, and a wrong guess stops inventing identities
+
+Reported by **salesland-dev-3metas** (Salesland iCPA, 3Metas) while registering a new agent against a local Maestro. Two bugs, and the root cause of the second turned out to be a directory-creation defect that has been quietly manufacturing garbage identities.
+
+Ships to hosts via [claude-plugin#27](https://github.com/agentmessaging/claude-plugin/pull/27) → [plugins#33](https://github.com/23blocks-OS/ai-maestro-plugins/pull/33) → this submodule bump. The upstream merge alone changes nothing on any machine.
+
+### Fixed
+- **A successfully registered agent reported `@default.local` everywhere a human would check.** `amp-register.sh` wrote `registrations/<provider>.json` and `IDENTITY.md` and called back to the Maestro API, but never touched `config.json` — so `amp-statusline`, `amp-identity` and `amp-inbox` all kept the pre-registration identity. The registration had genuinely succeeded; only the evidence of it was missing. Now patched surgically with `jq` (`.agent.tenant`, `.agent.address`, a `provider` block) rather than through `save_config`, which rebuilds the object and would drop `agent.id`, `fingerprint` and `createdAt` — the same destructive shape as the auto-fix removed in 0.37.8.
+- **`exit 0` having persisted nothing.** A first invocation could print "Updating identity file…" and exit clean with `registrations/` still empty; only a second run with `--force` worked. `set -e` does not catch it, because the failure is a `jq` that writes an *empty file* rather than a command returning non-zero. The success path now verifies the file exists and contains an `apiKey`, and exits 1 otherwise.
+- **The root cause of that: a wrong inference was manufacturing identities.** `amp-helper` resolves the agent from the working directory when nothing more explicit is available — a `.claude/settings.local.json` hint, else the agent that uniquely owns `$PWD`. That is an *inference about which agent a directory belongs to*, and it was being treated as licence to **create** that agent's identity. A hint naming an agent with no entry in this home fell through to the raw name path and auto-created an empty shell: `keys/`, `messages/`, `registrations/`, no config.
+
+  Reproduced from a clean home: **one `amp-init --name foo` produced two directories** — the real UUID one and a stray shell for an unrelated name — because `amp-init` overrides `AMP_DIR` only *after* the helper has already created the wrong one. That is also how a registration can land under one resolution while the operator inspects another.
+
+  These shells are not harmless: a later name-based resolution can select the empty shell over the real identity, which is one of the ways an agent ends up looking unregistered or reading an empty inbox.
+
+### Changed
+- **`amp-init` no longer depends on an inference firing.** Requiring the cwd hint to point at an existing identity exposed a latent dependency: init only worked because *something* resolved, so on a genuinely clean home with no project hint it would have failed outright. It now sets `AMP_ALLOW_UNRESOLVED=1`; every other script keeps refusing to guess.
+- `--help` documents that `--api-url` must include the API base. The script posts to `{API_URL}/v1/register`, so `http://localhost:23000` returns a 404 that reads like the provider is down — the failure sends you to inspect the wrong system entirely.
+
+### Verified
+End to end from a clean home: `amp-init` creates exactly one directory, `amp-register` updates `config.json`, and `amp-identity` reports `Tenant: rnd23blocks` rather than `default` — the reporter's exact symptom.
+
+### Notes
+- Upstream suite 211 passing, 13 new tests, including that the config patch preserves `agent.id` and `fingerprint`, and that a cwd hint for an unknown agent creates nothing.
+- The reporter's repro was precise enough to work from without a clarifying question. Their `--force` observation — *"since exit 0 is not trustworthy there"* — was the correct read of the failure and is what pointed at the root cause.
+
 ## [0.37.12] - 2026-09-02 — The five-minute poll was not the rescue, it was the same failure retried
 
 3Metas captured the verbatim staged text from eight panes this morning, read-only, before anything was cleared:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.12-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.13-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.37.12
+**Current Version:** v0.37.13
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.12",
+  "version": "0.37.13",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.12",
+  "version": "0.37.13",
   "releaseDate": "2026-09-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
[claude-plugin#27](https://github.com/agentmessaging/claude-plugin/pull/27) merged and [plugins#33](https://github.com/23blocks-OS/ai-maestro-plugins/pull/33) rebuilt. This bumps the submodule so hosts actually get them — the upstream merge alone changes nothing on any machine, because `install-plugin.sh` and the host updater read the **built** submodule.

Reported by **salesland-dev-3metas** (Salesland iCPA, 3Metas), both bugs confirmed by reading the success path.

## A registered agent looked unregistered

`amp-register.sh` wrote `registrations/<provider>.json` and `IDENTITY.md`, and called back to the Maestro API — but **never touched `config.json`**:

| tool | showed |
|---|---|
| `amp-statusline.sh` | `agent@default.local` |
| `amp-identity.sh` | `Tenant: default` |
| `amp-inbox.sh` | `Your address: agent@default.local` |

The registration had genuinely succeeded — apiKey issued, file present. Only the evidence of it was missing, in every place a human would think to look.

Patched surgically with `jq`, **not** `save_config`, which rebuilds the object and would drop `agent.id`, `fingerprint` and `createdAt` — the same destructive shape as the auto-fix removed in 0.37.8. Two tests pin that.

## `exit 0` having persisted nothing

A first invocation could print "Updating identity file…" and exit clean with `registrations/` still empty; only a second run with `--force` worked. `set -e` misses it because the failure is a `jq` that writes an **empty file** rather than a command returning non-zero.

The reporter's read — *"since exit 0 is not trustworthy there"* — was correct, and is what pointed at the root cause.

## The root cause: a wrong guess was inventing identities

`amp-helper` resolves the agent from the working directory when nothing more explicit is available — a `.claude/settings.local.json` hint, else the agent that uniquely owns `$PWD`. That is an **inference about which agent a directory belongs to**, and it was treated as licence to **create** that agent's identity.

Reproduced from a clean home:

```
$ amp-init --name zz-regtest --tenant rnd23blocks
$ ls ~/.agent-messaging/agents/
a6d187f3-34f6-4e96-9aa3-87be00d60ba7
ai-maestro                              ← stray shell, no config, never asked for
```

`amp-init` overrides `AMP_DIR` only *after* the helper has already created the wrong one. That is also how a registration lands under one resolution while the operator inspects another — the reporter's empty `registrations/`.

The shells are not harmless: a later name-based resolution can select the empty shell over the real identity, which is one of the ways an agent ends up looking unregistered or reading an empty inbox.

**Fix**: the cwd hint resolves only when the identity already exists. Otherwise the inference was wrong, and we fall through rather than manufacture one.

## A latent dependency that fix exposed

`amp-init` only worked because *something* resolved — it was relying on a cwd inference firing. On a genuinely clean home with no project hint it would have failed outright, and nobody knew, because the inference almost always fired.

It now sets `AMP_ALLOW_UNRESOLVED=1`. Every other script keeps refusing to guess.

## Verified

End to end from a clean home: `amp-init` creates **exactly one** directory, `amp-register` updates `config.json`, and `amp-identity` reports `Tenant: rnd23blocks` instead of `default` — the reporter's exact symptom, fixed and observed.

Upstream suite **211 passing** (13 new). App suite **1130 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)