### PR TITLE
fix(hook): the inbox nudge reads properly when the label truncates it (v0.38.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.38.1] - 2026-09-04 — The inbox nudge reads properly when the label truncates it
+
+Reported from the receiving end: the notification showed up as
+
+```
+Stop hook error: [A
+```
+
+Two separate things, and only one of them is ours.
+
+**"Stop hook error" is Claude Code's label** for any Stop hook returning `decision: block`. We cannot change that wording, and it is misleading here — nothing failed. `block` is the documented way for a hook to hand work back to an agent, and it is the only AMP delivery route that needs no tmux pane.
+
+**"[A" was ours.** Claude Code renders the start of the reason string, truncated to the label width, and we led with a bracketed tag — so the characters that survived carried no information at all.
+
+### Changed
+- The blocking reason now leads with the count instead of `[AMP]`:
+
+  | width | before | after |
+  |---|---|---|
+  | 4 | `[AMP` | `1 un` |
+  | 12 | `[AMP] You ha` | `1 unread AMP` |
+  | 20 | `[AMP] You have 1 unr` | `1 unread AMP message` |
+
+  Urgency still appears in the header (`3 unread AMP messages in your inbox (1 urgent):`), since that is the one thing worth interrupting for.
+
+### Notes
+- A reason string that is also a UI label has two audiences: the agent reading the whole thing, and a human reading the first dozen characters. The second one had not been considered.
+- Hook synced to both plugin copies per the single-source rule. 1247 tests passing, 4 new pinning the truncation behaviour.
+
 ## [0.38.0] - 2026-09-04 — Attachments actually work, and a failed program launch is no longer silent
 
 Two tracks. The first makes agents able to exchange files; the second stops the class of failure that made creating an agent feel broken.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.38.0-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.38.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.38.0
+**Current Version:** v0.38.1
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/claude-hooks/ai-maestro-hook.cjs
+++ b/scripts/claude-hooks/ai-maestro-hook.cjs
@@ -393,9 +393,21 @@ function saveNotifiedIds(cwd, ids) {
 // to read + respond before going idle.
 function buildAmpBlockReason(messages) {
     const urgentCount = messages.filter(m => m.priority === 'urgent').length;
+    // Lead with the count and the word, not a bracketed tag.
+    //
+    // Claude Code renders a Stop hook's `decision: block` as "Stop hook error:"
+    // followed by the start of this string, TRUNCATED to the label width. We
+    // cannot change its wording (nothing failed here — block is the documented
+    // way to hand work back to an agent), but we choose what survives the
+    // truncation. Leading with "[AMP]" made the label read
+    //
+    //     Stop hook error: [A
+    //
+    // which tells the reader nothing at all. Putting the count first means even
+    // a dozen characters carry the message: "1 unread AMP m…".
     const header = messages.length === 1
-        ? `[AMP] You have 1 unread message in your inbox:`
-        : `[AMP] You have ${messages.length} unread messages in your inbox${urgentCount > 0 ? ` (${urgentCount} urgent)` : ''}:`;
+        ? `1 unread AMP message in your inbox:`
+        : `${messages.length} unread AMP messages in your inbox${urgentCount > 0 ? ` (${urgentCount} urgent)` : ''}:`;
     const lines = messages.slice(0, 10).map((m, i) => {
         const urgent = m.priority === 'urgent' ? '[URGENT] ' : '';
         const subj = m.subject ? ` — "${m.subject}"` : '';

--- a/tests/ai-maestro-hook.test.ts
+++ b/tests/ai-maestro-hook.test.ts
@@ -45,7 +45,7 @@ describe('ai-maestro-hook · decideStopDelivery', () => {
     const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: false, messages: [msg('1'), msg('2')], alreadyIds: [] })
     expect(d.block).toBe(true)
     expect(d.response.decision).toBe('block')
-    expect(d.response.reason).toContain('2 unread messages')
+    expect(d.response.reason).toContain('2 unread AMP messages')
     expect(d.freshIds).toEqual(['1', '2'])
   })
 
@@ -53,7 +53,7 @@ describe('ai-maestro-hook · decideStopDelivery', () => {
     const d = hook.decideStopDelivery({ agent: 'claude', stopHookActive: false, messages: [msg('1'), msg('2')], alreadyIds: ['1'] })
     expect(d.block).toBe(true)
     expect(d.freshIds).toEqual(['2'])
-    expect(d.response.reason).toContain('1 unread message')
+    expect(d.response.reason).toContain('1 unread AMP message')
   })
 
   it('does NOT block when every unread message was already surfaced', () => {
@@ -80,21 +80,21 @@ describe('ai-maestro-hook · buildAmpBlockReason', () => {
   it('flags a single urgent message and points at the agent-messaging skill', () => {
     const reason = hook.buildAmpBlockReason([msg('1', { priority: 'urgent' })])
     expect(reason).toContain('[URGENT]')
-    expect(reason).toContain('1 unread message in your inbox')
+    expect(reason).toContain('1 unread AMP message in your inbox')
     expect(reason).toContain('agent-messaging skill')
     expect(reason).toContain('amp-inbox.sh')
   })
 
   it('counts urgent messages in the plural header', () => {
     const reason = hook.buildAmpBlockReason([msg('1', { priority: 'urgent' }), msg('2')])
-    expect(reason).toContain('2 unread messages')
+    expect(reason).toContain('2 unread AMP messages')
     expect(reason).toContain('(1 urgent)')
   })
 
   it('caps the listed messages at 10 and notes the remainder', () => {
     const many = Array.from({ length: 13 }, (_, i) => msg(String(i)))
     const reason = hook.buildAmpBlockReason(many)
-    expect(reason).toContain('13 unread messages')
+    expect(reason).toContain('13 unread AMP messages')
     expect(reason).toContain('…and 3 more')
   })
 
@@ -180,5 +180,43 @@ describe('resolveAgent — detached sessions', () => {
 
   it('falls back to cwd when the hint names an agent that does not exist', () => {
     expect(resolveAgent('/solo', AGENTS, { CLAUDE_AGENT_NAME: 'ghost' })?.name).toBe('solo')
+  })
+})
+
+/**
+ * The blocking reason is also a UI label.
+ *
+ * Claude Code renders a Stop hook's `decision: block` as "Stop hook error:"
+ * followed by the START of this string, truncated to the label width. We cannot
+ * change its wording — and "error" is misleading, since nothing failed — but we
+ * choose what survives the truncation.
+ *
+ * Leading with a bracketed tag made the label read `Stop hook error: [A`, which
+ * tells the reader nothing. Leading with the count means even a few characters
+ * carry the message.
+ */
+describe('buildAmpBlockReason — reads correctly when truncated', () => {
+  const msg = (id: string, extra: Record<string, unknown> = {}) => ({
+    id, from: 'alice', fromAlias: 'alice', subject: 'Deploy failed', ...extra,
+  })
+
+  it('leads with the count, not a bracketed tag', () => {
+    const reason = hook.buildAmpBlockReason([msg('1')])
+    expect(reason.startsWith('1 unread AMP message')).toBe(true)
+    expect(reason.startsWith('[')).toBe(false)
+  })
+
+  it('is informative at a dozen characters', () => {
+    // The width at which the old header still read "[AMP] You ha".
+    expect(hook.buildAmpBlockReason([msg('1')]).slice(0, 12)).toBe('1 unread AMP')
+  })
+
+  it('carries the count for several messages', () => {
+    expect(hook.buildAmpBlockReason([msg('1'), msg('2'), msg('3')]).slice(0, 8)).toBe('3 unread')
+  })
+
+  it('still names urgency, which is the one thing worth interrupting for', () => {
+    const reason = hook.buildAmpBlockReason([msg('1', { priority: 'urgent' }), msg('2')])
+    expect(reason).toContain('(1 urgent)')
   })
 })

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0",
+  "version": "0.38.1",
   "releaseDate": "2026-09-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Reported from the receiving end — the notification arrived looking like this:

```
Stop hook error: [A
```

Two separate things, and only one of them is ours.

## "Stop hook error" is Claude Code's label

It applies to **any** Stop hook returning `decision: block`, and we cannot change the wording. It is also misleading: nothing failed. `block` is the documented mechanism for a hook to hand work back to an agent, and it is the **only** AMP delivery route that needs no tmux pane — the one that made detached agents reachable at all in v0.37.16.

## "[A" was ours

Claude Code renders the *start* of the reason string, truncated to the label width. We led with a bracketed tag, so the characters that survived carried no information whatsoever.

| width | before | after |
|---|---|---|
| 4 | `[AMP` | `1 un` |
| 12 | `[AMP] You ha` | `1 unread AMP` |
| 20 | `[AMP] You have 1 unr` | `1 unread AMP message` |

Urgency still appears in the header — `3 unread AMP messages in your inbox (1 urgent):` — since that is the one thing worth interrupting for.

## The general point

A reason string that doubles as a UI label has **two audiences**: the agent, which reads all of it, and a human, who reads the first dozen characters. Only the first had been considered.

Hook synced to both plugin copies per the single-source rule; submodule bumped via [plugins#35](https://github.com/23blocks-OS/ai-maestro-plugins/pull/35).

**1247 tests passing**, 4 new pinning the truncation behaviour so it cannot silently regress.