### PR TITLE
fix(ui): surface a failed program launch where people actually are (#441) (v0.38.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.38.4] - 2026-09-04 — A failed program launch is now visible where people actually are (#441)
+
+[v0.38.0](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.38.0) made the API report `programStarted: false` with a reason. **Nothing displayed it**, so the dashboard still showed a healthy-looking agent and someone had to read the API response or the server log to find out. That is the half the reporter of [#426](https://github.com/23blocks-OS/ai-maestro/issues/426) would actually have seen.
+
+### Added
+- **The first-agent onboarding wizard** shows it on the success screen. This is the most important of the three: it is someone's very first agent, and #426 was reported by a user in exactly that position whose first message was executed by bash. The heading changes from *"ready to help you build amazing things"* to *"created, but its AI program did not start"*, with the reason and what to do next.
+- **The agent creation wizard** shows the same warning on its success screen — the agent genuinely exists, so this is a warning rather than a failure, and the wizard no longer implies everything is fine.
+- **Waking an agent** raises a 15-second warning toast. The wake path only checked `!response.ok`, so a wake returning **HTTP 200 with `programStarted: false`** was treated as complete success and said nothing at all.
+
+All three name the consequence rather than just the fault: *the terminal is at a shell prompt, so anything sent now would be run as a shell command instead of read.*
+
+### Verified end to end
+Creating an agent configured with `aider`, which is not installed on this machine:
+
+```json
+{
+  "success": true,
+  "programStarted": false,
+  "programError": "\"aider\" did not start: the program is not on PATH inside the tmux session. tmux starts a non-login shell, so a PATH exported from ~/.bash_profile or ~/.profile is not present — move it to ~/.bashrc (or ~/.zshrc), or check the program is installed at all.",
+  "shellSaid": "zsh: command not found: aider"
+}
+```
+
+Control, with a program that is installed: `programStarted: true`, no warning.
+
+### Notes
+- This closes the case that started with a fresh install and ends with a configured-but-missing framework: choosing `aider`, `codex`, `cursor` or a wrapper you have not installed used to be **indistinguishable from a working agent** at every layer — service, API and UI.
+- 1257 tests passing.
+
 ## [0.38.3] - 2026-09-04 — AMP commands no longer stop at a permission dialog nobody is watching (#337)
 
 [#337](https://github.com/23blocks-OS/ai-maestro/issues/337) reported that Claude Code prompts for approval on every AMP command. The friction is the visible part; the real cost is that **it breaks unattended message handling entirely** — the inbox poll injects "check your inbox", the agent tries to run `amp-inbox.sh`, and the run stops at a dialog nobody is watching. The message stays unread and nothing reports a problem.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.38.3-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.38.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -527,9 +527,24 @@ export default function DashboardPage() {
         body: JSON.stringify(body),
       })
 
+      const data = await response.json().catch(() => ({}))
+
       if (!response.ok) {
-        const data = await response.json()
         throw new Error(data.message || data.error || 'Failed to wake agent')
+      }
+
+      // A wake can succeed while the agent's PROGRAM does not start — the tmux
+      // session comes up and the pane sits at a shell. Until v0.38.0 that was
+      // swallowed entirely; the API now reports it, and this is where a person
+      // finds out. Without this the agent appears in the list looking healthy
+      // and the first thing typed at it is executed by bash (#426).
+      if (data?.programStarted === false && data?.programError) {
+        addToast({
+          type: 'warning',
+          title: `${agent.alias || agent.name} woke, but its program did not start`,
+          message: data.programError,
+          duration: 15000,
+        })
       }
 
       refreshAgents()

--- a/components/AgentCreationWizard.tsx
+++ b/components/AgentCreationWizard.tsx
@@ -233,6 +233,11 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
   const [creationSuccess, setCreationSuccess] = useState(false)
   const [showLetsGo, setShowLetsGo] = useState(false)
   const [creationError, setCreationError] = useState('')
+  // The agent was created but its PROGRAM did not start. Not a failure — the
+  // agent exists — but the pane is a bare shell, so anything typed at it would
+  // be executed by the shell rather than read (#426). Shown on the success
+  // screen rather than swallowed.
+  const [creationWarning, setCreationWarning] = useState('')
 
   // Input state
   const [nameInput, setNameInput] = useState('')
@@ -431,9 +436,12 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
             program,
           }),
         })
+        const data = await response.json().catch(() => ({}))
         if (!response.ok) {
-          const data = await response.json()
           throw new Error(data.message || data.error || 'Failed to create agent')
+        }
+        if (data?.programStarted === false && data?.programError) {
+          setCreationWarning(data.programError)
         }
       }
       setCreationSuccess(true)
@@ -573,6 +581,18 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
                     >
                       Let&apos;s Go!
                     </button>
+                  </div>
+                )}
+                {creationWarning && (
+                  <div className="mt-4 mx-auto max-w-md rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-left">
+                    <p className="text-amber-300 text-sm font-semibold mb-1">
+                      Created, but the program did not start
+                    </p>
+                    <p className="text-amber-200/80 text-xs leading-relaxed">{creationWarning}</p>
+                    <p className="text-amber-200/60 text-xs mt-2">
+                      The agent exists, but its terminal is sitting at a shell prompt — messages
+                      sent to it now would be run as shell commands, not read.
+                    </p>
                   </div>
                 )}
                 {creationError && (

--- a/components/onboarding/FirstAgentWizard.tsx
+++ b/components/onboarding/FirstAgentWizard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { X, Check, AlertCircle, Terminal } from 'lucide-react'
+import { X, Check, AlertCircle, Terminal, AlertTriangle } from 'lucide-react'
 import CreateAgentAnimation from '../CreateAgentAnimation'
 
 interface FirstAgentWizardProps {
@@ -11,6 +11,7 @@ interface FirstAgentWizardProps {
 
 export default function FirstAgentWizard({ onComplete, onCancel }: FirstAgentWizardProps) {
   const [step, setStep] = useState<'name' | 'directory' | 'creating' | 'success'>('name')
+  const [programWarning, setProgramWarning] = useState('')
   const [agentName, setAgentName] = useState('')
   const [workingDirectory, setWorkingDirectory] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -81,9 +82,16 @@ export default function FirstAgentWizard({ onComplete, onCancel }: FirstAgentWiz
         }),
       })
 
+      const data = await response.json().catch(() => ({}))
       if (!response.ok) {
-        const data = await response.json()
         throw new Error(data.message || data.error || 'Failed to create agent')
+      }
+      // The agent was created but its program did not start — the pane is a
+      // bare shell. This is the first agent someone ever makes, so it is the
+      // worst possible place to stay silent about it: #426 was reported by a
+      // user in exactly this position, whose first message was executed by bash.
+      if (data?.programStarted === false && data?.programError) {
+        setProgramWarning(data.programError)
       }
 
       // Animate completion
@@ -256,9 +264,30 @@ export default function FirstAgentWizard({ onComplete, onCancel }: FirstAgentWiz
                   Welcome to the team, <span className="text-green-400">{agentName}</span>!
                 </h3>
                 <p className="text-gray-400">
-                  Your new AI companion is ready to help you build amazing things
+                  {programWarning
+                    ? 'Your agent was created, but its AI program did not start'
+                    : 'Your new AI companion is ready to help you build amazing things'}
                 </p>
               </div>
+
+              {/* The agent exists but its pane is a bare shell. Saying so here
+                  is the whole point of #441: this is someone's FIRST agent, and
+                  the reporter of #426 was in exactly this position — their first
+                  message to it was executed by bash. */}
+              {programWarning && (
+                <div className="w-full mb-5 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
+                  <h4 className="text-sm font-semibold text-amber-300 mb-2 flex items-center gap-2">
+                    <AlertTriangle className="w-4 h-4" />
+                    The AI program did not start
+                  </h4>
+                  <p className="text-xs text-amber-200/80 leading-relaxed mb-2">{programWarning}</p>
+                  <p className="text-xs text-amber-200/60 leading-relaxed">
+                    The agent&apos;s terminal is at a shell prompt. Anything you send it now
+                    would be run as a shell command instead of read — open the terminal and
+                    start the program there first.
+                  </p>
+                </div>
+              )}
 
               <div className="w-full p-5 bg-gradient-to-br from-green-500/10 to-blue-500/10 border border-green-500/20 rounded-xl">
                 <h4 className="text-sm font-medium text-green-400 mb-4 flex items-center gap-2">

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.38.3
+**Current Version:** v0.38.4
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.38.3",
+      "softwareVersion": "0.38.4",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The OS for AI-first organizations. Build and run your AI company with any agent (Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes) from one dashboard. You're the CEO, your agents are the team.",
-      "softwareVersion": "0.38.3",
+      "softwareVersion": "0.38.4",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -453,7 +453,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.38.3</span>
+                        <span>v0.38.4</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.38.3"
+VERSION="0.38.4"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.3",
+  "version": "0.38.4",
   "releaseDate": "2026-09-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Closes #441.

[v0.38.0](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.38.0) made the API report `programStarted: false` with a reason. **Nothing displayed it.** The dashboard still showed a healthy-looking agent, and finding out meant reading the API response or the server log — which is the half the reporter of #426 would actually have seen.

## Three surfaces

**The first-agent onboarding wizard** — the most important of the three. It is someone's *very first* agent, and #426 was reported by a user in exactly that position whose first message was executed by bash. The heading changes from *"ready to help you build amazing things"* to *"created, but its AI program did not start"*.

**The agent creation wizard** — same warning on its success screen. The agent genuinely exists, so this is a warning, not a failure, and the wizard stops implying everything is fine.

**Waking an agent** — a 15-second warning toast. This path only checked `!response.ok`, so a wake returning **HTTP 200 with `programStarted: false`** was treated as complete success and said nothing at all.

All three name the *consequence*, not just the fault:

> The agent's terminal is at a shell prompt. Anything you send it now would be run as a shell command instead of read.

## Verified end to end

Creating an agent configured with `aider`, which is not installed on this machine — the exact scenario suspected when this was raised (*"maybe the user tried to create an agent using a framework he did not have installed?"*):

```json
{
  "success": true,
  "programStarted": false,
  "programError": "\"aider\" did not start: the program is not on PATH inside the tmux session. tmux starts a non-login shell, so a PATH exported from ~/.bash_profile or ~/.profile is not present — move it to ~/.bashrc (or ~/.zshrc), or check the program is installed at all.",
  "shellSaid": "zsh: command not found: aider"
}
```

Control, with a program that is installed: `programStarted: true`, no warning. Both test agents cleaned up.

## What this closes

The case ran from a fresh install (#426) to a configured-but-missing framework. Choosing `aider`, `codex`, `cursor` or a `sandbox-exec` wrapper you have not installed used to be **indistinguishable from a working agent at every layer** — service, API, and UI. All three now say so.

**1257 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)