### PR TITLE
fix(install): configure AMP command permissions with consent (#337) (v0.38.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.38.3] - 2026-09-04 — AMP commands no longer stop at a permission dialog nobody is watching (#337)
+
+[#337](https://github.com/23blocks-OS/ai-maestro/issues/337) reported that Claude Code prompts for approval on every AMP command. The friction is the visible part; the real cost is that **it breaks unattended message handling entirely** — the inbox poll injects "check your inbox", the agent tries to run `amp-inbox.sh`, and the run stops at a dialog nobody is watching. The message stays unread and nothing reports a problem.
+
+Both remedies the issue proposed are implemented.
+
+### Added
+- **`install-plugin.sh` offers to configure the permissions, with consent.** It shows exactly what would be added, asks (or applies under `-y`), backs up `settings.json` first, and merges structurally with `node` rather than appending — that file also holds the Stop hook that delivers messages to detached agents, and corrupting it would silence them completely. Re-running reports "already configured" instead of asking again.
+- **The AMP skill documents the same setup** as a required step, for anyone not using AI Maestro's installer ([claude-plugin#28](https://github.com/agentmessaging/claude-plugin/pull/28)).
+
+### What is allowed, and what deliberately is not
+| | commands | reasoning |
+|---|---|---|
+| allowed | `amp-inbox`, `amp-read`, `amp-reply`, `amp-send`, `amp-download`, `amp-status`, `amp-fetch`, `amp-identity` | the routine loop an agent must complete without a human |
+| **not** | `amp-init`, `amp-register` | they mutate the agent's identity, and after the defects fixed in 0.37.13 that is a boundary worth keeping a human on |
+| **not** | `amp-delete` | deleting mail is irreversible, and losing messages is the exact failure this cycle has been about |
+
+Each command is allowed in three invocation forms — bare, `CLAUDE_AGENT_NAME=`, and `AMP_DIR=` — because agents are launched in different ways.
+
+### Notes
+- The hand-applied workaround on the dev machine covered **3 of 12** commands and omitted `amp-send.sh`, which agents use constantly. That is the sort of gap a documented-and-installed list closes and a manual one does not.
+- Verified against a `settings.json` already containing hand-added entries, a Stop hook and a statusLine: 21 entries merged onto 3, no duplicates, hook and statusLine intact, exclusions honoured, and idempotent on a second run.
+
 ## [0.38.2] - 2026-09-04 — The version bumper stops reporting work it did not do (#375)
 
 [#375](https://github.com/23blocks-OS/ai-maestro/issues/375) reported `package.json` frozen at `0.29.16` for fifteen releases while every run printed **"✓ Updated N files"**. That specific case had already been fixed. **The mechanism behind it had not**, and it was still live in three places — including the source of truth.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.38.2-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.38.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.38.2
+**Current Version:** v0.38.3
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.38.2",
+      "softwareVersion": "0.38.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The OS for AI-first organizations. Build and run your AI company with any agent (Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes) from one dashboard. You're the CEO, your agents are the team.",
-      "softwareVersion": "0.38.2",
+      "softwareVersion": "0.38.3",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -453,7 +453,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.38.2</span>
+                        <span>v0.38.3</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/install-plugin.sh
+++ b/install-plugin.sh
@@ -861,6 +861,113 @@ if [ "$INSTALL_SCRIPTS" = true ] && command -v amp-statusline.sh &> /dev/null; t
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# Claude Code permissions for the AMP read-and-respond loop (issue #337)
+# ---------------------------------------------------------------------------
+#
+# Without these, Claude Code asks for approval every single time an agent runs
+# amp-inbox.sh or amp-read.sh. That is not merely annoying — it BLOCKS the
+# subconscious inbox poll, because the injected "check your inbox" prompt makes
+# the agent try to run a command it then cannot run unattended. Messages sit
+# unread behind a dialog nobody is watching.
+#
+# What is allowed, and what deliberately is not:
+#
+#   allowed   inbox, read, reply, send, download, status, fetch, identity
+#             — the routine loop an agent must complete without a human
+#   NOT       amp-init.sh, amp-register.sh — these mutate the agent's identity,
+#             and after the identity defects fixed in 0.37.13 that is a boundary
+#             worth keeping a human on
+#   NOT       amp-delete.sh — deleting mail is irreversible, and losing messages
+#             is the exact failure this release cycle has been about
+#
+# Each command is allowed in three invocation forms, because agents are launched
+# in different ways: bare, and with the CLAUDE_AGENT_NAME= or AMP_DIR= prefix
+# that AI Maestro's launcher and the detached-session hint use.
+configure_amp_permissions() {
+    local settings="$HOME/.claude/settings.json"
+    local cmds=(amp-inbox.sh amp-read.sh amp-reply.sh amp-send.sh amp-download.sh amp-status.sh amp-fetch.sh amp-identity.sh)
+
+    local entries=()
+    for c in "${cmds[@]}"; do
+        entries+=("Bash(${c}:*)")
+        entries+=("Bash(CLAUDE_AGENT_NAME=* ${c}:*)")
+        entries+=("Bash(AMP_DIR=* ${c}:*)")
+    done
+
+    # What is genuinely missing? Re-running the installer must not re-ask.
+    local missing=()
+    for e in "${entries[@]}"; do
+        if [ -f "$settings" ] && node -e "
+            const fs=require('fs');
+            let s={}; try { s = JSON.parse(fs.readFileSync(process.argv[1],'utf8')); } catch (_) {}
+            const allow = (s.permissions && s.permissions.allow) || [];
+            process.exit(allow.includes(process.argv[2]) ? 0 : 1);
+        " "$settings" "$e" 2>/dev/null; then
+            continue
+        fi
+        missing+=("$e")
+    done
+
+    if [ ${#missing[@]} -eq 0 ]; then
+        print_success "AMP permissions already configured (${#entries[@]} entries)"
+        return 0
+    fi
+
+    echo ""
+    print_info "Claude Code asks for approval every time an agent runs an AMP command."
+    echo "  That blocks the subconscious inbox poll, so messages sit unread behind a"
+    echo "  dialog nobody is watching."
+    echo ""
+    echo "  ${#missing[@]} permission entries would be added to ${settings}:"
+    echo "    amp-inbox, amp-read, amp-reply, amp-send, amp-download, amp-status, amp-fetch, amp-identity"
+    echo ""
+    echo "  NOT included, on purpose: amp-init and amp-register (they change the"
+    echo "  agent's identity) and amp-delete (deleting mail is irreversible)."
+    echo ""
+
+    if [ "$NON_INTERACTIVE" != true ]; then
+        read -r -p "  Add these permissions? [Y/n] " reply
+        case "$reply" in
+            [Nn]*)
+                print_warning "Skipped. Agents will prompt on every AMP command."
+                echo "  Re-run this installer, or add them by hand under permissions.allow"
+                return 0
+                ;;
+        esac
+    fi
+
+    mkdir -p "$(dirname "$settings")"
+    [ -f "$settings" ] && cp "$settings" "${settings}.bak-$(date +%Y%m%d%H%M%S)"
+
+    # Merge structurally. A sed/append would corrupt the file or duplicate
+    # entries, and this file also holds the Stop hook that delivers messages to
+    # detached agents — breaking it would silence them entirely.
+    if node -e "
+        const fs = require('fs');
+        const file = process.argv[1];
+        const add = process.argv.slice(2);
+        let s = {};
+        if (fs.existsSync(file)) {
+            try { s = JSON.parse(fs.readFileSync(file, 'utf8')); }
+            catch (e) { console.error('settings.json is not valid JSON: ' + e.message); process.exit(1); }
+        }
+        s.permissions = s.permissions || {};
+        const allow = new Set(s.permissions.allow || []);
+        for (const a of add) allow.add(a);
+        s.permissions.allow = [...allow];
+        fs.writeFileSync(file, JSON.stringify(s, null, 2) + '\n');
+    " "$settings" "${missing[@]}"; then
+        print_success "Added ${#missing[@]} AMP permission entries to settings.json"
+    else
+        print_warning "Could not update ${settings} — add the entries by hand"
+    fi
+}
+
+if [ "$INSTALL_SCRIPTS" = true ]; then
+    configure_amp_permissions
+fi
+
 echo ""
 echo "╔════════════════════════════════════════════════════════════════╗"
 echo "║                    Installation Complete!                      ║"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.38.2"
+VERSION="0.38.3"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.2",
+  "version": "0.38.3",
   "releaseDate": "2026-09-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Closes #337. Both remedies the issue proposed are implemented.

## Why this is more than friction

The issue title says AMP commands prompt on every use. The visible cost is annoyance; the real one is that **unattended message handling cannot work at all**.

The inbox poll injects "check your inbox", the agent tries to run `amp-inbox.sh`, and the run stops at an approval dialog nobody is watching. The message stays unread and **nothing reports a problem** — which is the same shape as everything else fixed this cycle.

## 1. The installer offers to configure it

`install-plugin.sh` now shows exactly what would be added, asks (or applies under `-y`), backs up `settings.json`, and **merges structurally with `node`** rather than appending.

That last point matters: `~/.claude/settings.json` also holds the Stop hook that delivers messages to detached agents. A `sed`/append that corrupted it would silence them completely.

Re-running reports "already configured" rather than asking again.

## 2. The skill documents it

[claude-plugin#28](https://github.com/agentmessaging/claude-plugin/pull/28) adds it as a required-setup section, for anyone not using AI Maestro's installer.

## What is allowed, and what deliberately is not

| | commands | reasoning |
|---|---|---|
| allowed | `amp-inbox`, `amp-read`, `amp-reply`, `amp-send`, `amp-download`, `amp-status`, `amp-fetch`, `amp-identity` | the routine loop an agent must complete without a human |
| **not** | `amp-init`, `amp-register` | they mutate the agent's identity — after the defects fixed in 0.37.13, a boundary worth keeping a human on |
| **not** | `amp-delete` | deleting mail is irreversible, and losing messages is the exact failure this cycle has been about |

Each in three invocation forms — bare, `CLAUDE_AGENT_NAME=`, `AMP_DIR=` — because agents are launched in different ways.

## Verified

Against a `settings.json` already containing hand-added entries, a Stop hook and a statusLine:

```
first run:   ✓ Added 21 AMP permission entries
second run:  ✓ AMP permissions already configured (24 entries)

entries: 24          no duplicates: true
hook preserved: yes  statusLine preserved: yes
amp-send now allowed: true
amp-init NOT allowed: true
amp-delete NOT allowed: true
```

## One thing the issue could not have known

The hand-applied workaround on the dev machine covered **3 of 12** commands and omitted `amp-send.sh` — which agents use constantly. That is the gap a documented-and-installed list closes and a manual one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)