### PR TITLE
feat(terminal): paste and drop files onto agents (#270) (v0.38.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to AI Maestro are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.38.5] - 2026-09-04 — Paste a screenshot onto an agent (#270)
+
+[#270](https://github.com/23blocks-OS/ai-maestro/issues/270) asked for three things. **The third — file attachments in the messaging system — shipped in [v0.38.0](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.38.0).** The other two are here.
+
+### Added
+- **Paste an image onto a terminal** (Cmd/Ctrl+V) and it goes to the agent. The existing paste handler read `navigator.clipboard.readText()` — **text only** — so an image on the clipboard produced silence, which is precisely what the issue reported. Images arrive as files on the paste event and are now intercepted before xterm sees them; a text paste falls through untouched.
+- **Drag and drop files onto a terminal**, with a drop-target overlay. Dragging a file over a terminal previously gave no indication anything would happen.
+- `POST /api/agents/{id}/files` (multipart). Remote agents are proxied to their own host — the same pattern the wake route uses, for the same reason: the bytes are useless on the wrong machine.
+
+### The design decision worth stating
+**A path, not the bytes.** Agent CLIs read files from disk — Claude Code takes a path and opens it, as do Codex and Aider. Pushing base64 into the pane would be both enormous and wrong: a one-megabyte screenshot becomes 1.3 MB of text typed one keystroke-batch at a time into a TUI that will mangle it.
+
+**Outside the working directory.** Files land in `~/.aimaestro/uploads/<agentId>/`, never in the agent's `workingDirectory`. That directory is usually a git repository someone is working in; screenshots dropped there show up in `git status`, get committed by an agent tidying up, or collide with real files. An absolute path outside the repo reads just as well to every CLI and cannot pollute anything.
+
+### Everything built this week made this safe
+- Validation reuses `lib/amp-attachments` — filename sanitising, blocked executables, magic bytes against the declared type, the 25 MB ceiling — rather than growing a second, weaker set of rules for the same job.
+- The prompt is delivered through `sendChatMessage`, which carries the **bare-shell guard from 0.37.14**. Without it, pasting a screenshot into an agent whose program never started would have typed the path at a shell, which would try to execute it.
+- **Saved and announced are separate outcomes.** A file can land safely while the agent cannot be told — no session, or a program that never started — and reporting that as plain success would be the same unearned claim removed everywhere else this cycle. The UI shows a warning naming the path, so the file is not lost.
+
+### Verified end to end
+A real 4×4 PNG posted to a live agent: byte-identical on disk, and the agent's own pane shows it **reading the file** —
+
+```
+❯ I've attached a file for you at "/Users/…/uploads/70796e0d-…/shot.png" —
+  ⎿  ~/.aimaestro/uploads/70796e0d-…/shot.png
+```
+
+Refusals, checked against the same agent:
+
+| file | response |
+|---|---|
+| ELF binary named `evil.pdf`, declared `application/pdf` | `file is an executable (elf) regardless of its declared type` |
+| `run.sh` declared `text/plain` | `blocked file extension: .sh` |
+
+### Notes
+- 26 new tests. 1283 passing.
+
 ## [0.38.4] - 2026-09-04 — A failed program launch is now visible where people actually are (#441)
 
 [v0.38.0](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.38.0) made the API report `programStarted: false` with a reason. **Nothing displayed it**, so the dashboard still showed a healthy-looking agent and someone had to read the API response or the server log to find out. That is the half the reporter of [#426](https://github.com/23blocks-OS/ai-maestro/issues/426) would actually have seen.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The OS for AI-first organizations — orchestrate any AI agent with persistent memory, agent-to-agent messaging, and multi-machine support.**
 
-[![Version](https://img.shields.io/badge/version-0.38.4-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
+[![Version](https://img.shields.io/badge/version-0.38.5-blue)](https://github.com/23blocks-OS/ai-maestro/releases)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL2)-lightgrey)](https://github.com/23blocks-OS/ai-maestro)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/23blocks-OS/ai-maestro?style=social)](https://github.com/23blocks-OS/ai-maestro)

--- a/app/api/agents/[id]/files/route.ts
+++ b/app/api/agents/[id]/files/route.ts
@@ -1,0 +1,62 @@
+/**
+ * POST /api/agents/{id}/files — hand files to an agent (#270).
+ *
+ * Accepts multipart/form-data so a browser can post a pasted screenshot or a
+ * dropped PDF directly. The bytes must land on the machine the agent runs on,
+ * so a request for a remote agent is proxied there — the same pattern the wake
+ * route uses, and for the same reason: the file is useless on the wrong host.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { uploadFilesToAgent, type IncomingFile } from '@/services/agents-upload-service'
+import { getAgent } from '@/lib/agent-registry'
+import { isSelf } from '@/lib/hosts-config'
+import { toResponse } from '@/app/api/_helpers'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  try {
+    const form = await request.formData()
+    const entries = form.getAll('files').filter((f): f is File => f instanceof File)
+    if (entries.length === 0) {
+      return NextResponse.json({ error: 'invalid_request', message: 'No files provided' }, { status: 400 })
+    }
+
+    // Remote agent: the bytes belong on its host, not this one.
+    const agent = getAgent(id)
+    const isLocal = !agent?.hostId || isSelf(agent.hostId) || (agent?.hostUrl ? isSelf(agent.hostUrl) : false)
+    if (!isLocal && agent?.hostUrl) {
+      const proxied = new FormData()
+      for (const f of entries) proxied.append('files', f, f.name)
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 60_000)
+      try {
+        const res = await fetch(`${agent.hostUrl}/api/agents/${id}/files`, {
+          method: 'POST', body: proxied, signal: controller.signal,
+        })
+        return NextResponse.json(await res.json().catch(() => ({})), { status: res.status })
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+
+    const files: IncomingFile[] = []
+    for (const f of entries) {
+      files.push({
+        filename: f.name || null,
+        contentType: f.type || null,
+        bytes: Buffer.from(await f.arrayBuffer()),
+      })
+    }
+
+    return toResponse(await uploadFilesToAgent(id, files))
+  } catch (error) {
+    console.error('[Agent Files] Error:', error)
+    return NextResponse.json(
+      { error: 'internal_error', message: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/TerminalView.tsx
+++ b/components/TerminalView.tsx
@@ -31,6 +31,75 @@ interface TerminalViewProps {
 
 export default function TerminalView({ session, isVisible: _isVisible = true, hideFooter = false, hideHeader = false, onConnectionStatusChange }: TerminalViewProps) {
   const { addToast } = useToast()
+  const [isDraggingFile, setIsDraggingFile] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
+
+  /**
+   * Hand files to the agent (#270).
+   *
+   * The bytes go to the server, which writes them to disk on the agent's own
+   * host and tells the agent the path — agent CLIs read files from disk, and
+   * pushing a megabyte of base64 through a TUI keystroke-batch would be both
+   * enormous and mangled.
+   */
+  const uploadFiles = useCallback(async (files: File[]) => {
+    if (files.length === 0) return
+    const agentId = session.agentId
+    if (!agentId) {
+      addToast({ type: 'error', title: 'Cannot attach files', message: 'This session has no registered agent.' })
+      return
+    }
+
+    setIsUploading(true)
+    try {
+      const form = new FormData()
+      // A pasted screenshot has no name. The server generates one from the MIME
+      // type rather than inventing a uuid, because the agent quotes the path
+      // back to a human.
+      for (const f of files) form.append('files', f, f.name || '')
+
+      const res = await fetch(`/api/agents/${agentId}/files`, { method: 'POST', body: form })
+      const data = await res.json().catch(() => ({}))
+
+      if (!res.ok) {
+        addToast({
+          type: 'error',
+          title: 'Could not attach the file',
+          message: data?.message || `Upload failed (${res.status})`,
+        })
+        return
+      }
+
+      // Saved and announced are separate outcomes: the file can land safely
+      // while the agent cannot be told (no session, or a program that never
+      // started). Reporting that as plain success would be a claim we have not
+      // earned.
+      if (data?.announced === false) {
+        addToast({
+          type: 'warning',
+          title: 'File saved, but the agent was not told',
+          message: `${data.announceError || 'The agent could not be reached.'} The file is at ${data.files?.[0]?.path ?? 'the upload directory'}.`,
+          duration: 15000,
+        })
+        return
+      }
+
+      const n = data?.files?.length ?? files.length
+      addToast({
+        type: 'success',
+        title: n === 1 ? 'File sent to the agent' : `${n} files sent to the agent`,
+        message: data?.files?.[0]?.path || '',
+      })
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: 'Could not attach the file',
+        message: err instanceof Error ? err.message : 'Unknown error',
+      })
+    } finally {
+      setIsUploading(false)
+    }
+  }, [session.agentId, addToast])
   const terminalRef = useRef<HTMLDivElement>(null)
   const [isReady, setIsReady] = useState(false)
   const messageBufferRef = useRef<string[]>([])
@@ -819,6 +888,38 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
       >
         <div
           ref={terminalRef}
+          // Paste and drop files onto the terminal (#270).
+          //
+          // The existing Cmd+V handler in useTerminal reads clipboard TEXT only,
+          // so an image on the clipboard silently produced nothing at all —
+          // which is exactly what this issue reported. Images arrive as files on
+          // the paste event, so they are intercepted here before xterm sees it;
+          // a text paste falls through untouched to the existing handler.
+          onPaste={(e) => {
+            const files = Array.from(e.clipboardData?.files ?? [])
+            if (files.length === 0) return
+            e.preventDefault()
+            e.stopPropagation()
+            void uploadFiles(files)
+          }}
+          onDragOver={(e) => {
+            if (!Array.from(e.dataTransfer.types).includes('Files')) return
+            e.preventDefault()
+            setIsDraggingFile(true)
+          }}
+          onDragLeave={(e) => {
+            // Only when the pointer actually leaves the terminal — dragging over
+            // a child fires dragleave for the child and would flicker the overlay.
+            if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+            setIsDraggingFile(false)
+          }}
+          onDrop={(e) => {
+            const files = Array.from(e.dataTransfer.files ?? [])
+            setIsDraggingFile(false)
+            if (files.length === 0) return
+            e.preventDefault()
+            void uploadFiles(files)
+          }}
           style={{
             // Terminal takes full available space within container
             flex: '1 1 0%',
@@ -827,6 +928,21 @@ export default function TerminalView({ session, isVisible: _isVisible = true, hi
             position: 'relative',
           }}
         />
+
+        {/* Drop target feedback. Without it, dragging a file over a terminal
+            gives no sign anything will happen. */}
+        {isDraggingFile && (
+          <div className="absolute inset-0 z-30 flex items-center justify-center bg-blue-500/10 border-2 border-dashed border-blue-400/60 rounded-lg pointer-events-none">
+            <div className="px-4 py-2 rounded-lg bg-gray-900/90 text-blue-200 text-sm font-medium">
+              Drop to send to {session.name || session.id}
+            </div>
+          </div>
+        )}
+        {isUploading && (
+          <div className="absolute top-3 right-3 z-30 px-3 py-1.5 rounded-lg bg-gray-900/90 text-gray-200 text-xs font-medium pointer-events-none">
+            Sending file…
+          </div>
+        )}
         {/* Touch clipboard toolbar - floating bottom-right */}
         {isTouch && terminal && isReady && (
           <div className="absolute bottom-3 right-3 z-20 flex gap-1.5">

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 **Purpose:** This document tracks planned features, improvements, and ideas for AI Maestro. Items are prioritized into three categories: Now (next release), Next (upcoming releases), and Later (future considerations).
 
 **Last Updated:** 2026-09-02
-**Current Version:** v0.38.4
+**Current Version:** v0.38.5
 
 ---
 

--- a/docs/ai-index.html
+++ b/docs/ai-index.html
@@ -32,7 +32,7 @@
         "priceCurrency": "USD"
       },
       "description": "Browser-based dashboard for orchestrating multiple AI coding agents (Claude Code, Aider, Cursor, GitHub Copilot) from one unified interface. Features agent-to-agent communication, Slack integration, email identity, persistent memory, and code graph visualization.",
-      "softwareVersion": "0.38.4",
+      "softwareVersion": "0.38.5",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "downloadUrl": "https://github.com/23blocks-OS/ai-maestro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
         "priceCurrency": "USD"
       },
       "description": "The OS for AI-first organizations. Build and run your AI company with any agent (Claude Code, Codex, Aider, Cursor, OpenClaw, Hermes) from one dashboard. You're the CEO, your agents are the team.",
-      "softwareVersion": "0.38.4",
+      "softwareVersion": "0.38.5",
       "releaseNotes": "https://github.com/23blocks-OS/ai-maestro/releases",
       "url": "https://ai-maestro.23blocks.com",
       "screenshot": "https://ai-maestro.23blocks.com/images/aiteam-web.png",
@@ -453,7 +453,7 @@
                 <div class="flex flex-wrap gap-8 text-sm font-mono text-slate-500" id="stats" style="opacity: 0;">
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>
-                        <span>v0.38.4</span>
+                        <span>v0.38.5</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <span class="text-cyan-400">▸</span>

--- a/lib/agent-uploads.ts
+++ b/lib/agent-uploads.ts
@@ -1,0 +1,166 @@
+/**
+ * Files handed to an agent from the web UI — pasted screenshots, dropped PDFs.
+ *
+ * WHY A PATH AND NOT THE BYTES
+ *
+ * Agent CLIs read files from disk. Claude Code takes a path and opens it; so do
+ * Codex and Aider. Pushing base64 into the pane would be both enormous and
+ * wrong — a megabyte screenshot becomes 1.3 MB of text typed one keystroke-batch
+ * at a time into a TUI that will mangle it. So the file is written to disk on
+ * the agent's own host and the agent is told where it is.
+ *
+ * WHERE IT LANDS, AND WHY NOT THE WORKING DIRECTORY
+ *
+ * Under ~/.aimaestro/uploads/<agentId>/, never inside the agent's
+ * workingDirectory. That directory is usually a git repository someone is
+ * actually working in, and dropping screenshots into it means they show up in
+ * `git status`, get committed by an agent tidying up, or collide with real
+ * files. An absolute path outside the repo reads just as well to every CLI and
+ * cannot pollute anything.
+ *
+ * VALIDATION IS THE SAME AS ATTACHMENTS
+ *
+ * Deliberately reuses lib/amp-attachments rather than growing a second, weaker
+ * set of rules. This is a file arriving from a browser and being written to a
+ * host's filesystem; it deserves at least what an AMP attachment gets —
+ * filename sanitising, blocked executables, magic-byte checking against the
+ * declared type, and a size ceiling.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  MAX_ATTACHMENT_SIZE,
+  checkMagicBytes,
+  computeDigest,
+  isBlockedType,
+  sanitizeFilename,
+} from '@/lib/amp-attachments'
+
+/** Root for everything uploaded to agents on this host. */
+export function uploadsRoot(): string {
+  return path.join(os.homedir(), '.aimaestro', 'uploads')
+}
+
+export function agentUploadDir(agentId: string): string {
+  return path.join(uploadsRoot(), agentId)
+}
+
+/**
+ * A pasted screenshot has no filename — the clipboard gives a blob and a MIME
+ * type. Generate something readable and sortable rather than a uuid, because
+ * the agent quotes this path back to a human.
+ */
+export function defaultNameFor(contentType: string, now: Date): string {
+  const ext = ({
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'application/pdf': 'pdf',
+    'text/plain': 'txt',
+  } as Record<string, string>)[contentType.toLowerCase().split(';')[0].trim()] || 'bin'
+
+  const stamp = now.toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19)
+  return `pasted_${stamp}.${ext}`
+}
+
+export interface StoredUpload {
+  path: string
+  filename: string
+  size: number
+  digest: string
+}
+
+export type UploadRejection = { reason: string }
+
+/**
+ * Validate and store one file for an agent.
+ *
+ * `agentId` is used as a directory name, so it is checked rather than trusted:
+ * this value arrives from a URL and would otherwise be a path traversal.
+ */
+export function storeUpload(
+  agentId: string,
+  bytes: Buffer,
+  declared: { filename?: string | null; contentType?: string | null },
+  now: Date = new Date()
+): StoredUpload | UploadRejection {
+  if (!/^[a-zA-Z0-9_-]{1,128}$/.test(agentId)) {
+    return { reason: 'invalid agent id' }
+  }
+  if (bytes.length === 0) {
+    return { reason: 'file is empty' }
+  }
+  if (bytes.length > MAX_ATTACHMENT_SIZE) {
+    return { reason: `file exceeds the ${Math.round(MAX_ATTACHMENT_SIZE / 1024 / 1024)} MB limit` }
+  }
+
+  const contentType = (declared.contentType || 'application/octet-stream').toLowerCase().split(';')[0].trim()
+
+  // A pasted image has no name; a dropped file does. Either way the result must
+  // survive being used as a filename.
+  const filename = declared.filename
+    ? sanitizeFilename(declared.filename) || defaultNameFor(contentType, now)
+    : defaultNameFor(contentType, now)
+
+  const blocked = isBlockedType(contentType, filename)
+  if (blocked) return { reason: blocked }
+
+  // The same primary-type check attachments get: content that disagrees with
+  // its declared type, or is an executable however it is labelled.
+  const magic = checkMagicBytes(bytes, contentType)
+  if (magic) return { reason: magic }
+
+  const dir = agentUploadDir(agentId)
+  fs.mkdirSync(dir, { recursive: true })
+
+  // Never overwrite. Two screenshots pasted in the same second must not silently
+  // become one, and an agent told about a path should find what it was told
+  // about.
+  let target = path.join(dir, filename)
+  if (fs.existsSync(target)) {
+    const ext = path.extname(filename)
+    const base = path.basename(filename, ext)
+    let n = 2
+    while (fs.existsSync(target) && n < 1000) {
+      target = path.join(dir, `${base}_${n}${ext}`)
+      n++
+    }
+  }
+
+  // Write then rename, so a reader never sees a partial file under a name we
+  // have already told an agent about.
+  const tmp = `${target}.part`
+  fs.writeFileSync(tmp, bytes, { mode: 0o600 })
+  fs.renameSync(tmp, target)
+
+  return {
+    path: target,
+    filename: path.basename(target),
+    size: bytes.length,
+    digest: computeDigest(bytes),
+  }
+}
+
+export function isRejection(r: StoredUpload | UploadRejection): r is UploadRejection {
+  return 'reason' in r
+}
+
+/**
+ * What to type into the agent's pane.
+ *
+ * Phrased as a sentence rather than a bare path because it is submitted as a
+ * PROMPT: a bare path is ambiguous ("what do you want me to do with it?"),
+ * while this reads as an instruction and works for a screenshot and a PDF
+ * alike. The path is quoted so spaces cannot split it, though sanitizeFilename
+ * already rules them out.
+ */
+export function promptFor(uploads: StoredUpload[]): string {
+  if (uploads.length === 1) {
+    return `I've attached a file for you at "${uploads[0].path}" — please read it.`
+  }
+  const list = uploads.map(u => `"${u.path}"`).join(', ')
+  return `I've attached ${uploads.length} files for you: ${list} — please read them.`
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-maestro",
-  "version": "0.38.4",
+  "version": "0.38.5",
   "description": "Web dashboard for orchestrating multiple AI coding agents with hierarchical organization and real-time terminals",
   "author": "Juan Peláez <juan@23blocks.com> (https://23blocks.com)",
   "license": "MIT",

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -29,7 +29,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Version & config
-VERSION="0.38.4"
+VERSION="0.38.5"
 REPO_URL="https://github.com/23blocks-OS/ai-maestro.git"
 DEFAULT_INSTALL_DIR="$HOME/ai-maestro"
 PORT="${AIMAESTRO_PORT:-23000}"  # configurable via --port or AIMAESTRO_PORT env var

--- a/services/agents-upload-service.ts
+++ b/services/agents-upload-service.ts
@@ -1,0 +1,100 @@
+/**
+ * Handing a file to an agent from the web UI (#270).
+ *
+ * Save the bytes on the agent's own host, then tell the agent where they are.
+ * See lib/agent-uploads for why a path rather than the bytes, and why not the
+ * agent's working directory.
+ *
+ * The prompt is delivered through `sendChatMessage`, deliberately, rather than
+ * a fresh `sendKeys`. That path carries the bare-shell guard added in 0.37.14 —
+ * so if the agent's program never started, the path is NOT typed at a shell
+ * that would try to execute it. Pasting a screenshot into a broken agent should
+ * say why, not run `/Users/…/pasted_2026-09-04.png` as a command.
+ */
+
+import { getAgent } from '@/lib/agent-registry'
+import { sendChatMessage } from '@/services/agents-chat-service'
+import {
+  isRejection,
+  promptFor,
+  storeUpload,
+  type StoredUpload,
+} from '@/lib/agent-uploads'
+import {
+  invalidRequest,
+  notFound,
+  serviceError,
+  type ServiceResult,
+} from '@/services/service-errors'
+
+export interface IncomingFile {
+  filename?: string | null
+  contentType?: string | null
+  bytes: Buffer
+}
+
+export interface UploadOutcome {
+  success: true
+  files: Array<{ path: string; filename: string; size: number }>
+  /** Whether the agent was actually told. False when it has no live session. */
+  announced: boolean
+  /** Why it was not announced, when it was not. */
+  announceError?: string
+}
+
+/**
+ * Store files for an agent and tell it they are there.
+ *
+ * Storing and announcing are separate outcomes on purpose. A file can land
+ * safely while the agent cannot be told — no session, or a program that never
+ * started — and reporting that as plain success would be the same unearned
+ * claim this codebase has been removing all week. The caller gets both facts.
+ */
+export async function uploadFilesToAgent(
+  agentId: string,
+  files: IncomingFile[]
+): Promise<ServiceResult<UploadOutcome>> {
+  if (!files || files.length === 0) {
+    return invalidRequest('No files provided')
+  }
+  if (files.length > 10) {
+    return invalidRequest('At most 10 files at a time')
+  }
+
+  const agent = getAgent(agentId)
+  if (!agent) return notFound('Agent', agentId)
+
+  const stored: StoredUpload[] = []
+  for (const file of files) {
+    const result = storeUpload(agentId, file.bytes, {
+      filename: file.filename,
+      contentType: file.contentType,
+    })
+    if (isRejection(result)) {
+      // Refuse the whole batch rather than half of it. A partial upload leaves
+      // the agent told about some files and not others, and the person has no
+      // way to tell which.
+      return serviceError('invalid_request', `${file.filename || 'file'}: ${result.reason}`, 400)
+    }
+    stored.push(result)
+  }
+
+  const announce = await sendChatMessage(agentId, promptFor(stored))
+  const announceFailed = !announce.data || (announce.status >= 400)
+
+  return {
+    data: {
+      success: true,
+      files: stored.map(s => ({ path: s.path, filename: s.filename, size: s.size })),
+      announced: !announceFailed,
+      ...(announceFailed
+        ? {
+            announceError:
+              (announce.data as { message?: string } | undefined)?.message ||
+              'The files were saved, but the agent could not be told about them.',
+          }
+        : {}),
+    },
+    status: 200,
+  }
+}

--- a/tests/agent-uploads.test.ts
+++ b/tests/agent-uploads.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for lib/agent-uploads.ts — pasting and dropping files onto agents (#270).
+ *
+ * A file arriving from a browser and being written to a host's filesystem gets
+ * the same scrutiny an AMP attachment gets, by reusing lib/amp-attachments
+ * rather than growing a second, weaker set of rules. These cover the parts
+ * specific to uploads: naming a clipboard blob that has no filename, never
+ * overwriting, and never escaping the upload directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+let home: string
+let homeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'uploads-'))
+  homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(home)
+})
+afterEach(() => {
+  homeSpy.mockRestore()
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])
+const PDF = Buffer.from('%PDF-1.4 hello')
+const ELF = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01])
+const AGENT = 'agent-abc123'
+
+async function lib() {
+  return await import('@/lib/agent-uploads')
+}
+
+describe('naming a clipboard blob', () => {
+  it('derives a readable, sortable name from the MIME type', async () => {
+    const { defaultNameFor } = await lib()
+    const name = defaultNameFor('image/png', new Date('2026-09-04T12:34:56Z'))
+    expect(name).toBe('pasted_2026-09-04_12-34-56.png')
+  })
+
+  it.each([
+    ['image/jpeg', 'jpg'], ['image/gif', 'gif'], ['image/webp', 'webp'],
+    ['application/pdf', 'pdf'], ['text/plain', 'txt'],
+  ])('maps %s to .%s', async (mime, ext) => {
+    const { defaultNameFor } = await lib()
+    expect(defaultNameFor(mime, new Date())).toMatch(new RegExp(`\\.${ext}$`))
+  })
+
+  it('falls back to .bin for an unknown type rather than guessing', async () => {
+    const { defaultNameFor } = await lib()
+    expect(defaultNameFor('application/x-whatever', new Date())).toMatch(/\.bin$/)
+  })
+
+  it('tolerates a charset parameter on the MIME type', async () => {
+    const { defaultNameFor } = await lib()
+    expect(defaultNameFor('text/plain; charset=utf-8', new Date())).toMatch(/\.txt$/)
+  })
+})
+
+describe('storing a file', () => {
+  it('writes a pasted screenshot and returns its absolute path', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const r = storeUpload(AGENT, PNG, { filename: null, contentType: 'image/png' })
+    expect(isRejection(r)).toBe(false)
+    if (isRejection(r)) return
+    expect(path.isAbsolute(r.path)).toBe(true)
+    expect(fs.readFileSync(r.path)).toEqual(PNG)
+  })
+
+  it('stays OUT of the agent working directory', async () => {
+    // Screenshots dropped into a git repo show up in `git status`, get
+    // committed by an agent tidying up, or collide with real files.
+    const { storeUpload, isRejection } = await lib()
+    const r = storeUpload(AGENT, PDF, { filename: 'report.pdf', contentType: 'application/pdf' })
+    if (isRejection(r)) throw new Error(r.reason)
+    expect(r.path).toContain(path.join('.aimaestro', 'uploads', AGENT))
+  })
+
+  it('keeps a real filename when one is given', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const r = storeUpload(AGENT, PDF, { filename: 'services-agreement.pdf', contentType: 'application/pdf' })
+    if (isRejection(r)) throw new Error(r.reason)
+    expect(r.filename).toBe('services-agreement.pdf')
+  })
+
+  it('NEVER overwrites — two pastes in the same second stay two files', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const second = Buffer.concat([PNG, Buffer.from([0xff, 0xee])])
+    const a = storeUpload(AGENT, PNG, { filename: 'shot.png', contentType: 'image/png' })
+    const b = storeUpload(AGENT, second, { filename: 'shot.png', contentType: 'image/png' })
+    if (isRejection(a) || isRejection(b)) throw new Error('rejected')
+    expect(a.path).not.toBe(b.path)
+    // Both survive, each with its own bytes — the first is not clobbered.
+    expect(fs.readFileSync(a.path)).toEqual(PNG)
+    expect(fs.readFileSync(b.path)).toEqual(second)
+  })
+
+  it('leaves no .part file behind', async () => {
+    // Write-then-rename: a reader must never see a partial file under a name
+    // an agent has already been told about.
+    const { storeUpload, isRejection, agentUploadDir } = await lib()
+    const r = storeUpload(AGENT, PNG, { filename: 'shot.png', contentType: 'image/png' })
+    if (isRejection(r)) throw new Error(r.reason)
+    expect(fs.readdirSync(agentUploadDir(AGENT)).filter(f => f.endsWith('.part'))).toEqual([])
+  })
+})
+
+describe('refusing what it should', () => {
+  it('rejects an executable however it is labelled', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const r = storeUpload(AGENT, ELF, { filename: 'report.pdf', contentType: 'application/pdf' })
+    expect(isRejection(r)).toBe(true)
+  })
+
+  it('rejects a blocked extension', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const r = storeUpload(AGENT, Buffer.from('#!/bin/sh'), { filename: 'run.sh', contentType: 'text/plain' })
+    expect(isRejection(r)).toBe(true)
+  })
+
+  it('rejects content that disagrees with its declared type', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const r = storeUpload(AGENT, PNG, { filename: 'notes.txt', contentType: 'text/plain' })
+    expect(isRejection(r)).toBe(true)
+  })
+
+  it('rejects an empty file', async () => {
+    const { storeUpload, isRejection } = await lib()
+    expect(isRejection(storeUpload(AGENT, Buffer.alloc(0), { contentType: 'image/png' }))).toBe(true)
+  })
+
+  it('rejects an oversized file', async () => {
+    const { storeUpload, isRejection } = await lib()
+    const big = Buffer.alloc(26_214_401)
+    expect(isRejection(storeUpload(AGENT, big, { contentType: 'application/octet-stream' }))).toBe(true)
+  })
+
+  it.each(['../escape', 'a/b', '..', 'x'.repeat(200) + '/y'])(
+    'rejects agent id %j rather than letting it traverse',
+    async (bad) => {
+      // agentId becomes a directory name and arrives from a URL.
+      const { storeUpload, isRejection } = await lib()
+      expect(isRejection(storeUpload(bad, PNG, { contentType: 'image/png' }))).toBe(true)
+    }
+  )
+
+  it('sanitises a hostile filename instead of trusting it', async () => {
+    const { storeUpload, isRejection, agentUploadDir } = await lib()
+    const r = storeUpload(AGENT, PNG, { filename: '../../etc/passwd.png', contentType: 'image/png' })
+    if (isRejection(r)) return // rejecting outright is also acceptable
+    expect(path.dirname(r.path)).toBe(agentUploadDir(AGENT))
+  })
+})
+
+describe('what the agent is told', () => {
+  it('reads as an instruction, not a bare path', async () => {
+    // The text is submitted as a PROMPT. A bare path is ambiguous — "what do
+    // you want me to do with it?" — while this works for a screenshot and a
+    // PDF alike.
+    const { promptFor } = await lib()
+    const p = promptFor([{ path: '/tmp/a.png', filename: 'a.png', size: 1, digest: 'sha256:x' }])
+    expect(p).toContain('/tmp/a.png')
+    expect(p).toMatch(/read it/)
+  })
+
+  it('quotes the path so it cannot be split', async () => {
+    const { promptFor } = await lib()
+    expect(promptFor([{ path: '/tmp/a.png', filename: 'a.png', size: 1, digest: 'x' }]))
+      .toContain('"/tmp/a.png"')
+  })
+
+  it('lists several files with a count', async () => {
+    const { promptFor } = await lib()
+    const p = promptFor([
+      { path: '/tmp/a.png', filename: 'a.png', size: 1, digest: 'x' },
+      { path: '/tmp/b.pdf', filename: 'b.pdf', size: 1, digest: 'x' },
+    ])
+    expect(p).toContain('2 files')
+    expect(p).toContain('/tmp/b.pdf')
+  })
+})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.4",
+  "version": "0.38.5",
   "releaseDate": "2026-09-04",
   "changelog": "https://github.com/23blocks-OS/ai-maestro/releases",
   "minSupportedVersion": "0.10.0"


### PR DESCRIPTION
Closes #270.

The issue asked for three things. **The third — file attachments in the messaging system — shipped in [v0.38.0](https://github.com/23blocks-OS/ai-maestro/releases/tag/v0.38.0).** These are the other two.

## What was actually broken

The existing paste handler:

```js
navigator.clipboard.readText()   // text only
```

An image on the clipboard returns nothing, so pasting a screenshot produced **silence** — exactly what was reported. Images arrive as *files* on the paste event; they are now intercepted before xterm sees them, and a text paste falls through untouched.

Dragging a file over a terminal also gave no indication anything would happen. There is now a drop overlay.

## The design decision worth reviewing

**A path, not the bytes.** Agent CLIs read files from disk — Claude Code takes a path and opens it, as do Codex and Aider. Pushing base64 into the pane would be both enormous and wrong: a 1 MB screenshot becomes 1.3 MB of text typed one keystroke-batch at a time into a TUI that will mangle it.

**Outside the working directory.** Files land in `~/.aimaestro/uploads/<agentId>/`, never in the agent's `workingDirectory`. That is usually a git repository someone is working in — screenshots dropped there show up in `git status`, get committed by an agent tidying up, or collide with real files. An absolute path outside the repo reads just as well to every CLI and cannot pollute anything.

## This was cheap because of the rest of the week

| need | reused |
|---|---|
| filename / blocked types / magic bytes / size ceiling | `lib/amp-attachments` (v0.38.0) |
| don't type a path at a bare shell | the guard in `sendChatMessage` (v0.37.14) |
| remote agents | the wake route's proxy pattern |

That middle one matters: without it, pasting a screenshot into an agent whose program never started would type the path at a shell, **which would try to execute it**.

**Saved and announced are separate outcomes.** A file can land safely while the agent cannot be told — no session, or a program that never started. Reporting that as plain success would be the same unearned claim removed everywhere else this cycle, so the UI warns and names the path.

## Verified end to end

A real 4×4 PNG posted to a live agent. Byte-identical on disk, and the agent's own pane shows it **reading the file**:

```
❯ I've attached a file for you at "/Users/…/uploads/70796e0d-…/shot.png" —
  ⎿  ~/.aimaestro/uploads/70796e0d-…/shot.png
```

Refusals, against the same agent:

| file | response |
|---|---|
| ELF binary named `evil.pdf`, declared `application/pdf` | `file is an executable (elf) regardless of its declared type` |
| `run.sh` declared `text/plain` | `blocked file extension: .sh` |

**26 new tests, 1283 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)