### PR TITLE
fix(chat): do not type prose into a shell (#426) (v0.37.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.14] - 2026-09-02 — Prose typed into an agent no longer runs as shell commands (#426)
+
+Reported by **@Shadercloud** on a fresh install. They created an agent called Steve, sent it a sentence of ordinary English, and got:
+
+```
+david@David-Razer:~$ Steve you will be my second in command. When I say "Hire" an agent I actually mean "Create"…
+Steve: command not found
+david@David-Razer:~$ The first thing we need to do it setup an HR departmand hire and HR manager.
+Command 'The' not found, did you mean: command 'he' from deb node-he (1.2.0-4)
+```
+
+**Their prose was executed by bash, one line at a time.** Their question — *"Did I do something wrong in the installation?"* — deserved an answer, and the answer is no.
+
+### Fixed
+- **Session status `online` means the tmux session EXISTS, not that an agent is running in it.** Chat and meeting injection checked only that, so a pane sitting at a shell prompt accepted the message and the shell ran it. Both paths now refuse when the pane is visibly at a shell, and say what to do about it instead of failing cryptically.
+
+  The check is deliberately **asymmetric**: it does not try to prove an agent *is* running — there are too many agent CLIs, and a false negative would refuse to deliver to a working agent. It proves a **shell** is running, which is a short closed list (`bash`, `zsh`, `fish`, `login`, the `-bash` login forms…) and the only case that causes harm. Unknown occupants are allowed through, and any failure to introspect the pane allows through too: absence of evidence is not evidence.
+
+### Notes
+- The delivery layer behaved correctly throughout — the reporter saw *"Not confirmed — may not have reached the agent"*, which is exactly right and is the honesty work from 0.37.7–0.37.12 doing its job. What was missing was refusing to send at all, and explaining why.
+- This does **not** fix the underlying cause of their empty pane: the configured program never started, most likely because `claude` was not installed or not on `PATH` inside that tmux session, and the launch failure is currently swallowed with a warning. Surfacing that at creation time is the real fix and is not in this release — the guard stops the damage and names the likely cause, which is as far as it honestly goes.
+- 1160 tests passing, 30 new.
+
 ## [0.37.13] - 2026-09-02 — Registration no longer looks like it failed, and a wrong guess stops inventing identities
 
 Reported by **salesland-dev-3metas** (Salesland iCPA, 3Metas) while registering a new agent against a local Maestro. Two bugs, and the root cause of the second turned out to be a directory-creation defect that has been quietly manufacturing garbage identities.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.13-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.14-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.37.13
+**Current Version:** v0.37.14
 
 ---
 

--- a/lib/pane-occupant.ts
+++ b/lib/pane-occupant.ts
@@ -1,0 +1,72 @@
+/**
+ * What is actually running in an agent's pane.
+ *
+ * A tmux session existing does NOT mean an agent is running in it. Session
+ * status `online` means only that the session exists — so a pane sitting at a
+ * bare shell prompt passes every check we had, and anything injected into it is
+ * executed as shell commands.
+ *
+ * That is not hypothetical. Reported on a fresh install (#426): a user created
+ * an agent, sent it a sentence of ordinary English, and got
+ *
+ *     Steve: command not found
+ *     Command 'The' not found, did you mean: command 'he' from deb node-he
+ *
+ * Their prose was run by bash, one line at a time.
+ *
+ * The check here is deliberately asymmetric. We do NOT try to prove an agent is
+ * running — there are too many agent CLIs, and a false negative would refuse to
+ * deliver to a working agent. We prove the opposite: that a SHELL is running,
+ * which is a short, closed list and the only case that actually causes harm.
+ * Unknown occupants are allowed through.
+ */
+
+import { getRuntime } from '@/lib/agent-runtime'
+
+/**
+ * Shells, as tmux reports them in `pane_current_command`.
+ *
+ * A login shell can appear with a leading dash. `login` itself shows while a
+ * macOS Terminal session is still starting up.
+ */
+const SHELL_COMMANDS = new Set([
+  'bash', 'zsh', 'sh', 'fish', 'dash', 'ksh', 'tcsh', 'csh', 'ash',
+  '-bash', '-zsh', '-sh', 'login',
+])
+
+export function isShellCommand(command: string | undefined | null): boolean {
+  if (!command) return false
+  return SHELL_COMMANDS.has(command.trim().toLowerCase())
+}
+
+/**
+ * True only when we can SEE that the pane is sitting at a shell.
+ *
+ * Returns false when the runtime cannot introspect the pane, when the command
+ * is unrecognised, or on any error — absence of evidence is not evidence here,
+ * and refusing to deliver on a hunch would be worse than the bug this prevents.
+ */
+export async function isPaneAtBareShell(sessionName: string): Promise<boolean> {
+  try {
+    const runtime = getRuntime()
+    if (!runtime.describePane) return false
+    const info = await runtime.describePane(`${sessionName}:0.0`)
+    return isShellCommand(info?.command)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * What to tell someone whose agent has no program running.
+ *
+ * The reporter's question was "Did I do something wrong in the installation?" —
+ * so the message names the actual state and the actual next step, rather than
+ * failing with something they would have to interpret.
+ */
+export const BARE_SHELL_MESSAGE =
+  'The agent\'s session is sitting at a shell prompt — no agent program is running in it, ' +
+  'so this message would be executed as shell commands instead of read. ' +
+  'Wake the agent (or start its program in the Terminal tab). ' +
+  'If waking does not help, the configured program is probably not installed or not on PATH ' +
+  'in that session — check the Terminal tab and try running it by hand.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.13",
+  "version": "0.37.14",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/services/agents-chat-service.ts
+++ b/services/agents-chat-service.ts
@@ -7,6 +7,7 @@
 
 import { getAgent } from '@/lib/agent-registry'
 import { getRuntime } from '@/lib/agent-runtime'
+import { isPaneAtBareShell, BARE_SHELL_MESSAGE } from '@/lib/pane-occupant'
 import {
   enqueueForSession,
   shouldUseAdditionalContext,
@@ -179,11 +180,20 @@ export async function sendChatMessage(
     return invalidRequest('Agent session is not online')
   }
 
+  // `online` means the tmux session EXISTS, not that an agent is running in it.
+  // Without this guard a pane sitting at a shell prompt accepts the message and
+  // bash executes it — reported on a fresh install (#426) as
+  // "Steve: command not found".
+  if (await isPaneAtBareShell(sessionName)) {
+    console.warn(`[Chat Service] Refusing to send to ${sessionName}: pane is at a bare shell`)
+    return invalidRequest(BARE_SHELL_MESSAGE)
+  }
+
   const runtime = getRuntime()
   await runtime.cancelCopyMode(sessionName)
   await runtime.sendKeys(sessionName, message, { literal: true, enter: true })
 
-  console.log('[Chat Service] Message sent successfully')
+  console.log('[Chat Service] Message handed to the pane')
 
   return {
     data: {
@@ -249,6 +259,13 @@ export async function injectMeetingPrompt(
       data: { success: true, queued: true, sessionName },
       status: 200
     }
+  }
+
+  // Same guard as the chat path: a meeting prompt typed into a shell is
+  // executed, not read.
+  if (await isPaneAtBareShell(sessionName)) {
+    console.warn(`[Meeting Inject] Refusing to inject into ${sessionName}: pane is at a bare shell`)
+    return invalidRequest(BARE_SHELL_MESSAGE)
   }
 
   // ── Legacy path: sanitize + bracketed paste + send-keys ───────────

--- a/tests/pane-occupant.test.ts
+++ b/tests/pane-occupant.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for lib/pane-occupant.ts — do not type prose into a shell.
+ *
+ * Reported on a fresh install (#426). A user created an agent, sent it a
+ * sentence of ordinary English through the chat box, and got:
+ *
+ *     Steve: command not found
+ *     Command 'The' not found, did you mean: command 'he' from deb node-he
+ *
+ * Their prose was executed by bash, one line at a time, because session status
+ * `online` means only that the TMUX SESSION EXISTS — not that an agent is
+ * running in it. A pane sitting at a shell prompt passed every check.
+ *
+ * The check is deliberately asymmetric: it does not try to prove an agent is
+ * running (too many CLIs, and a false negative would refuse to deliver to a
+ * working agent). It proves a SHELL is running, which is a short closed list
+ * and the only case that causes harm.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockRuntime: { describePane?: ReturnType<typeof vi.fn> } = {
+  describePane: vi.fn(),
+}
+vi.mock('@/lib/agent-runtime', () => ({ getRuntime: () => mockRuntime }))
+
+import { isShellCommand, isPaneAtBareShell, BARE_SHELL_MESSAGE } from '@/lib/pane-occupant'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRuntime.describePane = vi.fn()
+})
+
+describe('isShellCommand', () => {
+  it.each(['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh', 'tcsh', 'csh', 'ash'])(
+    'recognises %s',
+    (shell) => expect(isShellCommand(shell)).toBe(true)
+  )
+
+  it.each(['-bash', '-zsh', '-sh'])('recognises the login form %s', (shell) => {
+    expect(isShellCommand(shell)).toBe(true)
+  })
+
+  it('recognises login, which shows while a session is still starting', () => {
+    expect(isShellCommand('login')).toBe(true)
+  })
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(isShellCommand(' BASH ')).toBe(true)
+  })
+
+  it.each(['node', 'claude', '2.1.252', 'python3', 'codex', 'nvim'])(
+    'does NOT claim %s is a shell',
+    (cmd) => expect(isShellCommand(cmd)).toBe(false)
+  )
+
+  it('treats nothing as not-a-shell', () => {
+    expect(isShellCommand(undefined)).toBe(false)
+    expect(isShellCommand(null)).toBe(false)
+    expect(isShellCommand('')).toBe(false)
+  })
+})
+
+describe('isPaneAtBareShell', () => {
+  it('is true when the pane is sitting at a shell', async () => {
+    mockRuntime.describePane = vi.fn().mockResolvedValue({ command: 'bash' })
+    expect(await isPaneAtBareShell('steve')).toBe(true)
+  })
+
+  it('is false when an agent occupies the pane', async () => {
+    // Claude Code reports its version as the command name.
+    mockRuntime.describePane = vi.fn().mockResolvedValue({ command: '2.1.252' })
+    expect(await isPaneAtBareShell('steve')).toBe(false)
+  })
+
+  it('is false for an UNKNOWN occupant — absence of evidence is not evidence', async () => {
+    // Refusing to deliver on a hunch would be worse than the bug this prevents.
+    mockRuntime.describePane = vi.fn().mockResolvedValue({ command: 'some-new-agent-cli' })
+    expect(await isPaneAtBareShell('steve')).toBe(false)
+  })
+
+  it('is false when the runtime cannot introspect the pane', async () => {
+    delete mockRuntime.describePane
+    expect(await isPaneAtBareShell('steve')).toBe(false)
+  })
+
+  it('is false when introspection throws', async () => {
+    mockRuntime.describePane = vi.fn().mockRejectedValue(new Error('no such session'))
+    expect(await isPaneAtBareShell('steve')).toBe(false)
+  })
+
+  it('is false when the pane reports no command at all', async () => {
+    mockRuntime.describePane = vi.fn().mockResolvedValue({})
+    expect(await isPaneAtBareShell('steve')).toBe(false)
+  })
+
+  it('inspects the first pane of the first window', async () => {
+    mockRuntime.describePane = vi.fn().mockResolvedValue({ command: 'zsh' })
+    await isPaneAtBareShell('steve')
+    expect(mockRuntime.describePane).toHaveBeenCalledWith('steve:0.0')
+  })
+})
+
+describe('the message shown to the user', () => {
+  it('names the actual state rather than failing cryptically', () => {
+    expect(BARE_SHELL_MESSAGE).toMatch(/shell prompt/i)
+    expect(BARE_SHELL_MESSAGE).toMatch(/executed as shell commands/i)
+  })
+
+  it('gives the next step, because the reporter asked what they did wrong', () => {
+    // "Did I do something wrong in the installation?" deserves an answer, not
+    // an error code.
+    expect(BARE_SHELL_MESSAGE).toMatch(/wake the agent/i)
+    expect(BARE_SHELL_MESSAGE).toMatch(/PATH/)
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.13",
+  "version": "0.37.14",
   "releaseDate": "2026-09-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Closes #426, reported by **@Shadercloud** on a fresh install.

They created an agent called Steve, sent him a sentence of ordinary English through the chat box, and got this in the Terminal tab:

```
david@David-Razer:~$ Steve you will be my second in command. When I say "Hire" an agent I actually mean "Create"…
Steve: command not found
david@David-Razer:~$ The first thing we need to do it setup an HR departmand hire and HR manager.
Command 'The' not found, did you mean: command 'he' from deb node-he (1.2.0-4)
```

**Their prose was executed by bash, one line at a time.**

Their question was *"Did I do something wrong in the installation?"* — and the answer is no, they did not.

## Cause

`online` means the **tmux session exists**. It does not mean an agent is running in it. Chat and meeting injection checked only `agent.sessions?.some(s => s.status === 'online')`, so a pane sitting at a shell prompt passed every check, and `sendKeys(…, { literal: true, enter: true })` handed the user's sentence to bash.

## Fix

Both paths now refuse when the pane is visibly at a shell, and say what to do:

> The agent's session is sitting at a shell prompt — no agent program is running in it, so this message would be executed as shell commands instead of read. Wake the agent (or start its program in the Terminal tab). If waking does not help, the configured program is probably not installed or not on PATH in that session…

The check is **deliberately asymmetric**, and that is the design decision worth reviewing:

- It does **not** try to prove an agent *is* running. There are too many agent CLIs, they report themselves inconsistently (Claude Code shows up as its version string), and a false negative would refuse to deliver to a perfectly healthy agent.
- It proves a **shell** is running — a short closed list (`bash`, `zsh`, `fish`, `dash`, the `-bash` login forms, `login`) — which is the only case that actually causes harm.
- Unknown occupants pass. Failure to introspect the pane passes. Absence of evidence is not evidence, and refusing on a hunch would be worse than the bug.

## What this does not fix, stated plainly

The **underlying cause of their empty pane**: the configured program never started, most likely `claude` not installed or not on `PATH` inside that tmux session. That launch failure is currently caught and downgraded to a `console.warn`, so nothing tells the user.

Surfacing it at creation time is the real fix and is not in this release. The guard stops the damage and names the likely cause, which is as far as this honestly goes.

## Worth noting

The delivery layer behaved correctly throughout — the reporter saw *"Not confirmed — may not have reached the agent"*, which is exactly right, and is the honesty work from 0.37.7–0.37.12 doing its job. What was missing was refusing to send at all, and explaining why.

**1160 tests passing**, 30 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)