### PR TITLE
fix(hook): detached agents were never told they had mail (v0.37.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.37.16] - 2026-09-02 — Detached agents were never told they had mail
+
+Juan asked the question that broke this open: *"why when you got a message are you not notified? neither by the hook or the poll or whatever it is"*.
+
+The `ai-maestro` agent had been receiving messages all day and had to be told to check its inbox by hand, every single time. Three delivery routes, all correct, all silent.
+
+### The diagnosis
+| route | why it could not reach a detached agent |
+|---|---|
+| push (`notification-service`) | needs a tmux pane. `sessions: 0` — there is nothing to type into |
+| 5-min poll (`Agent.checkMessages`) | needs a session name. Same |
+| **Stop hook** | needs no pane — but could not work out **which agent it was** |
+
+The hook is the only route that does not need a pane: it returns `{ decision: "block", reason }` and Claude Code renders it. So it is the only route that can reach a session which is not tmux-managed, and it was the one that failed.
+
+### Fixed
+- **Two environment variable names for one concept.** The documented detached-session hint in `.claude/settings.local.json` writes **`CLAUDE_AGENT_NAME`** — which is what the AMP tooling reads — while the hook looked only for **`AIM_AGENT_NAME`**, the name its own launcher sets. So the hint was ignored, resolution fell through to matching the working directory, three registered agents shared that directory, and the hook **correctly refused to guess**.
+
+  Correct refusal at every step, and the agent still never heard a thing. The hook now accepts either.
+
+### Verified
+Running the hook against a real Stop event, before and after:
+
+```
+$ echo '{"hook_event_name":"Stop",...}' | CLAUDE_AGENT_NAME=ai-maestro node ai-maestro-hook.cjs
+{"decision":"block","reason":"[AMP] You have 2 unread messages in your inbox: …"}
+
+$ echo '{"hook_event_name":"Stop",...}' | env -u CLAUDE_AGENT_NAME … node ai-maestro-hook.cjs
+{}
+```
+
+### Notes
+- This is not the dropped-Enter class these releases have been about. Nothing was staged, nothing failed to submit; the message simply never had a route. Worth separating, because it means "the wake is unreliable" was covering for a second, unrelated silence.
+- Any detached or manually-started Claude Code session sharing a working directory with more than one registered agent had this. Sessions launched by AI Maestro were unaffected — the launcher sets `AIM_AGENT_NAME`.
+- Hook synced to both plugin copies per the single-source rule; `tests/plugin-hook-sync.test.ts` covers the drift.
+- 1167 tests passing, 7 new on agent resolution.
+
 ## [0.37.15] - 2026-09-02 — Correcting the attribution in 0.37.12, and a third writer nobody had counted
 
 3Metas checked a claim I had accepted without checking, and it was wrong. Correcting the record rather than leaving it standing in a shipped release.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.37.15-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.37.16-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.37.15
+**Current Version:** v0.37.16
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.37.15",
+  "version": "0.37.16",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -49,7 +49,8 @@ function hashCwd(cwd) {
 }
 
 // Resolve the agent for this hook invocation.
-// Priority: AIM_AGENT_ID env (exact) > AIM_AGENT_NAME env (exact) > cwd exact match.
+// Priority: AIM_AGENT_ID env (exact) > AIM_AGENT_NAME / CLAUDE_AGENT_NAME env
+// (exact) > cwd exact match.
 function resolveAgent(cwd, agents) {
     const envId = process.env.AIM_AGENT_ID;
     if (envId) {
@@ -59,7 +60,18 @@ function resolveAgent(cwd, agents) {
             return byId;
         }
     }
-    const envName = process.env.AIM_AGENT_NAME;
+    // AIM_AGENT_NAME is what AI Maestro's launcher sets. CLAUDE_AGENT_NAME is
+    // what the AMP tooling reads and what the documented detached-session hint
+    // in .claude/settings.local.json actually writes — so accept both.
+    //
+    // Two names for one concept is how a detached session ends up with no
+    // identity at all: the hint file said CLAUDE_AGENT_NAME=ai-maestro, this
+    // function only looked for AIM_AGENT_NAME, fell through to the cwd match,
+    // found three agents sharing that directory, and correctly refused to
+    // guess. The result was an agent that received messages and was never once
+    // told about them, because the ONE delivery route that does not need a tmux
+    // pane could not work out who it was talking to.
+    const envName = process.env.AIM_AGENT_NAME || process.env.CLAUDE_AGENT_NAME;
     if (envName) {
         const byName = agents.find(a => a.name === envName);
         if (byName) {

--- a/tests/ai-maestro-hook.test.ts
+++ b/tests/ai-maestro-hook.test.ts
@@ -103,3 +103,82 @@ describe('ai-maestro-hook · buildAmpBlockReason', () => {
     expect(reason).toContain('from alice (rnd23blocks)')
   })
 })
+
+/**
+ * Agent resolution for DETACHED sessions — why an agent can receive messages
+ * for a whole day and never once be told.
+ *
+ * The Stop hook is the only delivery route that does not need a tmux pane: it
+ * returns `{ decision: "block", reason }` and Claude Code renders it. So it is
+ * the ONLY route that can reach a session which is not tmux-managed.
+ *
+ * It could not reach them, for a reason that has nothing to do with delivery:
+ * two different environment variable names for one concept. The documented
+ * detached-session hint in .claude/settings.local.json writes
+ * CLAUDE_AGENT_NAME — which is what the AMP tooling reads — while this hook
+ * looked only for AIM_AGENT_NAME, the name its own launcher sets. So the hint
+ * was ignored, resolution fell through to matching the working directory,
+ * three registered agents shared that directory, and the hook correctly
+ * refused to guess.
+ *
+ * Correct refusal, right down the line, and the agent still never heard a thing.
+ */
+describe('resolveAgent — detached sessions', () => {
+  const AGENTS = [
+    { id: 'aaa', name: 'agents-web', workingDirectory: '/repo' },
+    { id: 'bbb', name: 'ai-maestro', workingDirectory: '/repo' },
+    { id: 'ccc', name: 'maestro', workingDirectory: '/repo' },
+    { id: 'ddd', name: 'solo', workingDirectory: '/solo' },
+  ]
+
+  /** Mirrors resolveAgent in scripts/claude-hooks/ai-maestro-hook.cjs. */
+  function resolveAgent(cwd: string, agents: typeof AGENTS, env: Record<string, string> = {}) {
+    if (env.AIM_AGENT_ID) {
+      const byId = agents.find(a => a.id === env.AIM_AGENT_ID)
+      if (byId) return byId
+    }
+    const envName = env.AIM_AGENT_NAME || env.CLAUDE_AGENT_NAME
+    if (envName) {
+      const byName = agents.find(a => a.name === envName)
+      if (byName) return byName
+    }
+    const matches = agents.filter(a => a.workingDirectory === cwd)
+    return matches.length === 1 ? matches[0] : null
+  }
+
+  it('accepts CLAUDE_AGENT_NAME, which is what the hint file actually writes', () => {
+    // The whole bug: this returned null before, so the one pane-independent
+    // delivery route went silent for every detached session.
+    expect(resolveAgent('/repo', AGENTS, { CLAUDE_AGENT_NAME: 'ai-maestro' })?.name).toBe('ai-maestro')
+  })
+
+  it('still accepts AIM_AGENT_NAME, which the launcher sets', () => {
+    expect(resolveAgent('/repo', AGENTS, { AIM_AGENT_NAME: 'ai-maestro' })?.name).toBe('ai-maestro')
+  })
+
+  it('prefers an explicit id over any name', () => {
+    expect(
+      resolveAgent('/repo', AGENTS, { AIM_AGENT_ID: 'ccc', CLAUDE_AGENT_NAME: 'ai-maestro' })?.name
+    ).toBe('maestro')
+  })
+
+  it('AIM_AGENT_NAME wins over CLAUDE_AGENT_NAME when both are set', () => {
+    expect(
+      resolveAgent('/repo', AGENTS, { AIM_AGENT_NAME: 'maestro', CLAUDE_AGENT_NAME: 'ai-maestro' })?.name
+    ).toBe('maestro')
+  })
+
+  it('refuses to guess when several agents share the directory', () => {
+    // Correct, and worth keeping: guessing would silently misattribute the
+    // session to the wrong agent, which is worse than no identity.
+    expect(resolveAgent('/repo', AGENTS, {})).toBeNull()
+  })
+
+  it('still resolves an unambiguous directory with no hint at all', () => {
+    expect(resolveAgent('/solo', AGENTS, {})?.name).toBe('solo')
+  })
+
+  it('falls back to cwd when the hint names an agent that does not exist', () => {
+    expect(resolveAgent('/solo', AGENTS, { CLAUDE_AGENT_NAME: 'ghost' })?.name).toBe('solo')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.15",
+  "version": "0.37.16",
   "releaseDate": "2026-09-03",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Juan asked the question that broke this open:

> why when you got a message are you not notified? neither by the hook or the poll or whatever it is

The `ai-maestro` agent had been receiving messages all day and had to be told to check its inbox by hand, every single time. **Three delivery routes, all correct, all silent.**

## Diagnosis

| route | why it could not reach a detached agent |
|---|---|
| push (`notification-service`) | needs a tmux pane. `sessions: 0` — nothing to type into |
| 5-min poll (`Agent.checkMessages`) | needs a session name. Same |
| **Stop hook** | needs no pane — but could not work out **which agent it was** |

The hook is the only route that does not need a pane: it returns `{ decision: "block", reason }` and Claude Code renders it. For a session that is not tmux-managed it is *the only route there is* — and it was the one that failed.

## Cause: two env var names for one concept

The documented detached-session hint in `.claude/settings.local.json` writes **`CLAUDE_AGENT_NAME`** — which is what the AMP tooling reads. The hook looked only for **`AIM_AGENT_NAME`**, the name its own launcher sets.

So the hint was ignored, resolution fell through to matching the working directory, three registered agents shared that directory (`agents-web`, `ai-maestro`, `maestro`), and the hook **correctly refused to guess** rather than misattribute the session.

Correct refusal at every single step, and the agent still never heard a thing.

## Verified against a real Stop event

```
$ echo '{"hook_event_name":"Stop",…}' | CLAUDE_AGENT_NAME=ai-maestro node ai-maestro-hook.cjs
{"decision":"block","reason":"[AMP] You have 2 unread messages in your inbox:
  1. from pas-lola — \"ATTACHMENT UPLOAD ENDPOINT IS 404 ON THIS MESH…\"
  2. from ai-maestro-app — \"Re: Live Agent: animated talking avatars…\"
Read and respond to these now using the agent-messaging skill…"}

$ echo '{"hook_event_name":"Stop",…}' | env -u CLAUDE_AGENT_NAME … node ai-maestro-hook.cjs
{}
```

## Worth separating from the rest of this week

**This is not the dropped-Enter class.** Nothing was staged, nothing failed to submit — the message simply never had a route. That matters, because *"the wake is unreliable"* was covering for a second, unrelated silence, and the two need different fixes.

Any detached or manually-started Claude Code session sharing a working directory with more than one registered agent had this. Sessions launched by AI Maestro were unaffected, since the launcher sets `AIM_AGENT_NAME` — which is exactly why it went unnoticed.

Hook synced to both plugin copies per the single-source rule; submodule bumped via [plugins#34](https://github.com/23blocks-OS/ai-maestro-plugins/pull/34).

**1167 tests passing**, 7 new on agent resolution — including that it still refuses to guess on an ambiguous directory, because that behaviour is correct and worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)