### PR TITLE
fix(release): bump-version.sh stops reporting work it did not do (#375) (v0.38.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.38.2] - 2026-09-04 — The version bumper stops reporting work it did not do (#375)
+
+[#375](https://github.com/23blocks-OS/ai-maestro/issues/375) reported `package.json` frozen at `0.29.16` for fifteen releases while every run printed **"✓ Updated N files"**. That specific case had already been fixed. **The mechanism behind it had not**, and it was still live in three places — including the source of truth.
+
+Reproduced on a scratch checkout with three drifted files. The script reported `Updated 3 files`, exited **0**, and had changed none of them.
+
+### Fixed
+- **`update_file` skipped silently on a pattern miss.** A file that had drifted stayed drifted forever and never appeared in the output. It now distinguishes *absent* (a legitimate slim clone — fine) from *present but not matching* (a file that was supposed to be updated and was not — a failure), and **verifies the substitution actually took** rather than assuming `sed` succeeded.
+- **`docs/BACKLOG.md` printed a tick unconditionally.** It ran `sed` and claimed success whether or not anything changed — not a silent skip but a false claim, and the reason that header had to be corrected by hand after every single release in this cycle.
+- **`version.json` — the source of truth — was updated by an unchecked `sed`** keyed on `"version": "x"`, with a space after the colon. Reformat the file (jq, a merge, an editor) and the pattern stops matching: the version freezes at whatever it was, **every subsequent bump reads that stale value as `CURRENT_VERSION`**, and every release still reports success. It is now updated structurally with `node` — the same fix already applied to `package.json` — and read back to confirm before anything else runs.
+- **A partial bump now exits non-zero and names every file it could not update.** A bump that half-applies is worse than one that refuses, because the drift compounds silently across every release that follows. That is exactly how fifteen releases shipped with a frozen `package.json`.
+
+### And it immediately found four more frozen files
+The first run of the fixed script on this repo reported four files it could not update — **all stuck at `0.29.16`**, the same version the issue reported for `package.json`:
+
+```
+✗ scripts/remote-install.sh
+✗ docs/index.html (schema)
+✗ docs/index.html (display)
+✗ docs/ai-index.html
+```
+
+So the reporter found one symptom of a freeze that had actually hit **five** files. `scripts/remote-install.sh` is the public installer, which has been advertising `0.29.16` to every new user since April. All four are repaired here, and the bumper now completes with no misses.
+
+### Notes
+- 10 new tests in `tests/bump-version.test.ts`, driving the real script in a scratch checkout. **5 of them fail against the previous version**, including the compact-JSON case that silently froze `version.json`.
+- This is the same defect as the rest of this cycle, in the release tooling itself: a step that reports success it has not earned. It was reported in May and the reporter was right about the mechanism, not only the symptom.
+
 ## [0.38.1] - 2026-09-04 — The inbox nudge reads properly when the label truncates it
 
 Reported from the receiving end: the notification showed up as

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.38.1-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.38.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.38.1
+**Current Version:** v0.38.2
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.29.16",
+      "softwareVersion": "0.38.2",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The OS for AI-first organizations. Build and run your AI company with any agent (Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes) from one dashboard. You're the CEO, your agents are the team.",
-      "softwareVersion": "0.29.16",
+      "softwareVersion": "0.38.2",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -453,7 +453,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.29.16</span>
+                        <span>v0.38.2</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -97,27 +97,73 @@ _sed_inplace() {
     sed -i.bak "$@" "$file" && rm -f "${file}.bak"
 }
 
+# Files that were present but could not be updated. A non-empty list fails the
+# run — see the note at the bottom of this function.
+FILES_MISSED=()
+
 update_file() {
     local file="$1"
     local pattern="$2"
     local replacement="$3"
     local description="$4"
 
-    if [ -f "$file" ]; then
-        if grep -q "$pattern" "$file" 2>/dev/null; then
-            _sed_inplace "$file" "s|$pattern|$replacement|g"
-            echo -e "  ${GREEN}✓${NC} $description"
-            FILES_UPDATED=$((FILES_UPDATED + 1))
-        fi
+    # A file that is not in this checkout is not a failure — docs/ are optional
+    # in some clones. A file that IS here and does not contain the version we
+    # expected IS a failure, and used to be silent.
+    if [ ! -f "$file" ]; then
+        return 0
     fi
+
+    if ! grep -q "$pattern" "$file" 2>/dev/null; then
+        echo -e "  ${YELLOW}!${NC} $description — expected version not found, NOT updated"
+        FILES_MISSED+=("$description")
+        return 0
+    fi
+
+    _sed_inplace "$file" "s|$pattern|$replacement|g"
+
+    # Verify rather than assume. sed can match the grep pattern and still fail to
+    # substitute (an unescaped delimiter in the replacement, for instance), and
+    # a bump that reports success it did not earn is exactly how package.json sat
+    # at 0.29.16 for fifteen releases while every run printed a tick.
+    if grep -q "$pattern" "$file" 2>/dev/null; then
+        echo -e "  ${YELLOW}!${NC} $description — substitution did not take, NOT updated"
+        FILES_MISSED+=("$description")
+        return 0
+    fi
+
+    echo -e "  ${GREEN}✓${NC} $description"
+    FILES_UPDATED=$((FILES_UPDATED + 1))
 }
 
 echo "Updating files..."
 echo ""
 
-# 1. version.json
-_sed_inplace "$VERSION_FILE" "s|\"version\": \"$CURRENT_VERSION\"|\"version\": \"$NEW_VERSION\"|g"
-_sed_inplace "$VERSION_FILE" "s|\"releaseDate\": \"[^\"]*\"|\"releaseDate\": \"$(date -u +%Y-%m-%d)\"|g"
+# 1. version.json — the source of truth, so update it STRUCTURALLY.
+#
+# This used an unchecked sed keyed on `"version": "x"` with a space after the
+# colon, and printed a tick unconditionally. Reformat the file (jq, a merge, an
+# editor) and the pattern stops matching: the version would freeze at whatever
+# it was, every subsequent bump would read that same stale value as
+# CURRENT_VERSION, and every release would still report success. That is the
+# package.json failure again, on the one file everything else is derived from.
+node -e "
+  const fs = require('fs');
+  const f = process.argv[1];
+  const v = JSON.parse(fs.readFileSync(f, 'utf8'));
+  v.version = process.argv[2];
+  v.releaseDate = process.argv[3];
+  fs.writeFileSync(f, JSON.stringify(v, null, 2) + '\n');
+" "$VERSION_FILE" "$NEW_VERSION" "$(date -u +%Y-%m-%d)"
+
+# Read it back. Claiming a bump that did not land is how the drift starts.
+WROTE_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).version)" "$VERSION_FILE" 2>/dev/null || echo "")
+if [ "$WROTE_VERSION" != "$NEW_VERSION" ]; then
+    echo -e "  ${RED}✗${NC} version.json — wrote $NEW_VERSION but file reads '$WROTE_VERSION'"
+    echo ""
+    echo -e "${RED}Aborting: the source of truth was not updated.${NC}"
+    exit 1
+fi
 echo -e "  ${GREEN}✓${NC} version.json"
 FILES_UPDATED=$((FILES_UPDATED + 1))
 
@@ -164,14 +210,36 @@ update_file "$PROJECT_ROOT/docs/ai-index.html" \
     "docs/ai-index.html"
 
 # 8. docs/BACKLOG.md (current version header)
-if [ -f "$PROJECT_ROOT/docs/BACKLOG.md" ]; then
-    _sed_inplace "$PROJECT_ROOT/docs/BACKLOG.md" "s|\*\*Current Version:\*\* v$CURRENT_VERSION|\*\*Current Version:\*\* v$NEW_VERSION|g"
-    echo -e "  ${GREEN}✓${NC} docs/BACKLOG.md (header)"
-    FILES_UPDATED=$((FILES_UPDATED + 1))
-fi
+#
+# This ran sed unconditionally and printed a tick whether or not anything
+# changed — not a silent skip but an outright false claim, and the reason the
+# header had to be corrected by hand after every release.
+update_file "$PROJECT_ROOT/docs/BACKLOG.md" \
+    "\*\*Current Version:\*\* v$CURRENT_VERSION" \
+    "**Current Version:** v$NEW_VERSION" \
+    "docs/BACKLOG.md (header)"
 
 echo ""
 echo -e "${GREEN}Updated $FILES_UPDATED files${NC}"
+
+# Fail loudly on anything we were supposed to update and did not.
+#
+# The whole point: a bump that half-applies is worse than one that refuses,
+# because the drift compounds silently over every subsequent release. This is
+# what let package.json sit at 0.29.16 for fifteen releases while the script
+# reported success each time.
+if [ ${#FILES_MISSED[@]} -gt 0 ]; then
+    echo ""
+    echo -e "${RED}${#FILES_MISSED[@]} file(s) were NOT updated:${NC}"
+    for missed in "${FILES_MISSED[@]}"; do
+        echo -e "  ${RED}✗${NC} $missed"
+    done
+    echo ""
+    echo "These files did not contain version $CURRENT_VERSION, so they had already"
+    echo "drifted. Fix them by hand, then re-run — version.json now says $NEW_VERSION."
+    exit 1
+fi
+
 echo ""
 
 # Show what changed

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.29.16"
+VERSION="0.38.2"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/tests/bump-version.test.ts
+++ b/tests/bump-version.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for scripts/bump-version.sh — issue #375.
+ *
+ * The reported symptom was `package.json` frozen at 0.29.16 for fifteen
+ * releases while every run printed "✓ Updated N files". That specific case had
+ * already been fixed; the mechanism behind it had not, and it was still live in
+ * three places:
+ *
+ *   - `update_file` skipped silently whenever its grep missed, so any file that
+ *     had drifted stayed drifted forever and never appeared in the output;
+ *   - `docs/BACKLOG.md` ran sed unconditionally and printed a tick whether or
+ *     not anything changed — not a silent skip but a false claim, and the
+ *     reason that header had to be corrected by hand after every release;
+ *   - `version.json`, the SOURCE OF TRUTH, was updated by an unchecked sed
+ *     keyed on `"version": "x"` with a space after the colon. Reformat the file
+ *     and the version freezes at whatever it was, every subsequent bump reads
+ *     that stale value as CURRENT_VERSION, and every release still reports
+ *     success.
+ *
+ * A bump that half-applies is worse than one that refuses, because the drift
+ * compounds silently over every release that follows.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'bump-version.sh')
+
+let dir: string
+
+/** A checkout where every file agrees on `version`. */
+function seed(version: string, overrides: Record<string, string> = {}) {
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true })
+  fs.copyFileSync(SCRIPT, path.join(dir, 'scripts', 'bump-version.sh'))
+
+  const files: Record<string, string> = {
+    'version.json': JSON.stringify({ version, releaseDate: '2026-01-01', keep: 'me' }, null, 2) + '\n',
+    'package.json': JSON.stringify({ name: 'x', version }, null, 2) + '\n',
+    'README.md': `![version](https://img.shields.io/badge/version-${version}-blue)\n`,
+    'docs/BACKLOG.md': `**Current Version:** v${version}\n`,
+    'scripts/remote-install.sh': `VERSION="${version}"\n`,
+    ...overrides,
+  }
+  for (const [name, body] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), body)
+  }
+}
+
+function bump(): { status: number; out: string } {
+  try {
+    const out = execFileSync('bash', ['scripts/bump-version.sh', 'patch'], {
+      cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return { status: 0, out }
+  } catch (e: any) {
+    return { status: e.status ?? 1, out: `${e.stdout || ''}${e.stderr || ''}` }
+  }
+}
+
+const read = (f: string) => fs.readFileSync(path.join(dir, f), 'utf8')
+const versionOf = (f: string) => JSON.parse(read(f)).version
+
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bumpver-')) })
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+describe('every file aligned — the happy path', () => {
+  it('bumps all of them and succeeds', () => {
+    seed('1.2.3')
+    const { status } = bump()
+    expect(status).toBe(0)
+    expect(versionOf('version.json')).toBe('1.2.4')
+    expect(versionOf('package.json')).toBe('1.2.4')
+    expect(read('README.md')).toContain('version-1.2.4-')
+    expect(read('docs/BACKLOG.md')).toContain('v1.2.4')
+    expect(read('scripts/remote-install.sh')).toContain('1.2.4')
+  })
+
+  it('preserves unrelated fields in version.json', () => {
+    seed('1.2.3')
+    bump()
+    expect(JSON.parse(read('version.json')).keep).toBe('me')
+  })
+
+  it('stamps the release date', () => {
+    seed('1.2.3')
+    bump()
+    expect(JSON.parse(read('version.json')).releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('a drifted file must fail the run, not be skipped', () => {
+  it('exits non-zero rather than reporting success', () => {
+    // The heart of #375: this used to exit 0 having silently skipped the file.
+    seed('1.2.3', { 'README.md': '![version](https://img.shields.io/badge/version-0.1.0-blue)\n' })
+    expect(bump().status).not.toBe(0)
+  })
+
+  it('names the file that was not updated', () => {
+    seed('1.2.3', { 'README.md': '![version](https://img.shields.io/badge/version-0.1.0-blue)\n' })
+    const { out } = bump()
+    expect(out).toContain('NOT updated')
+    expect(out).toContain('README.md')
+  })
+
+  it('names EVERY drifted file, not just the first', () => {
+    seed('1.2.3', {
+      'README.md': 'badge/version-0.1.0-blue\n',
+      'scripts/remote-install.sh': 'VERSION="0.1.0"\n',
+      'docs/BACKLOG.md': '**Current Version:** v0.1.0\n',
+    })
+    const { out } = bump()
+    expect(out).toContain('3 file(s) were NOT updated')
+  })
+
+  it('does NOT count a drifted file as updated', () => {
+    // It used to print a tick for BACKLOG.md whether or not anything changed.
+    seed('1.2.3', { 'docs/BACKLOG.md': '**Current Version:** v0.1.0\n' })
+    const { out } = bump()
+    expect(read('docs/BACKLOG.md')).toContain('v0.1.0')
+    expect(out).not.toMatch(/✓.*BACKLOG/)
+  })
+})
+
+describe('version.json is the source of truth and is verified', () => {
+  it('updates it even when the JSON is formatted differently', () => {
+    // The old sed keyed on `"version": "x"` — a space after the colon. Compact
+    // JSON silently froze the version while the script printed a tick.
+    seed('1.2.3', { 'version.json': '{"version":"1.2.3","releaseDate":"2026-01-01","keep":"me"}\n' })
+    const { status } = bump()
+    expect(status).toBe(0)
+    expect(versionOf('version.json')).toBe('1.2.4')
+  })
+
+  it('does not corrupt the file it rewrites', () => {
+    seed('1.2.3', { 'version.json': '{"version":"1.2.3","releaseDate":"2026-01-01","keep":"me"}\n' })
+    bump()
+    expect(() => JSON.parse(read('version.json'))).not.toThrow()
+    expect(JSON.parse(read('version.json')).keep).toBe('me')
+  })
+})
+
+describe('an absent optional file is not a failure', () => {
+  it('succeeds when docs/ is simply not in this checkout', () => {
+    // Missing and drifted are different: one is a legitimate slim clone, the
+    // other is a file that was supposed to be updated and was not.
+    seed('1.2.3')
+    fs.rmSync(path.join(dir, 'docs', 'BACKLOG.md'))
+    expect(bump().status).toBe(0)
+    expect(versionOf('version.json')).toBe('1.2.4')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1",
+  "version": "0.38.2",
   "releaseDate": "2026-09-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Closes #375.

The issue reported `package.json` frozen at `0.29.16` for fifteen releases while every run printed **"✓ Updated N files"**. That specific case had already been fixed — but **the mechanism behind it had not**, and it was still live in three places, including the source of truth.

Reproduced on a scratch checkout with three drifted files:

```
✓ version.json
✓ package.json
✓ docs/BACKLOG.md (header)     ← printed a tick. Did not change the file.
Updated 3 files
$ echo $?
0
```

Three files drifted, none updated, exit 0.

## What was wrong

**`update_file` skipped silently on a pattern miss.** A file that had drifted stayed drifted forever and never appeared in the output. It now distinguishes *absent* (a legitimate slim clone — fine) from *present but not matching* (a file that was supposed to be updated and was not — a failure), and **verifies the substitution actually took** rather than assuming `sed` succeeded.

**`docs/BACKLOG.md` printed a tick unconditionally** — `sed` ran and success was claimed whether or not anything changed. Not a silent skip but a false claim, and the reason that header needed hand-correcting after every release in this cycle. I had been papering over it by hand all day without noticing why.

**`version.json` — the source of truth — used an unchecked `sed`** keyed on `"version": "x"` with a space after the colon. Reformat the file (jq, a merge, an editor) and the pattern stops matching: the version freezes, **every subsequent bump reads that stale value as `CURRENT_VERSION`**, and every release still reports success. Now updated structurally with `node` — the same fix already applied to `package.json` — and read back to confirm before anything else runs.

**A partial bump now exits non-zero** and names every file it could not update. A bump that half-applies is worse than one that refuses, because the drift compounds silently across every release that follows. That is precisely how fifteen releases shipped with a frozen `package.json`.

## The fix immediately found four more frozen files

First run on this repo:

```
✗ scripts/remote-install.sh
✗ docs/index.html (schema)
✗ docs/index.html (display)
✗ docs/ai-index.html
```

**All four stuck at `0.29.16`** — the same version the issue reported for `package.json`.

So the reporter found one symptom of a freeze that had actually hit **five** files. `scripts/remote-install.sh` is the **public installer**, which has been advertising `0.29.16` to every new user since April.

All four repaired in this PR; the bumper now completes all eight files with no misses.

## Tests

10 new in `tests/bump-version.test.ts`, driving the real script in a scratch checkout. **5 fail against the previous version**, including the compact-JSON case that silently froze `version.json` and the BACKLOG tick that was never earned.

**1257 passing** overall.

## Why this one matters beyond itself

It is the same defect as the rest of this cycle — a step reporting success it has not earned — sitting in the release tooling, where it silently corrupted the metadata of every release it touched. It was reported in May, and the reporter was right about the mechanism, not just the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)